### PR TITLE
New mutating policies page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Quick Start](./quick-start.md)
 
 - [Common tasks](./tasks.md)
+  - [Mutating Policies](./mutating-policies.md)
 
 - [Architecture](./architecture.md)
 

--- a/src/mutating-policies.md
+++ b/src/mutating-policies.md
@@ -1,4 +1,4 @@
-### Mutating policies validation
+### Mutating policies
 
 Since [Kubewarden controller](https://github.com/kubewarden/kubewarden-controller) version v0.4.5 and [Policy Server](https://github.com/kubewarden/policy-server) version v0.2.6, the `mutating` field impacts how mutated requests are validated. If you deploy a policy which mutates requests and the `mutating` field set to `true`, the requests will act as a validated ones.
 

--- a/src/mutating-policies.md
+++ b/src/mutating-policies.md
@@ -1,8 +1,8 @@
 ### Mutating policies
 
-Since [Kubewarden controller](https://github.com/kubewarden/kubewarden-controller) version v0.4.5 and [Policy Server](https://github.com/kubewarden/policy-server) version v0.2.6, the `mutating` field impacts how mutated requests are validated. If you deploy a policy which mutates requests and the `mutating` field set to `true`, the requests will act as a validated ones.
+A mutating policy will rebuild the requests with definied values that are conformant with the policy definition. If you want allow the behavior of mutating requests, you need to set the `ClusterAdmissionPolicy.mutating` filed to `true`.
 
-However, if you set the `mutating` field to `false`, the mutated requests will be rejected. For example, create the following `ClusterAdmissionPolicy` with the `mutating` field set to `true`:
+However, if you set the `ClusterAdmissionPolicy.mutating` field to `false`, the mutated requests will be rejected. For example, create the following `ClusterAdmissionPolicy` with the `mutating` field set to `true`:
 
 ```bash
 # Command

--- a/src/mutating-policies.md
+++ b/src/mutating-policies.md
@@ -1,0 +1,129 @@
+### Mutating policies validation
+
+Since [Kubewarden controller](https://github.com/kubewarden/kubewarden-controller) version v0.4.5 and [Policy Server](https://github.com/kubewarden/policy-server) version v0.2.6, the `mutating` field impacts how mutated requests are validated. If you deploy a policy which mutates requests and the `mutating` field set to `true`, the requests will act as a validated ones.
+
+However, if you set the `mutating` field to `false`, the mutated requests will be rejected. For example, create the following `ClusterAdmissionPolicy` with the `mutating` field set to `true`:
+
+```bash
+# Command
+kubectl apply -f - <<EOF
+apiVersion: policies.kubewarden.io/v1alpha2
+kind: ClusterAdmissionPolicy
+metadata:
+  name: psp-user-group
+spec:
+  module: "registry://ghcr.io/kubewarden/policies/user-group-psp:v0.1.5"
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    operations:
+    - CREATE
+    - UPDATE
+  mutating: true
+  settings:
+    run_as_user:
+      rule: "MustRunAs"
+      ranges:
+        - min: 1000
+          max: 2000
+        - min: 3000
+          max: 4000
+    run_as_group:
+      rule: "RunAsAny"
+    supplemental_groups:
+      rule: "RunAsAny" 
+EOF
+
+# Output
+clusteradmissionpolicy.policies.kubewarden.io/psp-user-group created
+```
+
+The [`psp-user-group`](https://github.com/kubewarden/user-group-psp-policy) policy is used to control users and groups in containers and can mutate the requests. In the example above, the `runAsUser` field is set and it will be added to the container `securityContext` section. 
+
+As the `mutating` field is set to `true`, the following request will be applied successfully:
+
+```bash
+# Command
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pause-user-group
+spec:
+  containers:
+    - name: pause
+      image: k8s.gcr.io/pause
+EOF
+
+# Output
+pod/pause-user-group created
+```
+
+Once the request is applied, you can see the results of the container's `securityContext`:
+
+```bash
+# Command
+kubectl get pods pause-user-group -o jsonpath='{ .spec.containers[].securityContext }'
+
+# Output
+{"runAsUser":1000}
+```
+
+Now, modify the `ClusterAdmissionPolicy` by setting the field `mutating` to `false`:
+
+```bash
+# Command
+kubectl apply -f - <<EOF
+apiVersion: policies.kubewarden.io/v1alpha2
+kind: ClusterAdmissionPolicy
+metadata:
+  name: psp-user-group
+spec:
+  module: "registry://ghcr.io/kubewarden/policies/user-group-psp:v0.1.5"
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    operations:
+    - CREATE
+    - UPDATE
+  mutating: false
+  settings:
+    run_as_user:
+      rule: "MustRunAs"
+      ranges:
+        - min: 1000
+          max: 2000
+        - min: 3000
+          max: 4000
+    run_as_group:
+      rule: "RunAsAny"
+    supplemental_groups:
+      rule: "RunAsAny" 
+EOF
+
+# Output
+clusteradmissionpolicy.policies.kubewarden.io/psp-user-group configured
+```
+
+As the `mutating` field is set to `false`, the following request will fail:
+
+```bash
+# Command
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pause-user-group
+spec:
+  containers:
+    - name: pause
+      image: k8s.gcr.io/pause
+EOF
+
+# Output
+Error from server: error when creating ".\\pause-user-group.yaml": admission webhook "psp-user-group.kubewarden.admission" denied the request: Request rejected by policy psp-user-group. The policy attempted to mutate the request, but it is currently configured to not allow mutations.
+```
+
+As a conclusion, you can see that Kubewarden allows you to replicate the exact same behavior as the deprecated Kubernetes Pod Security Polices (PSP).


### PR DESCRIPTION
Created the mutating policies validation page, based on the new Kubewarden controller and policy server versions.

Updated the Summary page to add it as a follow-up to the tasks page