### PR TITLE
Update the Rust instructions

### DIFF
--- a/docs/writing-policies/rust/01-intro-rust.md
+++ b/docs/writing-policies/rust/01-intro-rust.md
@@ -32,10 +32,10 @@ As a first step install the Rust compiler and its tools, this can be easily done
 using [rustup](https://github.com/rust-lang/rustup). Please follow
 [rustup's install documentation](https://rust-lang.github.io/rustup/installation/index.html).
 
-Once `rustup` is installed add the Wasm target:
+Once `rustup` is installed add the WASI target:
 
 ```shell
-rustup target add wasm32-unknown-unknown
+rustup target add wasm32-wasi
 ```
 
 ## OSX specific dependencies

--- a/docs/writing-policies/rust/07-build-and-distribute.md
+++ b/docs/writing-policies/rust/07-build-and-distribute.md
@@ -23,8 +23,8 @@ compilation target.
 The build will produce the following file:
 
 ```shell
-$ file target/wasm32-unknown-unknown/release/demo.wasm
-target/wasm32-unknown-unknown/release/demo.wasm: WebAssembly (wasm) binary module version 0x1 (MVP)
+$ file target/wasm32-wasi/release/demo.wasm
+target/wasm32-wasi/release/demo.wasm: WebAssembly (wasm) binary module version 0x1 (MVP)
 ```
 
 ## Distributing the policy


### PR DESCRIPTION
We've recently changed our rust compilation target to be `wasm32-wasi` instead of the `wasm32-unknown-unknown`.
This is required to prevent a Rust panic to happen when the policy is loaded.

For more details, see https://github.com/kubewarden/rust-policy-template/pull/25
