### PR TITLE
Install `kubewarden-defaults` chart in metrics docs

### DIFF
--- a/docs/operator-manual/telemetry/metrics/01-quickstart.md
+++ b/docs/operator-manual/telemetry/metrics/01-quickstart.md
@@ -120,7 +120,7 @@ helm install --wait \
   kubewarden-defaults kubewarden/kubewarden-defaults \
   --set recommendedPolicies.enabled=True \
   --set recommendedPolicies.defaultPolicyMode=monitor \
-  --set policyServer.Telemetry.enabled=True
+  --set policyServer.telemetry.enabled=True
 ```
 
 This leads to the creation of the `default` instance of `PolicyServer`:

--- a/docs/operator-manual/telemetry/metrics/01-quickstart.md
+++ b/docs/operator-manual/telemetry/metrics/01-quickstart.md
@@ -64,7 +64,10 @@ then take care of generating a valid configuration file for Prometheus, and relo
 automatically after updating its configuration file.
 
 ```console
-helm install --wait --create-namespace --namespace prometheus --values kube-prometheus-stack-values.yaml prometheus prometheus-community/kube-prometheus-stack
+helm install --wait --create-namespace \
+  --namespace prometheus \
+  --values kube-prometheus-stack-values.yaml \
+  prometheus prometheus-community/kube-prometheus-stack
 ```
 
 ## Install Kubewarden
@@ -103,10 +106,20 @@ policyServer:
       port: 8080
 ```
 
-Now, let's install the helm chart:
+Now, let's install the helm charts:
 
 ```console
-helm install --wait --namespace kubewarden --values kubewarden-values.yaml kubewarden-controller kubewarden/kubewarden-controller
+helm install --wait \
+  --namespace kubewarden \
+  --values kubewarden-values.yaml \
+  kubewarden-controller kubewarden/kubewarden-controller
+
+helm install --wait \
+  --namespace kubewarden \
+  --create-namespace \
+  kubewarden-defaults kubewarden/kubewarden-defaults \
+  --set recommendedPolicies.enabled=True \
+  --set recommendedPolicies.defaultPolicyMode=monitor
 ```
 
 This leads to the creation of the `default` instance of `PolicyServer`:

--- a/docs/operator-manual/telemetry/metrics/01-quickstart.md
+++ b/docs/operator-manual/telemetry/metrics/01-quickstart.md
@@ -119,7 +119,8 @@ helm install --wait \
   --create-namespace \
   kubewarden-defaults kubewarden/kubewarden-defaults \
   --set recommendedPolicies.enabled=True \
-  --set recommendedPolicies.defaultPolicyMode=monitor
+  --set recommendedPolicies.defaultPolicyMode=monitor \
+  --set policyServer.Telemetry.enabled=True
 ```
 
 This leads to the creation of the `default` instance of `PolicyServer`:


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Install `kubewarden-defaults` chart in metrics docs, or we don't have a default PolicyServer.
