### PR TITLE
Update 01-intro.md

### DIFF
--- a/src/writing-policies/rust/01-intro.md
+++ b/src/writing-policies/rust/01-intro.md
@@ -32,3 +32,11 @@ Once `rustup` is installed add the Wasm target:
 ```shell
 rustup target add wasm32-unknown-unknown
 ```
+
+## OSX specific dependencies
+
+In order to use `cargo-generate` you will need to add the Xcode tool set. If it isn't installed through Xcode the following command will give you the dependencies needed:
+
+```shell
+xcode-select --install
+```


### PR DESCRIPTION
Adding known OSX dependencies that are needed to use `cargo-generate`.