### PR TITLE
Adapt documentation

### DIFF
--- a/src/distributing-policies.md
+++ b/src/distributing-policies.md
@@ -27,15 +27,88 @@ regular OCI compliant container registry.
 The target OCI compliant registry **must support artifacts** in order
 to successfully push a Kubewarden Policy to it.
 
-The [`wasm-to-oci`](https://github.com/engineerd/wasm-to-oci) command line tool
+The [`kwctl`](https://github.com/kubewarden/kwctl) command line tool
 can be used to push a Kubewarden Policy to an OCI compliant registry.
 
-Pushing a policy can be done in this way:
+## Annotating the policy
 
-```bash
-$ wasm-to-oci push pod-runtime-class-policy.wasm \
-              <oci-registry>/kubewarden-policies/pod-runtime-class-policy:v0.0.2
+Annotating a policy is done by the `kwctl` CLI tool as well. The
+process of annotating a Kubewarden policy is done by adding
+WebAssembly custom sections to the policy binary. This means that the
+policy metadata travels with the policy itself.
+
+The `kwctl annotate` command needs two main inputs:
+
+* The Kubewarden policy to be annotated, in the form of a local file
+  in the filesystem.
+
+* The annotations file, a file containing a YAML with the policy
+  metadata. This file is located somewhere in your filesystem, usually
+  in the root project of your policy.
+
+An example follows; we save this file as `metadata.yml` in the current
+directory:
+
+```yaml
+rules:
+- apiGroups: ["*"]
+  apiVersions: ["*"]
+  resources: ["*"]
+  operations: ["*"]
+mutating: false
+annotations:
+  io.kubewarden.policy.title: palindromify
+  io.kubewarden.policy.description: Allows you to reject palindrome names in resources and namespace names, or to only accept palindrome names
+  io.kubewarden.policy.author: Name Surname <name.surname@example.com>
+  io.kubewarden.policy.url: https://github.com/<org>/palindromify
+  io.kubewarden.policy.source: https://github.com/<org>/palindromify
+  io.kubewarden.policy.license: Apache-2.0
+  io.kubewarden.policy.usage: |
+    This is markdown text and as such allows you to define a free form usage text.
+
+    This policy allows you to reject requests if:
+    - The name of the resource is a palindrome name.
+    - The namespace name where this resource is created has a palindrome name.
+
+    This policy accepts the following settings:
+
+    - `invert_behavior`: bool that inverts the policy behavior. If enabled, only palindrome names will be accepted.
 ```
 
-The policy can then be referenced from the Kubewarden Policy Server as
-`registry://<oci-registry>/kubewarden-policies/pod-runtime-class-policy:v0.0.2`.
+Now, let's annotate the policy:
+
+```shell
+$ kwctl annotate policy.wasm \
+    --metadata-path metadata.yml \
+    --output-path annotated-policy.wasm
+```
+
+This process performs some optimizations on the policy, so it's not
+uncommon to end up with a smaller annotated policy than the original
+one. This depends a lot on the toolchain that was used to produce the
+unannotated WebAssembly object.
+
+You can check with `kwctl inspect` that everything looks correct:
+
+```shell
+$ kwctl inspect annotated-policy.wasm
+# here you will see a colored output of the metadata you provided on the `metadata.yml` file. This information is now read from the WebAssembly custom sections
+```
+
+## Pushing the policy
+
+Pushing an annotated policy can be done in this way:
+
+```shell
+$ kwctl push annotated-policy.wasm \
+              <oci-registry>/kubewarden-policies/palindromify-policy:v0.0.1
+```
+
+It is discouraged to push unannotated policies. This is why by default
+`kwctl push` will reject to push such a policy to an OCI registry. If
+you really want to push an unannotated policy you can use the
+`--force` flag of `kwctl push`.
+
+The policy can then be referenced from the Kubewarden Policy Server or
+`kwctl` as
+`registry://<oci-registry>/kubewarden-policies/palindromify-policy:v0.0.1`.

--- a/src/writing-policies/go/03-policy-settings.md
+++ b/src/writing-policies/go/03-policy-settings.md
@@ -306,6 +306,7 @@ func TestParseValidSettings(t *testing.T) {
 		t.Errorf("Execpted regexp to be %v - got %v instead",
 			expected_regexp, re.String())
 	}
+}
 ```
 
 Next we will define a test that ensures a `Settings` instance

--- a/src/writing-policies/go/04-validation.md
+++ b/src/writing-policies/go/04-validation.md
@@ -63,6 +63,7 @@ func validate(payload []byte) ([]byte, error) {
 	}
 
 	return kubewarden.AcceptRequest()
+}
 ```
 
 The code has some `NOTE` section inside of it. Let's get through them:

--- a/src/writing-policies/rust/03-define-policy-settings.md
+++ b/src/writing-policies/rust/03-define-policy-settings.md
@@ -9,6 +9,7 @@ struct to look like that:
 use std::collections::HashSet;
 
 #[derive(Deserialize, Default, Debug, Serialize)]
+#[serde(default)]
 pub(crate) struct Settings {
     pub invalid_names: HashSet<String>,
 }

--- a/src/writing-policies/rust/06-build-and-distribute.md
+++ b/src/writing-policies/rust/06-build-and-distribute.md
@@ -24,8 +24,9 @@ target/wasm32-unknown-unknown/release/demo.wasm: WebAssembly (wasm) binary modul
 
 ## Distributing the policy
 
-This topic is covered inside of the ["distributing policies"](/distributing-policies.html)
-section of Kubewarden's documentation.
+This topic is covered inside of the [distributing
+policies](/distributing-policies.html) section of Kubewarden's
+documentation.
 
 ## More examples
 

--- a/src/writing-policies/spec/01-intro.md
+++ b/src/writing-policies/spec/01-intro.md
@@ -1,9 +1,9 @@
 # Policy communication specification
 
-The policy evaluator interacts with Kubewarden policies using a well defined API.
-The purpose of this section is to document the API used by the host (
-be it `policy-server` or `policy-testdrive`) to communicate with Kubewarden's
-policies.
+The policy evaluator interacts with Kubewarden policies using a well
+defined API.  The purpose of this section is to document the API used
+by the host ( be it `policy-server` or `kwctl`) to communicate with
+Kubewarden's policies.
 
 > **Note well:** this section of the documentation is a bit low level, you can
 > jump straight to one of the "language focused" chapters and come back to this


### PR DESCRIPTION
- Replace `policy-testdrive` with `kwctl` and adapt their command
names, arguments, workflow...
- Replace `wasm-to-oci` with `kwctl`
- Update the go project template so it includes some expected labels
to execute when following this documentation
- Make sure that all examples work as expected

Fixes: https://github.com/kubewarden/kubewarden.io/issues/15