### PR TITLE
fix: typos and grammar in TypeScript docs

### DIFF
--- a/src/writing-policies/typescript.md
+++ b/src/writing-policies/typescript.md
@@ -13,12 +13,12 @@ designed explicitly for WebAssembly.
 
 ## Current State
 
-Currently there's currently no Kubewarden SDK for AssemblyScript, we haven't
-created it bacause of lack of time. We will do that in the near future.
+Currently there's no Kubewarden SDK for AssemblyScript. We haven't created it
+because of lack of time. We will do that in the near future.
 
 In the meantime, there seem to be some limitatations affecting AssemblyScript:
 
-* There's no built-in way to Serialize and Deserilize classed to
+* There's no built-in way to serialize and deserialize Classes to
   and from JSON. See [this issue](https://github.com/AssemblyScript/assemblyscript/issues/292)
 * It *seems* there's no JSON path library for AssemblyScript
 
@@ -27,10 +27,10 @@ In the meantime, there seem to be some limitatations affecting AssemblyScript:
 [This GitHub repository](https://github.com/kubewarden/pod-privileged-policy)
 contains a Kubewarden Policy written in AssemblyScript.
 
-**Worth of note:** this repository has a series of GitHub Actions that automate
+**Worth noting:** this repository has a series of GitHub Actions that automate
 the following tasks:
 
   * Run unit tests and code linting on pull requests and after code is merged
     into the main branch
-  * Build the policy in `release` mode and push it to a OCI registry as an
+  * Build the policy in `release` mode and push it to an OCI registry as an
     artifact


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
<!-- Fix #XXX -->

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

### Summary

Fixes a few typos, misspellings, and grammar in the TS doc

### Details

- duplicated "currently"
- misspelled "bacause" -> "because"
- misspelled "deserilize" -> "deserialize"

- lowercase serialize and deserialize as they aren't proper nouns; uppercase Classes as Class is a proper noun/term
- grammar: "Worth of note" -> "Worth noting"
- grammar: "a OCI" -> "an OCI"

## Test

N/A
<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

Saw some small issues in the docs while I was reading them, figured I'd make some quick patches

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->
N/A

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
Easier to read/understand/interpret docs
