### PR TITLE
fix: typos and grammar in Mutating Policies docs

### DIFF
--- a/src/writing-policies/spec/04-mutating-policies.md
+++ b/src/writing-policies/spec/04-mutating-policies.md
@@ -1,14 +1,13 @@
 # Mutating policies
 
-Mutation policies are structured in the very same was as validating ones:
- * They have to register a `validate` and a `validate_settings` waPC functions
+Mutating policies are structured in the very same way as validating ones:
+ * They have to register `validate` and `validate_settings` waPC functions
  * The communication API used between the host and the policy is the very same
   as the one used by validating policies.
 
 Mutating policies can accept a request and propose a mutation of the incoming
-object by returning a `ValidationResponse` object that looks like that:
+object by returning a `ValidationResponse` object that looks like this:
 
-```json
 ```json
 {
   "accepted": true,
@@ -21,7 +20,7 @@ inside of the Kubernetes cluster serialized to JSON.
 
 ## A concrete example
 
-Let's assume the policy received `ValidationRequest`:
+Let's assume the policy received this `ValidationRequest`:
 
 ```json
 {
@@ -52,10 +51,10 @@ Let's assume the policy received `ValidationRequest`:
 }
 ```
 
-> **Note well:** we left some irrelevant fields out of the `request` object.
+> **Note:** we left some irrelevant fields out of the `request` object.
 
 This request is generated because someone tried to create a Pod that would
-look like that:
+look like this:
 
 ```yaml
 apiVersion: v1
@@ -108,7 +107,7 @@ Let's assume our policy replies with the following `ValidationResponse`:
 ```
 
 That would lead to the request being accepted, but the final Pod would look like
-that:
+this:
 
 ```yaml
 apiVersion: v1
@@ -128,12 +127,12 @@ spec:
         - BPF
 ```
 
-As you can see the policy altered the `securityContext.capabilities.drop`
+As you can see, the policy altered the `securityContext.capabilities.drop`
 section of the only container declared inside of the Pod.
 
 The container is now dropping the `BPF` capability thanks to our policy.
 
-# Recap
+## Recap
 
 These are the functions a mutating policy must implement:
 
@@ -200,4 +199,3 @@ These are the functions a mutating policy must implement:
     </tr>
   </tbody>
 </table>
-


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
<!-- Fix #XXX -->

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

### Summary

Fixes a few typos, misspellings, grammar, and a markdown error in the Mutating Policies doc

### Details

- typo "Mutation policies" -> "Mutating policies"
- typo "same was" -> "same way"
- grammar: "register a ... and a .. functions" -> "register ... and ... functions"
  - "a" is singular while "functions" is plural

- duplicated "```json" top of code block
  - this was visible _inside_ the code block

- grammar: "that" -> "this" in a few places
  - "that" means 'further away', but it's referring to just below itself
    in a code block, so "this" would be the appropriate word
  - also missing "this" in one place

- grammar: "Note well:" -> "Note:"
  - just common parlance, no need for a qualifier

- grammar: "As you can see the policy" -> "As you can see, the policy"
  - missing comma

- markdown error: "# Recap" -> "## Recap"
  - can't have two H1s on a page and normally shouldn't have an H1 in
    the middle either -- pretty sure this was supposed to be an H2
  - markdownlint will error on this too


## Test

N/A
<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

Some other issues in the docs I found in addition to #105 

### Tradeoff

N/A
<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
Easier to read/understand/interpret docs