### PR TITLE
Documentation about the new kubewarden-defaults chart.

### DIFF
--- a/src/quick-start.md
+++ b/src/quick-start.md
@@ -47,11 +47,11 @@ Kubewarden has three main components which you will interact with:
 * The ClusterAdmissionPolicy
 * The AdmissionPolicy
 
-### Policy Server
+### PolicyServer
 
-A Kubewarden Policy Server is completely managed by the `kubewarden-controller` and multiple Policy Servers can be deployed in the same Kubernetes cluster.
+A Kubewarden `PolicyServer` is completely managed by the `kubewarden-controller` and multiple `PolicyServers` can be deployed in the same Kubernetes cluster.
 
-The Policy Server is the component which executes the Kubewarden policies when requests arrive and validates them.
+The `PolicyServer` is the component which executes the Kubewarden policies when requests arrive and validates them.
 
 Default `PolicyServer` configuration:
 


### PR DESCRIPTION
## Description

Updates the quick start section explaining to the users how to install the kubewarden-controller and kubewarden-defaults charts if the user already have a Policy Server installed by older versions of the kubewarden-controller chart.

Fix #96 

### Potential improvement

I'm not sure if the current text is enough and if it is in the right place. Please, let me know how can I improve it. 