### PR TITLE
Remove admonition about development stage.

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -6,11 +6,6 @@ title: ""
 
 # Introduction
 
-> **NOTE:** Kubewarden is still in development and not yet fully production ready.
->
-> However, we encourage you to give Kubewarden a try.
-> Feedback is highly appreciated.
-
 Kubewarden is a [Kubernetes Dynamic Admission
 Controller](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
 that validates incoming requests using policies written in


### PR DESCRIPTION
Removes admonition in the introduction page telling users that Kubewarden is in development. The project already released v1.0.0. Therefore, this sentence does not make sense.