### PR TITLE
Update info on custom CAs, add operator page

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,7 @@
 [book]
 title = "Kubewarden Kubernetes Policy Engine"
 description = "Documentation of Kubewarden project"
-authors = ["Flavio Castelli", "Rafael Fernández López"]
+authors = ["Kubewarden Developers"]
 language = "en"
 multilingual = false
 src = "src"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -45,4 +45,5 @@
   - [While creating a policy](./testing-policies/02-policy-authors.md)
   - [Before deployment](./testing-policies/03-cluster-operators.md)
 - [Operator Manual](./operator-manual/01-intro.md)
+  - [Configuring PolicyServers](./operator-manual/policy-servers/01-custom-cas.md)
   - [Tracing](./operator-manual/tracing/01-quickstart.md)

--- a/src/distributing-policies/custom-certificate-authorities.md
+++ b/src/distributing-policies/custom-certificate-authorities.md
@@ -4,6 +4,10 @@ Both `kwctl` and `policy-server` allow you to pull policies from OCI registries 
 
 The system CA store is used to validate the trusted chain of certificates presented by the OCI registry. In a regular Kubewarden installation, the `policy-server` will use the CA store shipped with its Linux container. In the client side, `kwctl` will use your operating system CA store.
 
+If you are using the Controller, you can configure the PolicyServer via their
+`spec` fields, as documented
+[here](../operator-manual/policy-servers/01-custom-cert-auths.html).
+
 > **Important**: the default behavior of `kwctl` and `policy-server` is to enforce HTTPS with trusted certificates matching the system CA store. You can interact with registries using untrusted certificates or even without TLS, by using the `insecure_sources` setting. This approach is **highly discouraged** in environments closer to production.
 
 ## The `sources.yaml` file
@@ -18,10 +22,16 @@ insecure_sources:
   - "registry-dev2.example.com:5500"
 source_authorities:
   "registry-pre.example.com":
-    - /opt/example.com/pki/ca-pre1-1.pem
-    - /opt/example.com/pki/ca-pre1-2.pem
+    - type: Path
+      path: /opt/example.com/pki/ca-pre1-1.pem
+    - type: Path
+      path: /opt/example.com/pki/ca-pre1-2.der
   "registry-pre2.example.com:5500":
-    - /opt/example.com/pki/ca-pre2.pem
+    - type: Data
+      data: |
+            -----BEGIN CERTIFICATE-----
+            ca-pre2 PEM cert
+            -----END CERTIFICATE-----
 ```
 
 This file can be provided in YAML or JSON format. All keys are optional, so the following are also valid `sources.yaml` files:
@@ -35,7 +45,10 @@ As well as:
 ```json
 {
     "source_authorities": {
-        "pre.registry.example.com:3000": ["/some-certificate.pem"]
+        "host.k3d.internal:5000": [
+            {"type": "Data","data":"pem cert 1"},
+            {"type": "Data","data":"pem cert 2"}
+        ]
     }
 }
 ```
@@ -52,8 +65,36 @@ Hosts listed in the `insecure_sources` configuration behave in a different way t
   * Try to connect using HTTPS, skipping host verification. If the connection fails,
   * Try to connect using HTTP. If the connection fails, operation is aborted.
 
-It is generally fine to use `insecure_sources` when using local registries or HTTP servers when developing locally, to avoid the certificate burden. However, this setting is **completely discouraged** as the environment is closer to production.
+It is generally fine to use `insecure_sources` when using local registries or
+HTTP servers when developing locally, to avoid the certificate burden. However,
+this setting is **completely discouraged** for environments closer to
+production.
 
 ### Source authorities
 
-The source authorities is a map that contains the host and a list of CA certificates used to verify the identity of OCI registries and HTTPs servers.
+The `source_authorities` is a map that contains URIs and a list of CA
+certificates that form a certificate chain for that URI, used to verify the
+identity of OCI registries and HTTPs servers.
+
+These certificates can be encoded in PEM or DER format. Certificates in binary
+DER format can be provided as a path to a file containing the certificate,
+meanwhile certificates in PEM format can either by a path to the certificate
+file, or a string with the certificate contents. Both possibilities are
+specified via a `type` key:
+
+```yaml
+source_authorities:
+  "registry-pre.example.com":
+    - type: Path
+      path: /opt/example.com/pki/ca-pre1-1.pem
+    - type: Path
+      path: /opt/example.com/pki/ca-pre1-2.der
+    - type: Data
+      data: |
+            -----BEGIN CERTIFICATE-----
+            ca-pre1-3 PEM cert
+            -----END CERTIFICATE-----
+  "registry-pre2.example.com:5500":
+    - type: Path
+      path: /opt/example.com/pki/ca-pre2-1.der
+```

--- a/src/distributing-policies/custom-certificate-authorities.md
+++ b/src/distributing-policies/custom-certificate-authorities.md
@@ -4,8 +4,8 @@ Both `kwctl` and `policy-server` allow you to pull policies from OCI registries 
 
 The system CA store is used to validate the trusted chain of certificates presented by the OCI registry. In a regular Kubewarden installation, the `policy-server` will use the CA store shipped with its Linux container. In the client side, `kwctl` will use your operating system CA store.
 
-If you are using the Controller, you can configure the PolicyServer via their
-`spec` fields, as documented
+If you are using the [Kubewarden Controller](https://github.com/kubewarden/kubewarden-controller),
+you can configure the PolicyServer via their `spec` fields, as documented
 [here](../operator-manual/policy-servers/01-custom-cert-auths.html).
 
 > **Important**: the default behavior of `kwctl` and `policy-server` is to enforce HTTPS with trusted certificates matching the system CA store. You can interact with registries using untrusted certificates or even without TLS, by using the `insecure_sources` setting. This approach is **highly discouraged** in environments closer to production.

--- a/src/operator-manual/policy-servers/01-custom-cas.md
+++ b/src/operator-manual/policy-servers/01-custom-cas.md
@@ -1,0 +1,61 @@
+# Configuring PolicyServers
+
+## Custom Certificate Authorities for Policy registries
+
+It is possible to specify and configure the Certificate Authorities that a
+PolicyServer uses when pulling the ClusterAdmissionPolicy artifacts from the
+policy registry. The following `spec` fields will configure the deployed
+`policy-server` executable to that effect.
+
+### Insecure sources
+
+> **Important**: the default behavior of `kwctl` and `policy-server` is to
+> enforce HTTPS with trusted certificates matching the system CA store. You can
+> interact with registries using untrusted certificates or even without TLS, by
+> using the `insecure_sources` setting. This approach is **highly discouraged**
+> for environments closer to production.
+
+To configure the PolicyServer to accept insecure connections to specific
+registries, use the `spec.insecureSources` field of PolicyServer. This field
+accepts a list of URIs to be regarded as insecure. Example:
+
+```yaml
+spec:
+  insecureSources:
+    - localhost:5000
+    - host.k3d.internal:5000
+```
+
+See [here](../../distributing-policies/custom-certificate-authorities.html) for more
+information on how the `policy-server` executable treats them.
+
+
+### Custom Certificate Authorities
+
+To configure the PolicyServer with a custom certificate chain of 1 or more
+certificates for a specific URI, use the field `spec.sourceAuthorities`.
+
+This field is a map of URIs, each with its own list of strings that contain PEM
+encoded certificates. Example:
+
+```yaml
+spec:
+  sourceAuthorities:
+    "registry-pre.example.com":
+      - |
+        -----BEGIN CERTIFICATE-----
+        ca-pre1-1 PEM cert
+        -----END CERTIFICATE-----
+      - |
+        -----BEGIN CERTIFICATE-----
+        ca-pre1-2 PEM cert
+        -----END CERTIFICATE-----
+    "registry-pre2.example.com:5500":
+      - |
+        -----BEGIN CERTIFICATE-----
+        ca-pre2 PEM cert
+        -----END CERTIFICATE-----
+```
+
+See [here](/distributing-policies/custom-certificate-authorities.html) for more
+information on how the `policy-server` executable treats them.


### PR DESCRIPTION
Update distributing-policies/custom-certificate-authorities.md with new
sources.yml format.

Add new operator-manual/policy-servers/01-custom-cas.md with info on
`spec.{sourceAuthorities,insecureSources}`.

Rename authors to Kubewarden Developers.

Fixes https://github.com/kubewarden/docs/issues/62.