### PR TITLE
feat: add a tiny stub page on JavaScript policies

### DIFF
--- a/src/writing-policies/javascript.md
+++ b/src/writing-policies/javascript.md
@@ -1,0 +1,11 @@
+# JavaScript
+
+JavaScript **cannot** be converted to WebAssembly, however
+[Javy](https://github.com/Shopify/javy) can execute JavaScript code in a
+WebAssembly embedded JavaScript runtime, powered by the
+[QuickJS embedded JavaScript engine](https://github.com/bellard/quickjs).
+
+## Current State
+
+Currently there's no Kubewarden SDK for JavaScript. As of the time of writing,
+Javy is a beta project that was only recently released.


### PR DESCRIPTION

## Description

### Summary

Adds a tiny stub page on writing policies in JavaScript using [Javy](https://github.com/Shopify/javy)

### Details

- similar to the TypeScript stub page that just briefly mentions AssemblyScript
  - minus the example

- I found out about Javy recently, think it might deserve a mention
  - especially for potential eventual compatibility with [jsPolicy](https://github.com/loft-sh/jspolicy)
    policies, similar to how Kubewarden has some Rego/OPA/Gatekeeper compat
    
<!-- Please provide the link to the GitHub issue you are addressing -->
<!-- Fix #XXX -->

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

N/A
<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

It's a stub, so not particularly useful and potentially even misleading, but it also shows potential users that there is opportunity for JS usage as well. Javy is also in beta, so could be abandoned, but it is also used by Shopify, so maybe not so likely. The stub is also transparent about the status, similar to the TypeScript stub.

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

Just informing the Kubewarden and broader WASM and Policy communities about Javy

<!-- Please describe, if any, potential improvement that you are envisioning -->
