### PR TITLE
Split "testing policies" section

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -2,7 +2,6 @@
 
 - [Introduction](./introduction.md)
 - [Quick Start](./quick-start.md)
-- [Testing Policies](./testing-policies.md)
 - [Writing Policies](./writing-policies/index.md)
   - [Policy Specification](./writing-policies/spec/01-intro.md)
     - [Settings](./writing-policies/spec/02-settings.md)
@@ -28,3 +27,6 @@
   #- [Domain Specific Language](./writing-policies/dsl.md)
   #- [Other languages](./writing-policies/other-languages.md)
 - [Distributing Policies](./distributing-policies.md)
+- [Testing Policies](./testing-policies/01-intro.md)
+  - [While creating a policy](./testing-policies/02-policy-authors.md)
+  - [Before deployment](./testing-policies/03-cluster-operators.md)

--- a/src/testing-policies/01-intro.md
+++ b/src/testing-policies/01-intro.md
@@ -1,0 +1,13 @@
+# Testing Policies
+
+This section covers the topic of testing Kubewarden Policies. There are two possible
+personas interested in testing policies:
+
+  * As a policy author: you're writing a Kubewarden Policy and you want to ensure
+    your code behaves the way you expect.
+  * As an end user: you found a Kubewarden Policy and you want to tune/test the policy
+    settings before deploying it, maybe you want to keep testing these settings
+    inside of your CI/CD pipelines,...
+
+The next sections of the documentation will show how Kubewarden policies can
+be tested by these two personas.

--- a/src/testing-policies/02-policy-authors.md
+++ b/src/testing-policies/02-policy-authors.md
@@ -26,7 +26,7 @@ As a policy author you can also write tests that are executed against the actual
 WebAssembly binary containing your policy. This can be done without having
 to deploy a Kubernetes cluster by using these tools:
 
-* [bats](https://github.com/sstephenson/bats): used to write the
+* [bats](https://github.com/bats-core/bats-core): used to write the
   tests and automate their execution.
 * [policy-testdrive](https://github.com/kubewarden/policy-server/releases):
   cli tool provided by Kubewarden to run its policies outside of

--- a/src/testing-policies/02-policy-authors.md
+++ b/src/testing-policies/02-policy-authors.md
@@ -1,0 +1,93 @@
+# While creating a policy
+
+Kubewarden Policies are regular programs compiled as WebAssembly. As with any kind
+of program, it's important to have good test coverage.
+
+Policy authors can leverage the testing frameworks and tools of their language
+of choice to verify the behaviour of their policies.
+
+As an example, you can take a look at these Kubewarden policies:
+
+* [psp-apparmor](https://github.com/kubewarden/psp-apparmor): this
+  is a Kubewarden Policy written using [Rust](/writing-policies/rust/01-intro.html).
+* [ingress-policy](https://github.com/kubewarden/ingress-policy): this is
+  a Kubewarden Policy written using [Go](/writing-policies/go/01-intro.html).
+* [pod-privileged-policy](https://github.com/kubewarden/pod-privileged-policy): this
+  is a Kubewarden Policy written using [AssemblyScript](https://www.assemblyscript.org/).
+
+All these policies have integrated test suites built using the regular testing libraries
+of Rust, Go and AssemblyScript.
+
+Finally, all these projects rely on GitHub Actions to implement their CI pipelines.
+
+## End-to-end tests
+
+As a policy author you can also write tests that are executed against the actual
+WebAssembly binary containing your policy. This can be done without having
+to deploy a Kubernetes cluster by using these tools:
+
+* [bats](https://github.com/sstephenson/bats): used to write the
+  tests and automate their execution.
+* [policy-testdrive](https://github.com/kubewarden/policy-server/releases):
+  cli tool provided by Kubewarden to run its policies outside of
+  Kubernetes.
+
+`policy-testdrive` usage is quite simple, we just have to invoke it with the
+following data as input:
+
+1. Path to the WebAssembly binary file of the policy to be run. This is
+  specified through the `--policy` argument. Currently, `policy-testdrive`
+  can only load policies from the local filesystem.
+1. Path to the file containing the admission request object to be evaluated.
+  This is provided via the `--request-file` argument.
+1. The policy settings to be used at evaluation time, they can be provided
+  via `--settings` flag. The flag takes a JSON blob as parameter.
+
+Once the policy evaluation is done, `policy-testdrive` prints to the standard
+output the `SettingsValidationResponse`and the `ValidationResponse` objects.
+
+For example, this is how `policy-testdrive` can be used to test the
+WebAssembly binary of the `ingress-policy` linked above:
+
+```
+$ policy-testdrive -p ingress-policy.wasm \
+    -r test_data/ingress-wildcard.json \
+    -s '{"allowPorts": [80], "denyPorts": [3000]}'
+Settings validation result: SettingsValidationResponse { valid: true, message: None }
+Policy evaluation results:
+ValidationResponse { uid: "", allowed: false, patch_type: None, patch: None, status: Some(ValidationResponseStatus { message: Some("These ports are not on the allowed list: Set{3000}"), code: None }) }
+```
+
+Using `bats` we can can write a test that runs this command and looks for the
+expected outputs:
+
+```bash
+@test "all is good" {
+  run policy-testdrive -p ingress-policy.wasm \
+    -r test_data/ingress-wildcard.json \
+    -s '{"allowPorts": [80], "denyPorts": [3000]}'
+
+  # this prints the output when one the checks below fails
+  echo "output = ${output}"
+
+  # settings validation passed
+  [[ "$output" == *"valid: true"* ]]
+
+  # request accepted
+  [[ "$output" == *"allowed: true"* ]]
+}
+```
+
+We can copy the snippet from above inside of a file called `e2e.bats`,
+and then invoke `bats` in this way:
+
+```
+$ bats e2e.bats
+ ✓ all is good
+
+1 tests, 0 failures
+```
+
+Checkout [this section](/writing-policies/go/05-e2e-tests.html)
+of the documentation to learn more about writing end-to-end
+tests of your policies.

--- a/src/testing-policies/03-cluster-operators.md
+++ b/src/testing-policies/03-cluster-operators.md
@@ -251,7 +251,7 @@ ValidationResponse { uid: "", allowed: true, patch_type: None, patch: None, stat
 ## Automation
 
 All these steps shown above can be automated using
-[bats](https://github.com/sstephenson/bats).
+[bats](https://github.com/bats-core/bats-core).
 
 We can write a series of tests and integrate their execution inside
 of your existing CI and CD pipelines.

--- a/src/writing-policies/go/05-e2e-tests.md
+++ b/src/writing-policies/go/05-e2e-tests.md
@@ -11,7 +11,7 @@ These tools need to be installed on your development machine:
 * docker or another container engine: used to build the WebAssembly
   policy. We will rely on the compiler shipped within the official
   TinyGo container image.
-* [bats](https://github.com/sstephenson/bats): used to write the
+* [bats](https://github.com/bats-core/bats-core): used to write the
   tests and automate their execution.
 * [policy-testdrive](https://github.com/kubewarden/policy-server/releases):
   cli tool provided by Kubewarden to run its policies outside of
@@ -35,7 +35,7 @@ The compilation produces a file called `policy.wasm`.
 
 ## Writing tests
 
-We are going to use [bats](https://github.com/sstephenson/bats) to write and
+We are going to use [bats](https://github.com/bats-core/bats-core) to write and
 automate our tests. Each test will be composed by the following steps:
 
 1. Run the policy using `policy-testdrive`.


### PR DESCRIPTION
Split the testing document into two dedicated chapters.

Also, shuffle the topics around inside of the SUMMARY

This fixes #21