### PR TITLE
Move telemetry flag in the chart values.

### DIFF
--- a/src/operator-manual/telemetry/metrics/01-quickstart.md
+++ b/src/operator-manual/telemetry/metrics/01-quickstart.md
@@ -84,7 +84,7 @@ Now we can deploy the rest of the Kubewarden stack. The official helm
 chart will create a PolicyServer named `default`.
 
 Let's configure the values of the Helm Chart so that we have metrics enabled 
-in the Kubewarden. Write the `kubewarden-values.yaml` file:
+in Kubewarden. Write the `kubewarden-values.yaml` file with the following contents:
 
 ```yaml
 telemetry:

--- a/src/operator-manual/telemetry/metrics/01-quickstart.md
+++ b/src/operator-manual/telemetry/metrics/01-quickstart.md
@@ -83,13 +83,13 @@ helm install --wait --namespace kubewarden --create-namespace kubewarden-crds ku
 Now we can deploy the rest of the Kubewarden stack. The official helm
 chart will create a PolicyServer named `default`.
 
-Let's configure the values of the Helm Chart so that the default
-PolicyServer has metrics enabled. Write the `kubewarden-values.yaml` file:
+Let's configure the values of the Helm Chart so that we have metrics enabled 
+in the Kubewarden. Write the `kubewarden-values.yaml` file:
 
 ```yaml
+telemetry:
+  enabled: True
 policyServer:
-  telemetry:
-    enabled: True
     metrics:
       port: 8080
 ```


### PR DESCRIPTION
The flag to enable telemetry has been moved out from the policyserver field. Thus, it enables telemetry in the controller as well. This commit updates the docs to reflect that change in the chart values changes.

Closes #71 