### PR TITLE
Explain that cargo generate must be installed

### DIFF
--- a/src/writing-policies/rust/02-create-policy.md
+++ b/src/writing-policies/rust/02-create-policy.md
@@ -45,7 +45,15 @@ spec:
 
 The creation of a new policy project can be done by feeding this
 [template project](https://github.com/kubewarden/policy-rust-template)
-into `cargo generate`:
+into `cargo generate`.
+
+First, install `cargo-generate`. Note, this requires [openssl-devel](https://pkgs.org/download/openssl-devel).
+
+```
+cargo install cargo-generate
+```
+
+Now scaffold the project as follows:
 
 ```shell
 cargo generate --git https://github.com/kubewarden/policy-rust-template \


### PR DESCRIPTION
cargo generate is not part of a default rust installation so I have attempted to explain how to install the required tool