### PR TITLE
Add the namespace to the uninstall command

### DIFF
--- a/src/quick-start.md
+++ b/src/quick-start.md
@@ -221,7 +221,7 @@ kubectl delete -l "kubewarden" mutatingwebhookconfigurations.admissionregistrati
 Finally you can uninstall the Helm chart:
 
 ```shell
-helm uninstall kubewarden-controller
+helm uninstall --namespace kubewarden kubewarden-controller
 ```
 
 Once this is done you can remove the Kubernetes namespace that was used to deploy


### PR DESCRIPTION
The release is installed in the `kubewarden` namespace, thus you have to specify it for uninstallation too.

> helm install --namespace kubewarden --create-namespace kubewarden-controller kubewarden/kubewarden-controller