### PR TITLE
feat: Add security/{threat, disclosure, verifying}

### DIFF
--- a/docs/security/01-intro.md
+++ b/docs/security/01-intro.md
@@ -5,4 +5,4 @@ title: ""
 
 # Security
 
-This section covers security topics related with the Kubewarden project itself.
+This section covers security topics related to the Kubewarden project.

--- a/docs/security/01-intro.md
+++ b/docs/security/01-intro.md
@@ -1,0 +1,8 @@
+---
+sidebar_label: "Security"
+title: ""
+---
+
+# Security
+
+This section covers security topics related with the Kubewarden project itself.

--- a/docs/security/disclosure.md
+++ b/docs/security/disclosure.md
@@ -1,0 +1,28 @@
+---
+sidebar_label: "Disclosure"
+title: ""
+---
+
+# Disclosure
+
+The Kubewarden team greatly appreciates investigative work into security
+vulnerabilities carried out by well-intentioned, ethical security researchers.
+We follow the practice of [responsible
+disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) in order to
+best protect Kubewarden's user-base from the impact of security issues. On our
+side, this means:
+
+- We will respond to security incidents as a priority.
+- We will fix the issue as soon as is practical, keeping in mind that not all risks are created equal.
+- We will always transparently let the community know about any incident that affects them.
+
+If you have found a security vulnerability in Kubewarden, we kindly ask that you
+disclose it responsibly by emailing kubewarden@suse.de. Please do not discuss
+potential vulnerabilities in public without validating with us first.
+
+On receipt the security team will:
+
+- Review the report, verify the vulnerability and respond with confirmation
+  and/or further information requests.
+- Once the reported security bug has been addressed we will notify the
+  Researcher, who is then welcome to optionally disclose publicly.

--- a/docs/security/disclosure.md
+++ b/docs/security/disclosure.md
@@ -13,7 +13,7 @@ best protect Kubewarden's user-base from the impact of security issues. On our
 side, this means:
 
 - We will respond to security incidents on priority.
-- We will fix the issue as soon as is practical, keeping in mind that not all risks are created equal.
+- We will release fixes for issues as soon as is practical, keeping in mind that not all risks are created equal.
 - We will always transparently let the community know about any incident that affects them.
 
 If you have found a security vulnerability in Kubewarden, we kindly ask that you

--- a/docs/security/disclosure.md
+++ b/docs/security/disclosure.md
@@ -12,7 +12,7 @@ disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) in order to
 best protect Kubewarden's user-base from the impact of security issues. On our
 side, this means:
 
-- We will respond to security incidents as a priority.
+- We will respond to security incidents on priority.
 - We will fix the issue as soon as is practical, keeping in mind that not all risks are created equal.
 - We will always transparently let the community know about any incident that affects them.
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -86,7 +86,6 @@ between the API  server and the admission controller webhook.
 **Mitigation**
 Webhook uses TLS encryption for all traffic
 
-Kubewarden are safe. Because the webhook connections are encrypted.
 
 
 ## Threat 8 - Attacker carries out a MITM attack on the webhook

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -211,7 +211,11 @@ Kubewarden policies run in a restrictive environment. They do not have network a
 
 
 ## Threat Kubewarden ID 1 - Bootstrapping of trust for admission controller
-Assuming a trusted but fresh Kubernetes cluster, an attacker is able to compromise the Kubewarden stack before any of the policies securing it is deployed and enforcing. For example, by using unsigned and malicious images for kubewarden-controller, policy-server, or any of the Kubewarden dependencies (cert-manager) or optional dependencies (grafana, prometheus..), or by compromising the Helm charts payload.
+Assuming a trusted but fresh Kubernetes cluster, an attacker is able to compromise the Kubewarden stack 
+before any of the policies securing it are deployed and enforced.  For example, by using unsigned and 
+malicious images for kubewarden-controller, policy-server, or any of the Kubewarden dependencies 
+(cert-manager) or optional dependencies (grafana, prometheus, etc.), or by compromising 
+the Helm charts payload.
 
 ** Mitigation **
 1. Kubewarden provides a Software Bill Of Materials, which lists all images needed. This aids with Zero-Trust.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -56,7 +56,7 @@ RBAC rights are strictly controlled.
 Most of RBAC isn't within the scope of the current discussion. 
 However, we intend to provide the below in due course for helping Kubewarden users.
 - Directions around minimum RBAC to be implemented.
-- Provide a policy which detect RBAC changes and **maybe** block them.
+- Provision & documentation of a policy that detects and could potentially block RBAC changes.
 
 
 ## Threat 5 - Attacker gets access to valid credentials for the webhook

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,219 @@
+---
+sidebar_label: "Threat Model"
+title: ""
+---
+
+# Threat Model
+
+The [Kubernetes SIG Security team](https://github.com/kubernetes/community/tree/master/sig-security) has
+defined an Admission Control Threat Model. The Kubewarden team has evaluated
+Kubewarden against this threat model, and strives to provide secure defaults
+that cover it. Still, it is recommended for Kubewarden administrators to read
+and understand the threat model, and use it to devise their own thread model as
+needed.
+
+If more details about each threat is needed, refer to the [SIG-security original document ](https://github.com/kubernetes/sig-security/tree/main/sig-security-docs/papers/admission-control).
+
+
+## Threat 1 - Attacker floods webhook with traffic preventing its operation
+
+An attacker who has access to the Webhook endpoint, at the network level, could
+send large  quantities of traffic, causing an effective denial of service to the
+admission controller.
+
+**Mitigation**
+
+Webhook fails closed. In other words, if the webhook does not respond in time,
+for any reasion, API server should reject the request. We are safe on this.
+Kubewarden default behavior  already does that.
+
+## Threat 2 - Attacker passes workloads which require complex  processing causing timeouts
+
+An attacker, who can access the admission controller at a network level, passes
+requests to  the admission controller which require complex processing, causing
+timeouts as the  admission controller uses compute power to process the workloads
+
+**Mitigation**
+Webhook fail closed and authenticate callers. We are safe, Kubewarden already does that.
+
+## Threat 3 - Attacker exploits misconfiguration of webhook to bypass
+An attacker, who has rights to create workloads in the cluster, is able to exploit
+a mis-configuration to bypass the intended security control
+
+**Mitigation**
+Regular reviews of webhook configuration catch issues.
+
+
+### Threat 4 - Attacker has rights to delete or modify the k8s webhook  object
+
+An attacker who has Kubernetes API access, has sufficient privileges to delete
+the webhook  object in the cluster.
+
+**Mitigation**
+RBAC rights are strictly controlled.
+
+**To do**
+I think most of the RBAC is not Kubewarden responsibility. But we can help our users if we:
+- Warning them in our docs and *suggest* some minimum RBAC to be used.
+- Provide a policy which detect RBAC changes and **maybe** block them.
+
+
+## Threat 5 - Attacker gets access to valid credentials for the webhook
+An attacker gains access to valid client credentials for the admission controller webhook
+
+**Mitigation**
+Webhook fails closed.
+
+Kubewarden is failed closed. Thus, we should be fine.
+
+## Threat  6 - Attacker gains access to a cluster admin credential
+
+An attacker gains access to a cluster-admin level credential in the kubernetes cluster.
+
+**Mitigation**
+N/A
+
+I cannot see how Kubewarden can help here.
+
+## Threat 7 - Attacker sniffs traffic on the container network
+An attacker who has access to the container network is able to sniff traffic
+between the API  server and the admission controller webhook.
+
+**Mitigation**
+Webhook uses TLS encryption for all traffic
+
+Kubewarden are safe. Because the webhook connections are encrypted.
+
+
+## Threat 8 - Attacker carries out a MITM attack on the webhook
+An attacker on the container network, who has access to the NET_RAW capability
+can  attempt to use MITM tooling to intercept traffic between the API server
+and admission  controller webhook.
+
+**Mitigation**
+Webhook mTLS authentication is used.
+
+**To do**
+Kubewarden should implement mutual TLS authentication
+We can add in the recommended policies from the `kubewarden-defaults` Helm
+chart a policy to drop the `NET_RAW` capability.
+
+### Threat 9 - Attacker steals traffic from the webhook via spoofing
+An attacker is able to redirect traffic from the API server which is intended
+for the admission  controller webhook by spoofing.
+
+**Mitigation**
+Webhook mTLS authentication is used.
+
+**To do**
+Kubewarden should implement mutual TLS authentication
+
+### Threat 10 - Abusing a mutation rule to create a privileged container
+An attacker is able to cause a mutating admission controller to modify a workload,
+such that  it allows for privileged container creation
+
+**Mitigation**
+All rules are reviewed and tested.
+
+**To do**
+We may came up with some tests to cover this rules reviews
+We  should carefully review a PR changing the rules in the policies deployment
+
+## Threat 11 - Attacker deploys workloads to namespaces that are  exempt from admission control
+An attacker is able to deploy workloads to Kubernetes namespaces that are exempt
+from the  admission controller configuration.
+
+**Mitigation**
+RBAC rights are strictly controlled
+
+**To do**
+I think most of the RBAC is not Kubewarden responsability. But we can help our users if we:
+- Warning them in our docs and *suggest* some minimum RBAC to be used.
+- Provide a policy which detect RBAC changes and **maybe** block them. Is this possible?
+
+
+## Threat ID 12 - Block rule can be bypassed due to missing match (e.g.  missing initcontainers)
+An attacker created a workload manifest which uses a feature of the Kubernetes
+API which  is not covered by the admission controller
+
+**Mitigation**
+All rules are reviewed and tested.
+
+**To do**
+We may came up with some tests to cover this rules reviews
+We  should carefully review a PR changing the rules in the policies deployment
+
+## Threat ID 13 - Attacker exploits bad string matching on a blocklist to  bypass rules
+An attacker, who has rights to create workloads, bypasses a rule by exploiting
+bad string  matching.
+
+**Mitigation**
+All rules are reviewed and tested.
+
+**To do**
+We may came up with some tests to cover this rules reviews
+We  should carefully review a PR changing the rules in the policies deployment
+
+## Threat ID 14 - Attacker uses new/old features of the Kubernetes API  which have no rules
+An attacker, with rights to create workloads, uses new features of the Kubernetes
+API (for  example a changed API version) to bypass a rule.
+
+**Mitigation**
+All rules are reviewed and tested.
+
+**To do**
+We may came up with some tests to cover this rules reviews and API versions.
+We can create a configuration to reject by default requests where the API
+version not cover by the policy.  We should warning policies developers to cover
+all the supported API version in theirs tests and reject all of others.
+
+
+## Threat ID 15 - Attacker deploys privileged container to node running  Webhook controller
+An attacker, who has rights to deploy privileged containers to the cluster, creates
+a privileged  container on the cluster node where the admission controller webhook operates.
+
+**Mitigation**
+Admission controller uses restrictive policies to prevent privileged  workloads
+
+**To do**
+I do not know if Kuberwarden can help on this. Kubewarden does not have access to
+containers running in the cluster node.
+
+
+## Threat ID 16 - Attacker mounts a privileged node hostpath allowing  modification of Webhook controller configuration
+An attacker, who has rights to deploy hostPath volumes with workloads, creates a
+volume  which allows for access to the admission controller pod’s files.
+
+**Mitigation**
+Admission controller uses restrictive policies to prevent privileged  workloads
+
+**To do**
+We can add a recommended policy in the `kubewarden-default` Helm chart to prevent this.
+
+
+## Threat ID 17 - Attacker has privileged SSH access to cluster node  running admission webhook
+An attacker is able to log into cluster nodes as a privileged user via SSH.
+**Mitigation**
+N/A
+
+I don't think Kubewarden can help on this
+
+
+## Threat ID 18 - Attacker uses policies to send confidential data from  admission requests to external systems
+An attacker is able to configure a policy that listens to admission requests and
+sends  sensitive data to an external system.
+
+**Mitigation**
+Strictly control external access for webhook
+
+Kubewarden policies run in a restrictive environment. They do not have network access.
+
+
+## Threat Kubewarden ID 1 - Bootstrapping of trust for admission controller
+Assuming a trusted but fresh Kubernetes cluster, an attacker is able to compromise the Kubewarden stack before any of the policies securing it is deployed and enforcing. For example, by using unsigned and malicious images for kubewarden-controller, policy-server, or any of the Kubewarden dependencies (cert-manager) or optional dependencies (grafana, prometheus..), or by compromising the Helm charts payload.
+
+** Mitigation **
+1. Kubewarden provides a Software Bill Of Materials, which lists all images needed. This aids with Zero-Trust.
+  The Kubernetes Administrator must verify the Kubewarden images (and its dependencies' images and charts) out of the Kubernetes cluster, in a trusted environment. This can be done with `cosign`, for example.
+  Incidentally, this is part of the implementation needed for air-gapped installations.
+ 2. Use signed Helm charts, and verified digests (instead of tags) for Kubewarden images in those Helm charts. This doesn't secure dependencies though.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -31,7 +31,7 @@ Kubewarden default behavior already does that.
 
 An attacker, who can access the admission controller at a network level, passes
 requests to the admission controller requiring complex processing and causing
-timeouts as the  admission controller uses compute power to process the workloads
+timeouts as the admission controller utilizes compute power to process the workloads
 
 **Mitigation**
 Webhook fail closed and authenticate callers. Kubewarden default behaviour

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -12,7 +12,7 @@ that cover it. Still, it is recommended for Kubewarden administrators to read
 and understand the threat model, and use it to devise their own thread model as
 needed.
 
-If more details about each threat is needed, refer to the [SIG-security original document ](https://github.com/kubernetes/sig-security/tree/main/sig-security-docs/papers/admission-control).
+If more details about each threat is needed, refer to the [original document published by SIG-security](https://github.com/kubernetes/sig-security/tree/main/sig-security-docs/papers/admission-control).
 
 
 ## Threat 1 - Attacker floods webhook with traffic preventing its operation

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -42,7 +42,7 @@ An attacker, who has rights to create workloads in the cluster, is able to explo
 a misconfiguration to bypass the intended security control.
 
 **Mitigation**
-Regular reviews of webhook configuration catch issues.
+Regular reviews of webhook configuration can help catch issues.
 
 
 ### Threat 4 - Attacker has rights to delete or modify the k8s webhook  object

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -102,7 +102,7 @@ chart a policy to drop the `NET_RAW` capability.
 
 ### Threat 9 - Attacker steals traffic from the webhook via spoofing
 An attacker is able to redirect traffic from the API server which is intended
-for the admission  controller webhook by spoofing.
+for the admission controller webhook by spoofing.
 
 **Mitigation**
 Webhook mTLS authentication is used.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -90,7 +90,7 @@ Webhook uses TLS encryption for all traffic
 ## Threat 8 - Attacker carries out a MITM attack on the webhook
 An attacker on the container network, who has access to the NET_RAW capability
 can attempt to use MITM tooling to intercept traffic between the API server
-and admission  controller webhook.
+and admission controller webhook.
 
 **Mitigation**
 Webhook mTLS authentication is used.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -53,7 +53,8 @@ the webhook object in the cluster.
 RBAC rights are strictly controlled.
 
 **To do**
-I think most of the RBAC is not Kubewarden responsibility. But we can help our users if we:
+Most of RBAC isn't within the scope of the current discussion. 
+However, we intend to provide the below in due course for helping Kubewarden users.
 - Warning them in our docs and *suggest* some minimum RBAC to be used.
 - Provide a policy which detect RBAC changes and **maybe** block them.
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -112,7 +112,7 @@ Kubewarden should implement mutual TLS authentication
 
 ### Threat 10 - Abusing a mutation rule to create a privileged container
 An attacker is able to cause a mutating admission controller to modify a workload,
-such that  it allows for privileged container creation
+such that it allows for privileged container creation
 
 **Mitigation**
 All rules are reviewed and tested.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -136,7 +136,7 @@ I think most of the RBAC is not Kubewarden responsability. But we can help our u
 
 ## Threat ID 12 - Block rule can be bypassed due to missing match (e.g.  missing initcontainers)
 An attacker created a workload manifest which uses a feature of the Kubernetes
-API which  is not covered by the admission controller
+API which is not covered by the admission controller
 
 **Mitigation**
 All rules are reviewed and tested.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -47,7 +47,7 @@ Regular reviews of webhook configuration catch issues.
 ### Threat 4 - Attacker has rights to delete or modify the k8s webhook  object
 
 An attacker who has Kubernetes API access, has sufficient privileges to delete
-the webhook  object in the cluster.
+the webhook object in the cluster.
 
 **Mitigation**
 RBAC rights are strictly controlled.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -84,7 +84,7 @@ An attacker who has access to the container network is able to sniff traffic
 between the API  server and the admission controller webhook.
 
 **Mitigation**
-Webhook uses TLS encryption for all traffic
+Since the webhook uses TLS encryption for all traffic, Kubewarden is safe.
 
 
 ## Threat 8 - Attacker carries out a MITM attack on the webhook

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -38,7 +38,7 @@ Webhook fail closed and authenticate callers. We are safe, Kubewarden already do
 
 ## Threat 3 - Attacker exploits misconfiguration of webhook to bypass
 An attacker, who has rights to create workloads in the cluster, is able to exploit
-a mis-configuration to bypass the intended security control
+a misconfiguration to bypass the intended security control
 
 **Mitigation**
 Regular reviews of webhook configuration catch issues.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -119,7 +119,7 @@ All rules are reviewed and tested.
 
 **To do**
 The Kubewarden team may come up with some tests to cover the review of these rules in the future.
-We  should carefully review a PR changing the rules in the policies deployment
+In addition to the above, any change of rules during policies deployment must be carefully reviewed.
 
 ## Threat 11 - Attacker deploys workloads to namespaces that are  exempt from admission control
 An attacker is able to deploy workloads to Kubernetes namespaces that are exempt

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -168,7 +168,7 @@ All rules are reviewed and tested.
 Introduce tests to cover this rule.
 Create a configuration to reject requests where the API version not
 cover by the policy by default. Kubewarden should warn policy developers to cover all the
-supported API version in theirs tests and reject all of others.
+supported API version in their tests and reject all others.
 
 
 ## Threat ID 15 - Attacker deploys privileged container to node running  Webhook controller

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -12,7 +12,7 @@ that cover it. Still, it is recommended for Kubewarden administrators to read
 and understand the threat model, and use it to devise their own thread model as
 needed.
 
-If more details about each threat is needed, refer to the [original document published by SIG-security](https://github.com/kubernetes/sig-security/tree/main/sig-security-docs/papers/admission-control).
+If more details about each threat is needed, refer to the [original document published by SIG Security](https://github.com/kubernetes/sig-security/tree/main/sig-security-docs/papers/admission-control).
 
 
 ## Threat 1 - Attacker floods webhook with traffic preventing its operation

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -195,6 +195,7 @@ We can add a recommended policy in the `kubewarden-default` Helm chart to preven
 
 ## Threat ID 17 - Attacker has privileged SSH access to cluster node  running admission webhook
 An attacker is able to log into cluster nodes as a privileged user via SSH.
+
 **Mitigation**
 N/A
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -18,7 +18,7 @@ If more details about each threat is needed, refer to the [original document pub
 ## Threat 1 - Attacker floods webhook with traffic preventing its operation
 
 An attacker who has access to the Webhook endpoint, at the network level, could
-send large  quantities of traffic, causing an effective denial of service to the
+send large quantities of traffic, causing an effective denial of service to the
 admission controller.
 
 **Mitigation**

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -97,7 +97,7 @@ Webhook mTLS authentication is used.
 
 **To do**
 Kubewarden should implement mutual TLS authentication
-We can add in the recommended policies from the `kubewarden-defaults` Helm
+Additionally, within the recommended policies section in the `kubewarden-defaults` Helm
 chart a policy to drop the `NET_RAW` capability could potentially be incorporated.
 
 ### Threat 9 - Attacker steals traffic from the webhook via spoofing

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -98,7 +98,7 @@ Webhook mTLS authentication is used.
 **To do**
 Kubewarden should implement mutual TLS authentication
 We can add in the recommended policies from the `kubewarden-defaults` Helm
-chart a policy to drop the `NET_RAW` capability.
+chart a policy to drop the `NET_RAW` capability could potentially be incorporated.
 
 ### Threat 9 - Attacker steals traffic from the webhook via spoofing
 An attacker is able to redirect traffic from the API server which is intended

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -167,7 +167,7 @@ All rules are reviewed and tested.
 **To do**
 Introduce tests to cover this rule.
 Create a configuration to reject requests where the API version not
-cover by the policy. Kubewarden should warn policy developers to cover all the
+cover by the policy by default. Kubewarden should warn policy developers to cover all the
 supported API version in theirs tests and reject all of others.
 
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -184,7 +184,7 @@ containers running in the cluster node.
 
 ## Threat ID 16 - Attacker mounts a privileged node hostpath allowing  modification of Webhook controller configuration
 An attacker, who has rights to deploy hostPath volumes with workloads, creates a
-volume  which allows for access to the admission controller pod’s files.
+volume that allows for access to the admission controller pod’s files.
 
 **Mitigation**
 Admission controller uses restrictive policies to prevent privileged  workloads

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -132,7 +132,7 @@ RBAC rights are strictly controlled
 
 **To do**
 Most of the RBAC is out of scope with respect to this decision. However, the Kubewarden team aims to:
-- Warning users in our docs and *suggest* some minimum RBAC to be used.
+- Warn users via our docs and *suggest* some minimum RBAC to be used.
 - Provide a policy which detects RBAC changes and **maybe** block them.
 
 ## Threat ID 12 - Block rule can be bypassed due to missing match (e.g.  missing initcontainers)

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -30,7 +30,7 @@ Kubewarden default behavior already does that.
 ## Threat 2 - Attacker passes workloads which require complex  processing causing timeouts
 
 An attacker, who can access the admission controller at a network level, passes
-requests to  the admission controller which require complex processing, causing
+requests to the admission controller requiring complex processing and causing
 timeouts as the  admission controller uses compute power to process the workloads
 
 **Mitigation**

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -24,7 +24,7 @@ admission controller.
 **Mitigation**
 
 Webhook fails closed. In other words, if the webhook does not respond in time,
-for any reasion, API server should reject the request.
+for any reason, the API server should reject the request.
 Kubewarden default behavior already does that.
 
 ## Threat 2 - Attacker passes workloads which require complex  processing causing timeouts

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -39,7 +39,7 @@ already does that.
 
 ## Threat 3 - Attacker exploits misconfiguration of webhook to bypass
 An attacker, who has rights to create workloads in the cluster, is able to exploit
-a misconfiguration to bypass the intended security control
+a misconfiguration to bypass the intended security control.
 
 **Mitigation**
 Regular reviews of webhook configuration catch issues.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -159,7 +159,7 @@ As always, carefully review PRs changing the rules in the policies deployment.
 
 ## Threat ID 14 - Attacker uses new/old features of the Kubernetes API  which have no rules
 An attacker, with rights to create workloads, uses new features of the Kubernetes
-API (for  example a changed API version) to bypass a rule.
+API (for example, a changed API version) to bypass a rule.
 
 **Mitigation**
 All rules are reviewed and tested.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -166,7 +166,7 @@ All rules are reviewed and tested.
 
 **To do**
 Introduce tests to cover this rule.
-Create a configuration to reject by default requests where the API version not
+Create a configuration to reject requests where the API version not
 cover by the policy. Kubewarden should warn policy developers to cover all the
 supported API version in theirs tests and reject all of others.
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -118,7 +118,7 @@ such that it allows for privileged container creation
 All rules are reviewed and tested.
 
 **To do**
-We may came up with some tests to cover this rules reviews
+The Kubewarden team may come up with some tests to cover the review of these rules in the future.
 We  should carefully review a PR changing the rules in the policies deployment
 
 ## Threat 11 - Attacker deploys workloads to namespaces that are  exempt from admission control

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -78,7 +78,6 @@ An attacker gains access to a cluster-admin level credential in the kubernetes c
 **Mitigation**
 N/A
 
-I cannot see how Kubewarden can help here.
 
 ## Threat 7 - Attacker sniffs traffic on the container network
 An attacker who has access to the container network is able to sniff traffic

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -131,7 +131,7 @@ from the admission controller configuration.
 RBAC rights are strictly controlled
 
 **To do**
-Most of the RBAC is not Kubewarden responsability. But still Kubewarden can:
+Most of the RBAC is out of scope with respect to this decision. However, the Kubewarden team aims to:
 - Warning users in our docs and *suggest* some minimum RBAC to be used.
 - Provide a policy which detects RBAC changes and **maybe** block them.
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -65,7 +65,11 @@ An attacker gains access to valid client credentials for the admission controlle
 **Mitigation**
 Webhook fails closed.
 
-Kubewarden is failed closed. Thus, we should be fine.
+Kubewarden is failed closed. Thus, we should be fine. 
+
+(Failing closed means that if, for any reason, Kubewarden stops responding or
+crashes, the API server will reject the request by default, even if the request
+would be accepted by Kubewarden in normal situations)
 
 ## Threat  6 - Attacker gains access to a cluster admin credential
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -219,6 +219,7 @@ the Helm charts payload.
 
 ** Mitigation **
 1. Kubewarden provides a Software Bill Of Materials, which lists all images needed. This aids with Zero-Trust.
-  The Kubernetes Administrator must verify the Kubewarden images (and its dependencies' images and charts) out of the Kubernetes cluster, in a trusted environment. This can be done with `cosign`, for example.
+  The Kubernetes Administrator must verify the Kubewarden images, its dependencies' images, and charts 
+  out of the Kubernetes cluster, in a trusted environment. This can be done with `cosign`, for example.
   Incidentally, this is part of the implementation needed for air-gapped installations.
  2. Use signed Helm charts, and verified digests (instead of tags) for Kubewarden images in those Helm charts. This doesn't secure dependencies though.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -98,9 +98,10 @@ and admission controller webhook.
 Webhook mTLS authentication is used.
 
 **To do**
-Kubewarden should implement mutual TLS authentication
-Additionally, within the recommended policies section in the `kubewarden-defaults` Helm
-chart a policy to drop the `NET_RAW` capability could potentially be incorporated.
+Implement mutual TLS authentication.
+Additionally, it would be possible to add a policy within the recommended
+policies section in the `kubewarden-defaults` which drops the `NET_RAW`
+capability.
 
 ### Threat 9 - Attacker steals traffic from the webhook via spoofing
 An attacker is able to redirect traffic from the API server which is intended

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -172,7 +172,7 @@ all the supported API version in theirs tests and reject all of others.
 
 ## Threat ID 15 - Attacker deploys privileged container to node running  Webhook controller
 An attacker, who has rights to deploy privileged containers to the cluster, creates
-a privileged  container on the cluster node where the admission controller webhook operates.
+a privileged container on the cluster node where the admission controller webhook operates.
 
 **Mitigation**
 Admission controller uses restrictive policies to prevent privileged  workloads

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -89,7 +89,7 @@ Webhook uses TLS encryption for all traffic
 
 ## Threat 8 - Attacker carries out a MITM attack on the webhook
 An attacker on the container network, who has access to the NET_RAW capability
-can  attempt to use MITM tooling to intercept traffic between the API server
+can attempt to use MITM tooling to intercept traffic between the API server
 and admission  controller webhook.
 
 **Mitigation**

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -203,7 +203,7 @@ I don't think Kubewarden can help on this
 
 ## Threat ID 18 - Attacker uses policies to send confidential data from  admission requests to external systems
 An attacker is able to configure a policy that listens to admission requests and
-sends  sensitive data to an external system.
+sends sensitive data to an external system.
 
 **Mitigation**
 Strictly control external access for webhook

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -147,7 +147,7 @@ We  should carefully review a PR changing the rules in the policies deployment
 
 ## Threat ID 13 - Attacker exploits bad string matching on a blocklist to  bypass rules
 An attacker, who has rights to create workloads, bypasses a rule by exploiting
-bad string  matching.
+bad string matching.
 
 **Mitigation**
 All rules are reviewed and tested.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -24,8 +24,8 @@ admission controller.
 **Mitigation**
 
 Webhook fails closed. In other words, if the webhook does not respond in time,
-for any reasion, API server should reject the request. We are safe on this.
-Kubewarden default behavior  already does that.
+for any reasion, API server should reject the request.
+Kubewarden default behavior already does that.
 
 ## Threat 2 - Attacker passes workloads which require complex  processing causing timeouts
 
@@ -34,7 +34,8 @@ requests to  the admission controller which require complex processing, causing
 timeouts as the  admission controller uses compute power to process the workloads
 
 **Mitigation**
-Webhook fail closed and authenticate callers. We are safe, Kubewarden already does that.
+Webhook fail closed and authenticate callers. Kubewarden default behaviour
+already does that.
 
 ## Threat 3 - Attacker exploits misconfiguration of webhook to bypass
 An attacker, who has rights to create workloads in the cluster, is able to exploit
@@ -54,7 +55,8 @@ RBAC rights are strictly controlled.
 
 **To do**
 Most of RBAC isn't within the scope of the current discussion. 
-However, we intend to provide the below in due course for helping Kubewarden users.
+However, the following will be provided in due course for helping Kubewarden
+users:
 - Directions around minimum RBAC to be implemented.
 - Provision & documentation of a policy that detects and could potentially block RBAC changes.
 
@@ -65,7 +67,7 @@ An attacker gains access to valid client credentials for the admission controlle
 **Mitigation**
 Webhook fails closed.
 
-Kubewarden is failed closed. Thus, we should be fine. 
+Kubewarden default behaviour is failed closed. Thus, it covers this.
 
 (Failing closed means that if, for any reason, Kubewarden stops responding or
 crashes, the API server will reject the request by default, even if the request
@@ -112,7 +114,7 @@ Kubewarden should implement mutual TLS authentication
 
 ### Threat 10 - Abusing a mutation rule to create a privileged container
 An attacker is able to cause a mutating admission controller to modify a workload,
-such that it allows for privileged container creation
+such that it allows for privileged container creation.
 
 **Mitigation**
 All rules are reviewed and tested.
@@ -123,16 +125,15 @@ In addition to the above, any change of rules during policies deployment must be
 
 ## Threat 11 - Attacker deploys workloads to namespaces that are  exempt from admission control
 An attacker is able to deploy workloads to Kubernetes namespaces that are exempt
-from the  admission controller configuration.
+from the admission controller configuration.
 
 **Mitigation**
 RBAC rights are strictly controlled
 
 **To do**
-I think most of the RBAC is not Kubewarden responsability. But we can help our users if we:
-- Warning them in our docs and *suggest* some minimum RBAC to be used.
-- Provide a policy which detect RBAC changes and **maybe** block them. Is this possible?
-
+Most of the RBAC is not Kubewarden responsability. But still Kubewarden can:
+- Warning users in our docs and *suggest* some minimum RBAC to be used.
+- Provide a policy which detects RBAC changes and **maybe** block them.
 
 ## Threat ID 12 - Block rule can be bypassed due to missing match (e.g.  missing initcontainers)
 An attacker created a workload manifest which uses a feature of the Kubernetes
@@ -142,8 +143,8 @@ API which is not covered by the admission controller
 All rules are reviewed and tested.
 
 **To do**
-We may came up with some tests to cover this rules reviews
-We  should carefully review a PR changing the rules in the policies deployment
+Introduce tests to cover this rule.
+As always, carefully review PRs changing the rules in the policies deployment.
 
 ## Threat ID 13 - Attacker exploits bad string matching on a blocklist to  bypass rules
 An attacker, who has rights to create workloads, bypasses a rule by exploiting
@@ -153,8 +154,8 @@ bad string matching.
 All rules are reviewed and tested.
 
 **To do**
-We may came up with some tests to cover this rules reviews
-We  should carefully review a PR changing the rules in the policies deployment
+Introduce tests to cover this rule.
+As always, carefully review PRs changing the rules in the policies deployment.
 
 ## Threat ID 14 - Attacker uses new/old features of the Kubernetes API  which have no rules
 An attacker, with rights to create workloads, uses new features of the Kubernetes
@@ -164,10 +165,10 @@ API (for  example a changed API version) to bypass a rule.
 All rules are reviewed and tested.
 
 **To do**
-We may came up with some tests to cover this rules reviews and API versions.
-We can create a configuration to reject by default requests where the API
-version not cover by the policy.  We should warning policies developers to cover
-all the supported API version in theirs tests and reject all of others.
+Introduce tests to cover this rule.
+Create a configuration to reject by default requests where the API version not
+cover by the policy. Kubewarden should warn policy developers to cover all the
+supported API version in theirs tests and reject all of others.
 
 
 ## Threat ID 15 - Attacker deploys privileged container to node running  Webhook controller
@@ -175,11 +176,7 @@ An attacker, who has rights to deploy privileged containers to the cluster, crea
 a privileged container on the cluster node where the admission controller webhook operates.
 
 **Mitigation**
-Admission controller uses restrictive policies to prevent privileged  workloads
-
-**To do**
-I do not know if Kuberwarden can help on this. Kubewarden does not have access to
-containers running in the cluster node.
+Admission controller uses restrictive policies to prevent privileged workloads.
 
 
 ## Threat ID 16 - Attacker mounts a privileged node hostpath allowing  modification of Webhook controller configuration
@@ -190,7 +187,7 @@ volume that allows for access to the admission controller pod’s files.
 Admission controller uses restrictive policies to prevent privileged  workloads
 
 **To do**
-We can add a recommended policy in the `kubewarden-default` Helm chart to prevent this.
+Add a recommended policy in the `kubewarden-default` Helm chart to prevent this.
 
 
 ## Threat ID 17 - Attacker has privileged SSH access to cluster node  running admission webhook
@@ -198,9 +195,6 @@ An attacker is able to log into cluster nodes as a privileged user via SSH.
 
 **Mitigation**
 N/A
-
-I don't think Kubewarden can help on this
-
 
 ## Threat ID 18 - Attacker uses policies to send confidential data from  admission requests to external systems
 An attacker is able to configure a policy that listens to admission requests and

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -222,4 +222,5 @@ the Helm charts payload.
   The Kubernetes Administrator must verify the Kubewarden images, its dependencies' images, and charts 
   out of the Kubernetes cluster, in a trusted environment. This can be done with `cosign`, for example.
   Incidentally, this is part of the implementation needed for air-gapped installations.
- 2. Use signed Helm charts, and verified digests (instead of tags) for Kubewarden images in those Helm charts. This doesn't secure dependencies though.
+ 2. Use signed Helm charts, and verified digests instead of tags for Kubewarden images in those Helm charts. 
+ This doesn't secure dependencies though.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -55,7 +55,7 @@ RBAC rights are strictly controlled.
 **To do**
 Most of RBAC isn't within the scope of the current discussion. 
 However, we intend to provide the below in due course for helping Kubewarden users.
-- Warning them in our docs and *suggest* some minimum RBAC to be used.
+- Directions around minimum RBAC to be implemented.
 - Provide a policy which detect RBAC changes and **maybe** block them.
 
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -208,7 +208,7 @@ Kubewarden policies run in a restrictive environment. They do not have network a
 
 ## Threat Kubewarden ID 1 - Bootstrapping of trust for admission controller
 Assuming a trusted but fresh Kubernetes cluster, an attacker is able to compromise the Kubewarden stack 
-before any of the policies securing it are deployed and enforced.  For example, by using unsigned and 
+before any of the policies securing it are deployed and enforced. For example, by using unsigned and 
 malicious images for kubewarden-controller, policy-server, or any of the Kubewarden dependencies 
 (cert-manager) or optional dependencies (grafana, prometheus, etc.), or by compromising 
 the Helm charts payload.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -87,7 +87,6 @@ between the API  server and the admission controller webhook.
 Webhook uses TLS encryption for all traffic
 
 
-
 ## Threat 8 - Attacker carries out a MITM attack on the webhook
 An attacker on the container network, who has access to the NET_RAW capability
 can  attempt to use MITM tooling to intercept traffic between the API server

--- a/docs/security/verifying-kubewarden.md
+++ b/docs/security/verifying-kubewarden.md
@@ -40,7 +40,7 @@ The following checks were performed on each of these signatures:
   <snipped json>
 ```
 
-You can then verify either manually or with Sigstore tools that the cert in the
+You may either verify manually or with Sigstore tools that the cert in the
 returned json contains the correct issuer, subject, and
 `github_workflow_repository` extensions.
 

--- a/docs/security/verifying-kubewarden.md
+++ b/docs/security/verifying-kubewarden.md
@@ -85,7 +85,7 @@ returned json contains the correct issuer, subject, and
 `github_workflow_repository` extensions.
 
 
-## kubectl
+## kwctl
 
 kwctl binaries are signed using [Sigstore's blog signing](https://docs.sigstore.dev/cosign/working_with_blobs/#signing-blobs-as-files). 
 

--- a/docs/security/verifying-kubewarden.md
+++ b/docs/security/verifying-kubewarden.md
@@ -1,0 +1,111 @@
+---
+sidebar_label: "Verifying Kubewarden"
+title: ""
+---
+
+# Verifying Kubewarden
+
+Kubewarden artifacts are signed using [Sigstore](https://docs.sigstore.dev),
+with the keyless workflow. This means that the signing certificate contains the
+following info, where `*` matches any following characters:
+- issuer: `https://token.actions.githubusercontent.com`
+- subject: `https://github.com/kubewarden/*`
+- x509 certificate extension for GHA, "github_workflow_repository": `kubewarden/*`
+
+## Helm charts
+
+You can find our Helm charts in our `https://` traditional Helm repository under
+https://charts.kubewarden.io.
+
+The same Helm charts are signed via Sigstore's keyless signing, and pushed to an
+OCI repository that can hold both the Helm chart and its signature as OCI
+artifacts.
+
+Since Helm 3.8.0, Helm has support for OCI registries, but because of
+constraints in them, they can't be searched via `helm`. You can find the
+[list of charts in GitHub Container Registry](https://github.com/orgs/kubewarden/packages?tab=packages&q=charts).
+
+To verify a Helm chart, you need `cosign` installed. Then execute the following
+command, for example:
+
+```
+COSIGN_EXPERIMENTAL=1 cosign verify ghrc.io/kubewarden/charts/kubewarden-controller:0.4.6 | jq
+
+Verification for ghcr.io/kubewarden/charts/kubewarden-controller:0.4.6 --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - Any certificates were verified against the Fulcio roots.
+
+  <snipped json>
+```
+
+You can then verify either manually or with Sigstore tools that the cert in the
+returned json contains the correct issuer, subject, and
+`github_workflow_repository` extensions.
+
+## Container images
+
+Both our production images used in our Helm charts and our development images
+(tagged `:latest`) are signed with Sigstore's keyless signing.
+
+Kubewarden follows the usual practices with regards to Helm charts. Hence, one
+can find all the images in the Helm charts with a plugin such as
+[helm-image](https://github.com/cvila84/helm-image), or with the following script:
+
+```bash
+#!/usr/bin/env bash
+helm pull --untar kubewarden/kubewarden-controller && \
+helm pull --untar kubewarden/kubewarden-defaults && \
+{ helm template ./kubewarden-controller; helm template ./kubewarden-defaults } \
+    | yq '..|.image? | select(.)' \
+    | sort -u | sed 's/"//g'
+```
+
+which gives us:
+```
+ghcr.io/kubewarden/kubewarden-controller:v0.5.5
+ghcr.io/kubewarden/policy-server:v0.3.1
+ghcr.io/kubewarden/kubectl:v1.21.4
+```
+
+Now, for each image in that list you can verify their Sigstore signatures. E.g:
+```
+COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/kubewarden/policy-server:v0.3.1 | jq
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - Any certificates were verified against the Fulcio roots.
+
+  <snipped json>
+```
+
+You can then verify either manually or with Sigstore tools that the cert in the
+returned json contains the correct issuer, subject, and
+`github_workflow_repository` extensions.
+
+
+## kubectl
+
+kwctl binaries are signed using [Sigstore's blog signing](https://docs.sigstore.dev/cosign/working_with_blobs/#signing-blobs-as-files). 
+
+When you download a [kwctl
+release](https://github.com/kubewarden/kwctl/releases/) each zip file contains
+two files that can be used for verification: `kwctl.sig` and `kwctl.pem`.
+
+In order to verify kwctl you need cosign installed, and then execute the
+following command:
+
+```
+COSIGN_EXPERIMENTAL=1 cosign verify-blob  --signature kwctl-linux-x86_64.sig --cert kwctl-linux-x86_64.pem kwctl-linux-x86_64
+```
+
+The output should be:
+
+```
+tlog entry verified with uuid: 7e5a4fac8f45cdddeafd6901af566b9576be307a06caa3fbc45f91da102214e0 index: 2435066
+Verified OK
+```
+
+You can inspect the cert signature yourself to see that indeed was authenticated
+via GitHub OIDC, and performed in our GitHub Actions workflows.

--- a/docs/security/verifying-kubewarden.md
+++ b/docs/security/verifying-kubewarden.md
@@ -46,7 +46,7 @@ returned json contains the correct issuer, subject, and
 
 ## Container images
 
-Both our production images used in our Helm charts and our development images
+Both the production images used in our Helm charts and our development images
 (tagged `:latest`) are signed with Sigstore's keyless signing.
 
 Kubewarden follows the usual practices with regards to Helm charts. Hence, one

--- a/sidebars.js
+++ b/sidebars.js
@@ -165,5 +165,15 @@ module.exports = {
         },
       ],
     },
+    {
+      type: 'category',
+      label: 'Security',
+      link: {type: 'doc', id: 'security/intro'},
+      items:[
+        'security/threat-model',
+        'security/verifying-kubewarden',
+        `security/disclosure`
+      ],
+    },
   ],
 };


### PR DESCRIPTION
## Description

This adds a new "Security" section, containing:

- Threat model: straight from the RFC.
- Verifying Kubewarden: info on how to verify Helm charts, containers, kwctl.
- Disclosure: info on how to disclose security vulns to us.

## Rendered (on GH, not Docusaurus)

https://github.com/viccuad/docs/blob/add-security/docs/security/threat-model.md
https://github.com/viccuad/docs/blob/add-security/docs/security/verifying-kubewarden.md
https://github.com/viccuad/docs/blob/add-security/docs/security/disclosure.md


## Test

Tested locally with `yarn start`.