### PR TITLE
Adds the kubewarden-documentation team in the CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @kubewarden/kubewarden-developers
+* @kubewarden/kubewarden-documentation


### PR DESCRIPTION

## Description
Adds the kubewarden-documentation team in the CODEOWNERS file to ensure that they will see all PRs in the repository.
