### PR TITLE
Make use of docusaurus admonitions

### DIFF
--- a/docs/distributing-policies/oci-registries-support.md
+++ b/docs/distributing-policies/oci-registries-support.md
@@ -5,9 +5,11 @@ title: ""
 
 # OCI Registries support
 
-> **Note well**: this is not an exhaustive list. If a registry you know or use is working correctly
-> with Kubewarden, or if any information described here is not accurate at this time, please open a
-> [Pull Request against this documentation](https://github.com/kubewarden/docs) to fix it.
+:::note
+This is not an exhaustive list. If a registry you know or use is working correctly
+with Kubewarden, or if any information described here is not accurate at this time, please open a
+[Pull Request against this documentation](https://github.com/kubewarden/docs) to fix it.
+:::
 
 Kubewarden policies are distributed as [OCI Artifacts](https://github.com/opencontainers/artifacts)
 using regular OCI Registries.

--- a/docs/operator-manual/telemetry/metrics/01-quickstart.md
+++ b/docs/operator-manual/telemetry/metrics/01-quickstart.md
@@ -7,9 +7,11 @@ title: ""
 
 This section describes how to enable metrics reporting on the Policy Server.
 
-> **Note well**: before continuing, make sure you completed the previous
-> [OpenTelemetry](../opentelemetry/01-quickstart.md#install-opentelemetry) section of this book. It
-> is required for this section to work correctly.
+:::note
+Before continuing, make sure you completed the previous
+[OpenTelemetry](../opentelemetry/01-quickstart.md#install-opentelemetry) section of this book. It
+is required for this section to work correctly.
+:::
 
 We are going to use [Prometheus](https://prometheus.io/) to scrape metrics exposed by the Policy
 Server.
@@ -69,8 +71,10 @@ helm install --wait --create-namespace --namespace prometheus --values kube-prom
 
 We can now install Kubewarden in the recommended way with the Helm chart.
 
-> **Note well:** cert-manager is a requirement of Kubewarden, and OpenTelemetry is required for this
-> feature, but we've already installed them in a previous section of this book.
+:::note
+cert-manager is a requirement of Kubewarden, and OpenTelemetry is required for this
+feature, but we've already installed them in a previous section of this book.
+:::
 
 As a first step, we have to add the Helm repository that contains Kubewarden:
 

--- a/docs/operator-manual/telemetry/metrics/02-reference.md
+++ b/docs/operator-manual/telemetry/metrics/02-reference.md
@@ -16,8 +16,10 @@ provided by the policy to the Kubernetes API server.
 
 ### Metrics
 
-> **Note**: Baggage are key-value attributes added to the metric. They are used to enrich the metric
-> with additional information.
+:::note
+Baggage are key-value attributes added to the metric. They are used to enrich the metric
+with additional information.
+:::
 
 Name | Type | |
 --- | --- | ---

--- a/docs/operator-manual/telemetry/tracing/01-quickstart.md
+++ b/docs/operator-manual/telemetry/tracing/01-quickstart.md
@@ -8,9 +8,11 @@ title: ""
 This section illustrates how to enable tracing support of
 Policy Server.
 
-> **Note well**: before continuing, make sure you completed the previous
-> [OpenTelemetry](../opentelemetry/01-quickstart.md#install-opentelemetry) section of this book. It
-> is required for this section to work correctly.
+:::note
+Before continuing, make sure you completed the previous
+[OpenTelemetry](../opentelemetry/01-quickstart.md#install-opentelemetry) section of this book. It
+is required for this section to work correctly.
+:::
 
 Tracing allows to collect fine grained details about policy evaluations. It can
 be a useful tool for debugging issues inside of your Kubewarden deployment and policies.
@@ -64,8 +66,10 @@ Given this is a testing environment, we will use default
 strategy. As stated on the upstream documentation: this deployment strategy is
 meant to be used only for development, testing and demo purposes.
 
-> **Note well:** the operator can deploy Jaeger in many different ways. We strongly recommend
-> to read its [official documentation](https://www.jaegertracing.io/docs/1.26/operator/).
+:::note
+The operator can deploy Jaeger in many different ways. We strongly recommend
+to read its [official documentation](https://www.jaegertracing.io/docs/1.26/operator/).
+:::
 
 Let's create a Jaeger resource:
 
@@ -95,8 +99,10 @@ echo http://`minikube ip`
 
 We can proceed to the deployment of Kubewarden in the usual way.
 
-> **Note well:** cert-manager is a requirement of Kubewarden, and OpenTelemetry is required for this
-> feature, but we've already installed them in a previous section of this book.
+:::note
+cert-manager is a requirement of Kubewarden, and OpenTelemetry is required for this
+feature, but we've already installed them in a previous section of this book.
+:::
 
 As a first step, we have to add the Helm repository that contains Kubewarden:
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -324,4 +324,4 @@ kubectl delete -l "kubewarden" mutatingwebhookconfigurations.admissionregistrati
 
 As we have seen, `ClusterAdmissionPolicy` is the core resource that a cluster operator has to manage. The `kubewarden-controller` module automatically takes care of the configuration for the rest of the resources needed to run the policies.
 
-Now, you are ready to deploy Kubewarden! Have a look at the policies on [hub.kubewarden.io](https://hub.kubewarden.io), [on GitHub](https://github.com/topics/kubewarden-policy), or reuse existing Rego policies as shown in the [following chapters!](./writing-policies/rego/01-intro-rego.md)
+Now, you are ready to deploy Kubewarden! Have a look at the policies on [hub.kubewarden.io](https://hub.kubewarden.io), on [GitHub](https://github.com/topics/kubewarden-policy), or reuse existing Rego policies as shown in the [following chapters!](./writing-policies/rego/01-intro-rego.md)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -13,18 +13,18 @@ The Kubewarden stack is made of the following components:
 
 ## Installation
 
-> **PREREQUISITES:**
->
-> Currently, the chart depends on `cert-manager`. Make sure you have [`cert-manager` installed](https://cert-manager.io/docs/installation/) *before* installing the `kubewarden-controller` chart.
->
-> You can install the latest version of `cert-manager` by running the following commands:
->
+:::info PREREQUISITES
+Currently, the chart depends on `cert-manager`. Make sure you have [`cert-manager`](https://cert-manager.io/docs/installation/) installed *before* installing the `kubewarden-controller` chart.
+
+You can install the latest version of `cert-manager` by running the following commands:
+
 ```console
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
 ```
 ```console
 kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
 ```
+:::
 
 The Kubewarden stack can be deployed using `helm` charts as follows:
 
@@ -48,21 +48,20 @@ The following charts should be installed inside the `kubewarden` namespace in yo
 recommended policies to secure your cluster by enforcing some well known best practices.
 
 
-> **WARNING:**
-> Since [`v0.4.0`](https://github.com/kubewarden/kubewarden-controller/releases/tag/v0.4.0), a PolicyServer resource named default will not be created using the `kubewarden-controller` chart.
-> There is another Helm chart called `kubewarden-defaults`, which now installs
-> the default policy server.
->
-> This also means that if you are not using the latest version of the `kubewarden-controller` and are trying to upgrade,
-> your default policy server will not be upgraded or deleted. As a result, you might run into
-> issues if you try to install the `kubewarden-defaults` with some conflicting information, for example the same policy server name.
-> Therefore, to be able to take advantage of future upgrades in the `kubewarden-defaults` helm chart you need to remove the
-> existing PolicyServer resource created by the `kubewarden-controller` before installing the new chart. With this step, you ensure that you are able to update your policy server using Helm upgrades without running into
-> resource conflicts. It worth mentioning that when you remove the PolicyServer, all the policies bounded to it will be removed as well.
+:::caution
+Since [`v0.4.0`](https://github.com/kubewarden/kubewarden-controller/releases/tag/v0.4.0), a PolicyServer resource named default will not be created using the `kubewarden-controller` chart.
+There is another Helm chart called `kubewarden-defaults`, which now installs
+the default policy server.
 
-> **QUICK NOTE:**
->
-> The default configuration values should be good enough for the majority of deployments. All options are documented [here](https://charts.kubewarden.io/#configuration).
+This also means that if you are not using the latest version of the `kubewarden-controller` and are trying to upgrade,
+your default policy server will not be upgraded or deleted. As a result, you might run into
+issues if you try to install the `kubewarden-defaults` with some conflicting information, for example the same policy server name.
+Therefore, to be able to take advantage of future upgrades in the `kubewarden-defaults` helm chart you need to remove the
+existing PolicyServer resource created by the `kubewarden-controller` before installing the new chart. With this step, you ensure that you are able to update your policy server using Helm upgrades without running into
+resource conflicts. It worth mentioning that when you remove the PolicyServer, all the policies bounded to it will be removed as well.
+:::
+
+The default configuration values should be good enough for the majority of deployments. All options are documented [here](https://charts.kubewarden.io/#configuration).
 
 ## Main components
 
@@ -93,7 +92,9 @@ spec:
     value: debug
 ```
 
-> **NOTE:** Check the [latest released PolicyServer version](https://github.com/kubewarden/policy-server/pkgs/container/policy-server) and change the tag accordantly.
+:::note
+Check the [latest released PolicyServer version](https://github.com/kubewarden/policy-server/pkgs/container/policy-server) and change the tag accordantly.
+:::
 
 Overview of the attributes of the `PolicyServer` resource:
 
@@ -155,12 +156,17 @@ Overview of the attributes of the `ClusterAdmissionPolicy` resource:
 | | | - `Ignore`: an error calling the webhook is ignored and the API request is allowed to continue |
 | | | - `Fail`: an error calling the webhook causes the admission to fail and the API request to be rejected |
 
-> **NOTE:** The  `ClusterAdmissionPolicy` resources are registered with a `*` webhook `scope`, which means that registered webhooks will forward all requests matching the given `resources` and `operations` -- either namespaced (in any namespace), or cluster-wide resources.
+:::note
+The  `ClusterAdmissionPolicy` resources are registered with a `*` webhook `scope`, which means that registered webhooks will forward all requests matching the given `resources` and `operations` -- either namespaced (in any namespace), or cluster-wide resources.
+:::
 
 ### AdmissionPolicy
 
 `AdmissionPolicy` is a namespace-wide resource. The policy will process only the requests that are targeting the Namespace where the `AdmissionPolicy` is defined. Other than that, there are no functional differences between the `AdmissionPolicy` and `ClusterAdmissionPolicy` resources.
-> **NOTE:**  `AdmissionPolicy` requires kubernetes 1.21.0 or above. This is because we are using the `kubernetes.io/metadata.name` label, which was introduced in kubernetes 1.21.0
+
+:::info
+`AdmissionPolicy` requires Kubernetes 1.21.0 or above. This is because we are using the `kubernetes.io/metadata.name` label, which was introduced in Kubernetes 1.21.0
+:::
 
 The complete documentation of these Custom Resources can be found [here](https://github.com/kubewarden/kubewarden-controller/blob/main/docs/crds/README.asciidoc) or on [docs.crds.dev](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller).
 
@@ -271,7 +277,9 @@ The creation of the Pod has been denied by the policy and you should see the fol
 Error from server: error when creating "STDIN": admission webhook "privileged-pods.kubewarden.admission" denied the request: User 'minikube-user' cannot schedule privileged containers
 ```
 
-> **NOTE:** both examples didn't define a `namespace`, which means the `default` namespace was the target. However, as you could see in the second example, the policy is still applied. As stated above, this is due to the scope being cluster-wide and not targeting a specific namespace.
+:::note
+Both examples didn't define a `namespace`, which means the `default` namespace was the target. However, as you could see in the second example, the policy is still applied. As stated above, this is due to the scope being cluster-wide and not targeting a specific namespace.
+:::
 
 ## Uninstall
 
@@ -291,8 +299,10 @@ Once the `helm` charts have been uninstalled, you can remove the Kubernetes name
 kubectl delete namespace kubewarden
 ```
 
-> **Note:** kubewarden contains a helm pre-delete hook that will remove all `PolicyServers` and `kubewarden-controller`.
-> Then the `kubewarden-controller` will delete all resources, so it is important that `kubewarden-controller` is running when helm uninstall is executed.
+:::caution
+Kubewarden contains a helm pre-delete hook that will remove all `PolicyServers` and `kubewarden-controller`.
+Then the `kubewarden-controller` will delete all resources, so it is important that `kubewarden-controller` is running when helm uninstall is executed.
+:::
 
 `ValidatingWebhookConfigurations` and `MutatingWebhookConfigurations` created by kubewarden should be deleted, this can be checked with:
 
@@ -314,4 +324,4 @@ kubectl delete -l "kubewarden" mutatingwebhookconfigurations.admissionregistrati
 
 As we have seen, `ClusterAdmissionPolicy` is the core resource that a cluster operator has to manage. The `kubewarden-controller` module automatically takes care of the configuration for the rest of the resources needed to run the policies.
 
-Now, you are ready to deploy Kubewarden! Have a look at the policies on [hub.kubewarden.io](https://hub.kubewarden.io), [on Github](https://github.com/topics/kubewarden-policy), or reuse existing Rego policies as shown in the [following chapters!](./writing-policies/rego/01-intro-rego.md)
+Now, you are ready to deploy Kubewarden! Have a look at the policies on [hub.kubewarden.io](https://hub.kubewarden.io), [on GitHub](https://github.com/topics/kubewarden-policy), or reuse existing Rego policies as shown in the [following chapters!](./writing-policies/rego/01-intro-rego.md)

--- a/docs/writing-policies/rego/01-intro-rego.md
+++ b/docs/writing-policies/rego/01-intro-rego.md
@@ -5,9 +5,12 @@ title: ""
 
 # Rego
 
-> **Note well:** Rego support has been introduced starting from these releases:
-> * kwctl: v0.2.0
-> * policy-server: v0.2.0
+:::note
+Rego support has been introduced starting from these releases:
+  
+  * kwctl: v0.2.0
+  * policy-server: v0.2.0
+:::
 
 
 The Rego language is a tailor made language designed to embrace

--- a/docs/writing-policies/rego/gatekeeper/01-intro.md
+++ b/docs/writing-policies/rego/gatekeeper/01-intro.md
@@ -5,9 +5,12 @@ title: ""
 
 # Gatekeeper
 
-> **Note well:** Gatekeeper support has been introduced starting from these releases:
-> * kwctl: v0.2.0
-> * policy-server: v0.2.0
+:::note
+Gatekeeper support has been introduced starting from these releases:
+
+  * kwctl: v0.2.0
+  * policy-server: v0.2.0
+:::
 
 Gatekeeper is a project targeting Kubernetes, and as such, has some
 features that are thought out of the box for being integrated with it.
@@ -17,9 +20,11 @@ features that are thought out of the box for being integrated with it.
 All the existing Gatekeeper policies should be compatible with
 Kubewarden as we will explain during this chapter.
 
-> **Note**: if this is not the case, please report it to us and we
-> will do our best to make sure your policy runs flawlessly with
-> Kubewarden.
+:::info
+If this is not the case, please report it to us and we
+will do our best to make sure your policy runs flawlessly with
+Kubewarden.
+:::
 
 Policies have to be compiled with the `opa` CLI to the `wasm` target.
 

--- a/docs/writing-policies/rego/gatekeeper/02-create-policy.md
+++ b/docs/writing-policies/rego/gatekeeper/02-create-policy.md
@@ -9,10 +9,12 @@ Let's implement the same policy that [we wrote with Open Policy
 Agent](../open-policy-agent/02-create-policy.md): a policy that
 rejects a resource if it's targeting the `default` namespace.
 
-> **Note well:** we also provide a GitHub repository template
-> that you can use to quickly port an existing policy.
->
-> Check it out: [kubewarden/gatekeeper-policy-template](https://github.com/kubewarden/gatekeeper-policy-template)
+:::note
+We also provide a GitHub repository template
+that you can use to quickly port an existing policy.
+
+Check it out: [kubewarden/gatekeeper-policy-template](https://github.com/kubewarden/gatekeeper-policy-template)
+:::
 
 ## Requirements
 

--- a/docs/writing-policies/rego/open-policy-agent/01-intro.md
+++ b/docs/writing-policies/rego/open-policy-agent/01-intro.md
@@ -5,9 +5,11 @@ title: ""
 
 # Open Policy Agent
 
-> **Note well:** Open Policy Agent support has been introduced starting from these releases:
-> * kwctl: v0.2.0
-> * policy-server: v0.2.0
+:::note
+Open Policy Agent support has been introduced starting from these releases:
+  * kwctl: v0.2.0
+  * policy-server: v0.2.0
+:::
 
 Open Policy Agent is a general purpose policy framework that uses the
 Rego language to write policies.

--- a/docs/writing-policies/rego/open-policy-agent/02-create-policy.md
+++ b/docs/writing-policies/rego/open-policy-agent/02-create-policy.md
@@ -8,10 +8,12 @@ title: ""
 Let's create a sample policy that will help us go through some
 important concepts. Let's start!
 
-> **Note well:** we also provide a GitHub repository template
-> that you can use to quickly port an existing policy.
->
-> Check it out: [kubewarden/opa-policy-template](https://github.com/kubewarden/opa-policy-template)
+:::note
+We also provide a GitHub repository template
+that you can use to quickly port an existing policy.
+
+Check it out: [kubewarden/opa-policy-template](https://github.com/kubewarden/opa-policy-template)
+:::
 
 ## Requirements
 

--- a/docs/writing-policies/spec/01-intro-spec.md
+++ b/docs/writing-policies/spec/01-intro-spec.md
@@ -10,6 +10,8 @@ defined API.  The purpose of this section is to document the API used
 by the host ( be it `policy-server` or `kwctl`) to communicate with
 Kubewarden's policies.
 
-> **Note well:** this section of the documentation is a bit low level, you can
-> jump straight to one of the "language focused" chapters and come back to this
-> chapter later.
+:::note
+This section of the documentation is a bit low level, you can
+jump straight to one of the "language focused" chapters and come back to this
+chapter later.
+:::

--- a/docs/writing-policies/spec/02-settings.md
+++ b/docs/writing-policies/spec/02-settings.md
@@ -38,10 +38,12 @@ The structure of the `SettingsValidationResponse` object is the following one:
 If the user provided settings are `valid`, the contents of `message` are ignored.
 Otherwise the contents of `message` are shown to the user.
 
-> **Note well:** Kubewarden's [policy-server](https://github.com/chimera-kube/policy-server)
-> validates all the policy settings provided by users at start time.
-> The policy-server exits immediately with an error if at least one of its
-> policies received wrong configuration parameters.
+:::note
+Kubewarden's [policy-server](https://github.com/chimera-kube/policy-server)
+validates all the policy settings provided by users at start time.
+The policy-server exits immediately with an error if at least one of its
+policies received wrong configuration parameters.
+:::
 
 ## Example
 

--- a/docs/writing-policies/spec/04-mutating-policies.md
+++ b/docs/writing-policies/spec/04-mutating-policies.md
@@ -56,7 +56,9 @@ Let's assume the policy received this `ValidationRequest`:
 }
 ```
 
-> **Note:** we left some irrelevant fields out of the `request` object.
+:::note
+We left some irrelevant fields out of the `request` object.
+:::
 
 This request is generated because someone tried to create a Pod that would
 look like this:

--- a/docs/writing-policies/swift.md
+++ b/docs/writing-policies/swift.md
@@ -18,8 +18,10 @@ The Swiftwasm team is also working to upstream all these changes into the
 Swift project. In the meantime the toolchain provided by the Swiftwasm project
 can be used to build Kubewarden policies.
 
-**Note well:** you don't need an Apple system to write or run Swift code. Everything
+:::note
+You don't need an Apple system to write or run Swift code. Everything
 can be done also on a Linux machine or on Windows (by using Docker for Windows).
+:::
 
 ## Current State
 


### PR DESCRIPTION
Make use of [docusaurus admonitions](https://docusaurus.io/docs/markdown-features/admonitions) to give nuances to the docs.

The biggest changes have been done to the quickstart page, which now looks like that

![image](https://user-images.githubusercontent.com/22728/173542579-659b56aa-7a6b-427a-917b-d643c6718f05.png)
