### PR TITLE
Docs about how to use private registry.

### DIFF
--- a/docs/operator-manual/policy-servers/02-private-registry.md
+++ b/docs/operator-manual/policy-servers/02-private-registry.md
@@ -7,13 +7,13 @@ title: ""
 
 It is not uncommon that enterprises using cloud native environments have their
 own container registries to store their container images and other artefacts
-used to run their applications. As these artefacts are, most of the time, private
-it does not make sense to let their be public available in the web or even for
-some parts of the same organization. In this scenarios is common the
-use of private registries requiring authentication to access the resources stored
-on them. In that in mind, it possible to specify and configure the credentials
-used to authenticate into a private registry where your policies are stored.
-Allowing Kubewarden Policy Server to download policies from public and private
+used to run their applications. As these artifacts are, most of the time, private,
+it does not make sense to let them be publicly available on the web or even to
+other teams within the same organization. In these scenarios, it is common to
+use private registries that require authentication to access the resources stored
+In them. With this in mind, we have made it possible to specify and configure the credentials
+used to authenticate into a private registry where your policies are stored and
+allowing Kubewarden Policy Server to download policies from public and private
 registries.
 
 

--- a/docs/operator-manual/policy-servers/02-private-registry.md
+++ b/docs/operator-manual/policy-servers/02-private-registry.md
@@ -1,0 +1,56 @@
+---
+sidebar_label: "Using private registry"
+title: ""
+---
+
+# Configuring Policy Servers to use private registry
+
+It is possible to specify and configure the credentials used to authenticate
+into a private registry where your policies are stored.
+
+
+Before configure your Policy Server instance, you need to store the credentials
+used to access the registry in a `docker-registry` secret. The secret should be
+created in the same namespace where you run your Policy Server. This can be done
+with the following command:
+
+```shell
+kubectl --namespace kubewarden create secret docker-registry secret-ghcr-docker \
+  --docker-username=myuser \
+  --docker-password=mypass123 \
+  --docker-server=myregistry.io
+```
+
+If you want more information about how to create the secret. Please, go to the
+[Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets).
+
+Once you have the secret created, it is necessary to configure the Policy Server
+instance setting the `imagePullSecret` field with the name of the secret created with the
+credentials:
+
+```yaml
+# Example of a policy server using private registry
+apiVersion: policies.kubewarden.io/v1
+kind: PolicyServer
+metadata:
+  name: default
+spec:
+  image: ghcr.io/kubewarden/policy-server:v1.1.1
+  serviceAccountName: policy-server
+  replicas: 1
+  annotations:
+  imagePullSecret: "secret-ghcr-docker"
+```
+
+When deployed from the `kubewarden-defaults` Helm chart you can configure the
+`policyServer.imagePullSecret` field in the values file with the secret name. Thus,
+the policy server created will be able to download policies from your private
+registry as well:
+
+```yaml
+# values file example
+policyServer:
+  telemetry:
+    enabled: False
+  imagePullSecret: secret-ghcr-docker
+```

--- a/docs/operator-manual/policy-servers/02-private-registry.md
+++ b/docs/operator-manual/policy-servers/02-private-registry.md
@@ -5,11 +5,19 @@ title: ""
 
 # Configuring Policy Servers to use private registry
 
-It is possible to specify and configure the credentials used to authenticate
-into a private registry where your policies are stored.
+It is not uncommon that enterprises using cloud native environments have their
+own container registries to store their container images and other artefacts
+used to run their applications. As these artefacts are, most of the time, private
+it does not make sense to let their be public available in the web or even for
+some parts of the same organization. In this scenarios is common the
+use of private registries requiring authentication to access the resources stored
+on them. In that in mind, it possible to specify and configure the credentials
+used to authenticate into a private registry where your policies are stored.
+Allowing Kubewarden Policy Server to download policies from public and private
+registries.
 
 
-Before configure your Policy Server instance, you need to store the credentials
+Before configuring your Policy Server instance, you need to store the credentials
 used to access the registry in a `docker-registry` secret. The secret should be
 created in the same namespace where you run your Policy Server. This can be done
 with the following command:
@@ -25,7 +33,7 @@ If you want more information about how to create the secret. Please, go to the
 [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets).
 
 Once you have the secret created, it is necessary to configure the Policy Server
-instance setting the `imagePullSecret` field with the name of the secret created with the
+instance by setting the `imagePullSecret` field with the name of the secret created with the
 credentials:
 
 ```yaml

--- a/sidebars.js
+++ b/sidebars.js
@@ -7,9 +7,9 @@ module.exports = {
       label: 'Common Tasks',
       items: ['tasksDir/mutating-policies', 'tasksDir/psp-migration'],
       collapsed: 'true',
-      link: 
+      link:
       {
-        type: 'doc', 
+        type: 'doc',
         id: 'tasks',
       },
     },
@@ -77,7 +77,7 @@ module.exports = {
               type: 'category',
               label: 'Rego',
               link: {type: 'doc', id: 'writing-policies/rego/intro-rego'},
-              items: 
+              items:
               [
                 { type: 'doc', id: 'writing-policies/rego/builtin-support'},
                 {
@@ -148,7 +148,7 @@ module.exports = {
       link: {type: 'doc', id: 'operator-manual/intro'},
       items:[
         {
-          'Configuring Policy Servers': ['operator-manual/policy-servers/custom-cas',],
+          'Configuring Policy Servers': ['operator-manual/policy-servers/custom-cas', 'operator-manual/policy-servers/private-registry'],
           'Quickstart Guides':
           [
             'operator-manual/telemetry/quickstart',


### PR DESCRIPTION
## Description
Adds a new doc page explaining how Policy Servers can be configured to download policies from private registries.

Fix #113 