### PR TITLE
feat: Add airgap docs

### DIFF
--- a/docs/operator-manual/airgap/01-install.md
+++ b/docs/operator-manual/airgap/01-install.md
@@ -14,7 +14,7 @@ You need to add Kubewarden's images and policies to this OCI registry. Let's see
 
 1. Download `kubewarden-images.txt` from the Kubewarden [release page](https://github.com/kubewarden/helm-charts/releases/). Alternatively, you can find `imagelist.txt` and `policylist.txt` files shipped inside the helm charts, that contain the used container images and policy wasm modules respectively.
 :::note
-Optionally, you can verify the signatures of the [helm charts](https://docs.kubewarden.io/security/verifying-kubewarden#helm-charts) and [container images](https://docs.kubewarden.io/security/verifying-kubewarden#container-images)
+Optionally, you can verify the signatures of the [helm charts](../../security/verifying-kubewarden#helm-charts) and [container images](../../security/verifying-kubewarden#container-images)
 :::
 2. Add `cert-manager` if it is not available in your private registry. 
 ```
@@ -83,7 +83,7 @@ The `sources.yaml` file is needed by kwctl to connect to registries that fall in
 * Self signed certificate is being used
 * No TLS termination is done
 
-Please refer to [this section](../distributing-policies/custom-certificate-authorities.md) of our documentation to learn more about how to configure the `sources.yaml` file
+Please refer to [this section](../../distributing-policies/custom-certificate-authorities.md) of our documentation to learn more about how to configure the `sources.yaml` file
 ::: 
 
 ## Install kubewarden. 
@@ -117,7 +117,7 @@ helm install --wait -n kubewarden kubewarden-controller.tgz --set common.cattle.
 helm install --wait -n kubewarden kubewarden-defaults.tgz --set common.cattle.systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT>
 ```
 
-Finally, we need to configure PolicyServers to fetch policies from our private registry. See the [using private registry](https://docs.kubewarden.io/operator-manual/policy-servers/private-registry) section of the docs.
+Finally, we need to configure PolicyServers to fetch policies from our private registry. See the [using private registry](../policy-servers/private-registry) section of the docs.
 
 Now we can create Kubewarden policies in our cluster! Policies must be available in your private registry.
 

--- a/docs/operator-manual/airgap/01-install.md
+++ b/docs/operator-manual/airgap/01-install.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: "Airgap installation"
+sidebar_label: "Installation"
 title: ""
 ---
 

--- a/docs/operator-manual/airgap/01-install.md
+++ b/docs/operator-manual/airgap/01-install.md
@@ -76,8 +76,14 @@ to the air-gapped environment.
 ./kubewarden-load-policies.sh --policies kubewarden-policies.tar.gz --policies-list policies.txt --registry <REGISTRY.YOURDOMAIN.COM:PORT> --sources-path sources.yml 
 ```
 
-:::note
-Go to [kwctl documentation](https://docs.kubewarden.io/distributing-policies/custom-certificate-authorities) to learn more about how to configure your sources.yaml
+:::caution
+The `sources.yaml` file is needed by kwctl to connect to registries that fall into these categories:
+
+* Authentication required
+* Self signed certificate is being used
+* No TLS termination is done
+
+Please refer to [this section](../distributing-policies/custom-certificate-authorities.md) of our documentation to learn more about how to configure the `sources.yaml` file
 ::: 
 
 ## Install kubewarden. 

--- a/docs/operator-manual/airgap/01-install.md
+++ b/docs/operator-manual/airgap/01-install.md
@@ -12,12 +12,13 @@ You need to add Kubewarden's images and policies to this OCI registry. Let's see
 
 ## Save container images in your workstation
 
-1. Download `kubewarden-images.txt` from the Kubewarden [release page](https://github.com/kubewarden/helm-charts/releases/).
+1. Download `kubewarden-images.txt` from the Kubewarden [release page](https://github.com/kubewarden/helm-charts/releases/). Alternatively, you can find `imagelist.txt` and `policylist.txt` files shipped inside the helm charts, that contain the used container images and policy wasm modules respectively.
+1. Optionally, you can verify the signatures of the helm charts (see "verifying Kubewarden link") prior to obtaining the list of images and policies.
 2. Add `cert-manager` if it is not available in your private registry. 
 ```
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
-helm fetch jetstack/cert-manager --version v1.7.1
+helm pull jetstack/cert-manager --version v1.7.1
 helm template ./cert-manager-v1.7.1.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./kubewarden-images.txt
 ```
 3. Download [kubewarden-save-images.sh](https://github.com/kubewarden/utils/blob/main/scripts/kubewarden-save-images.sh) 

--- a/docs/operator-manual/airgap/01-install.md
+++ b/docs/operator-manual/airgap/01-install.md
@@ -1,0 +1,131 @@
+---
+sidebar_label: "Airgap installation"
+title: ""
+---
+
+# Airgap installation
+
+This guide will show you how to install Kubewarden in air-gapped environments. In an air-gapped installation of Kubewarden, 
+you will need a private OCI registry that is located somewhere accessible by your kubernetes cluster. Kubewarden Policies 
+are WebAssembly modules, therefore they can be stored inside of an OCI compliant registry as OCI artifacts.
+You need to add Kubewarden's images and policies to this OCI registry. Let's see how to do that.
+
+## Save container images in your workstation
+
+1. Download `kubewarden-images.txt` from the Kubewarden [release page](https://github.com/kubewarden/helm-charts/releases/).
+2. Add `cert-manager` if it is not available in your private registry. 
+```
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm fetch jetstack/cert-manager --version v1.7.1
+helm template ./cert-manager-v1.7.1.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./kubewarden-images.txt
+```
+3. Download [kubewarden-save-images.sh](https://github.com/kubewarden/utils/blob/main/scripts/kubewarden-save-images.sh) 
+and [kubewarden-load-images.sh](https://github.com/kubewarden/utils/blob/main/scripts/kubewarden-load-images.sh) from the Kubewarden utils repository.
+4. Save Kubewarden container images into a tar.gz file:
+```
+./kubewarden-save-images.sh --image-list ./kubewarden-images.txt --images kubewarden-images.tar.gz
+```
+Docker begins pulling the images used for an airgap install. Be patient. This process takes a few minutes. 
+When the process completes, your current directory will output a tarball named `kubewarden-images.tar.gz`. Check that the output is in the directory.
+
+## Save policies in your workstation
+
+[kwctl](https://github.com/kubewarden/kwctl/releases) version v1.3.1 or above is required for this step.
+
+1. Add all the policies you want to use in a `policies.txt` file. 
+Example: (TODO add link to default policies.txt once it is available) 
+```
+registry://ghcr.io/kubewarden/policies/pod-privileged:v0.2.2
+registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5
+```
+2. Download `kubewarden-save-policies.sh` and `kubewarden-load-policies.sh` from the [kwctl repository](https://github.com/kubewarden/kwctl/tree/main/scripts)
+3. Save policies into a tar.gz file:
+```
+./kubewarden-save-policies.sh --policies-list policies.txt
+```
+kwctl downloads all the policies and stores then in `kubewarden-policies.tar.gz`
+
+## Helm charts
+
+You need to download the following helm charts in your workstation:
+
+```
+helm pull kubewarden/kubewarden-crds         
+helm pull kubewarden/kubewarden-controller
+helm pull kubewarden/kubewarden-defaults  
+helm pull jetstack/cert-manager         
+```
+
+Then move the helm chart tar.gz files to your air-gapped environment.
+
+## Populate private registry
+
+Move `kubewarden-policies.tar.gz`, `kubewarden-images.tar.gz`, `kubewarden-load-images.sh`, `kubewarden-load-policies.sh` and `policies.txt`
+to the air-gapped environment.
+
+1. load Kubewarden images into the private registry
+```
+./kubewarden-load-images.sh --image-list ./kubewarden-images.txt --images kubewarden-images.tar.gz --registry <REGISTRY.YOURDOMAIN.COM:PORT>
+```
+2. load Kubewarden policies into the private registry  
+```
+./kubewarden-load-policies.sh --policies kubewarden-policies.tar.gz --policies-list policies.txt --registry <REGISTRY.YOURDOMAIN.COM:PORT> --sources-path sources.yml 
+```
+
+:::note
+Go to [kwctl documentation](https://docs.kubewarden.io/distributing-policies/custom-certificate-authorities) to learn more about how to configure your sources.yaml
+::: 
+
+## Install kubewarden. 
+
+Let's install Kubewarden now that we have everything we need in our private registry. The only difference with a normal
+Kubewarden installation is that we need to change the registry in the container images and policies to our private registry.
+
+Install cert-manager:
+
+```
+helm install --create-namespace cert-manager ./cert-manager-v1.7.1.tgz \
+    -n kubewarden \
+    --set installCRDs=true \
+    --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller \
+    --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-webhook \
+    --set cainjector.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-cainjector \
+    --set startupapicheck.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-ctl
+```
+
+Let's install the Kubewarden stack:
+
+```
+helm install --wait -n kubewarden kubewarden-crds.tgz
+```
+
+```
+helm install --wait -n kubewarden kubewarden-controller.tgz --set common.cattle.systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT>
+```
+
+```
+helm install --wait -n kubewarden kubewarden-defaults.tgz --set common.cattle.systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT>
+```
+
+Finally, we need to configure PolicyServers to fetch policies from our private registry. See the [using private registry](https://docs.kubewarden.io/operator-manual/policy-servers/private-registry) section of the docs.
+
+Now we can create Kubewarden policies in our cluster! Policies must be available in your private registry.
+
+```
+kubectl apply -f - <<EOF                                                                                        
+apiVersion: policies.kubewarden.io/v1      
+kind: ClusterAdmissionPolicy
+metadata:
+  name: privileged-pods
+spec:
+  module: registry://<REGISTRY.YOURDOMAIN.COM:PORT>/kubewarden/policies/pod-privileged:v0.2.2
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    operations:
+    - CREATE
+  mutating: false
+EOF
+```

--- a/docs/operator-manual/airgap/01-install.md
+++ b/docs/operator-manual/airgap/01-install.md
@@ -13,7 +13,9 @@ You need to add Kubewarden's images and policies to this OCI registry. Let's see
 ## Save container images in your workstation
 
 1. Download `kubewarden-images.txt` from the Kubewarden [release page](https://github.com/kubewarden/helm-charts/releases/). Alternatively, you can find `imagelist.txt` and `policylist.txt` files shipped inside the helm charts, that contain the used container images and policy wasm modules respectively.
-1. Optionally, you can verify the signatures of the helm charts (see "verifying Kubewarden link") prior to obtaining the list of images and policies.
+:::note
+Optionally, you can verify the signatures of the [helm charts](https://docs.kubewarden.io/security/verifying-kubewarden#helm-charts) and [container images](https://docs.kubewarden.io/security/verifying-kubewarden#container-images)
+:::
 2. Add `cert-manager` if it is not available in your private registry. 
 ```
 helm repo add jetstack https://charts.jetstack.io

--- a/docs/operator-manual/airgap/01-install.md
+++ b/docs/operator-manual/airgap/01-install.md
@@ -3,9 +3,9 @@ sidebar_label: "Installation"
 title: ""
 ---
 
-# Airgap installation
+# Air gap installation
 
-This guide will show you how to install Kubewarden in air-gapped environments. In an air-gapped installation of Kubewarden, 
+This guide will show you how to install Kubewarden in air gap environments. In an air gap installation of Kubewarden, 
 you will need a private OCI registry that is located somewhere accessible by your kubernetes cluster. Kubewarden Policies 
 are WebAssembly modules, therefore they can be stored inside of an OCI compliant registry as OCI artifacts.
 You need to add Kubewarden's images and policies to this OCI registry. Let's see how to do that.
@@ -29,7 +29,7 @@ and [kubewarden-load-images.sh](https://github.com/kubewarden/utils/blob/main/sc
 ```
 ./kubewarden-save-images.sh --image-list ./kubewarden-images.txt --images kubewarden-images.tar.gz
 ```
-Docker begins pulling the images used for an airgap install. Be patient. This process takes a few minutes. 
+Docker begins pulling the images used for an air gap install. Be patient. This process takes a few minutes. 
 When the process completes, your current directory will output a tarball named `kubewarden-images.tar.gz`. Check that the output is in the directory.
 
 ## Save policies in your workstation
@@ -60,12 +60,12 @@ helm pull kubewarden/kubewarden-defaults
 helm pull jetstack/cert-manager         
 ```
 
-Then move the helm chart tar.gz files to your air-gapped environment.
+Then move the helm chart tar.gz files to your air gap environment.
 
 ## Populate private registry
 
 Move `kubewarden-policies.tar.gz`, `kubewarden-images.tar.gz`, `kubewarden-load-images.sh`, `kubewarden-load-policies.sh` and `policies.txt`
-to the air-gapped environment.
+to the air gap environment.
 
 1. load Kubewarden images into the private registry
 ```

--- a/docs/operator-manual/airgap/01-requirements.md
+++ b/docs/operator-manual/airgap/01-requirements.md
@@ -1,0 +1,10 @@
+---
+sidebar_label: "Requirements"
+title: ""
+---
+
+# Requirements
+
+1. Private registry that supports OCI artifacts. It will be used for storing the container images and policies.
+2. [kwctl](https://github.com/kubewarden/kwctl) 1.3.1 or above
+3. docker v20.10.6 or above

--- a/docs/operator-manual/airgap/01-requirements.md
+++ b/docs/operator-manual/airgap/01-requirements.md
@@ -5,6 +5,6 @@ title: ""
 
 # Requirements
 
-1. Private registry that supports OCI artifacts. It will be used for storing the container images and policies.
+1. Private registry that supports OCI artifacts, [here](../../distributing-policies/oci-registries-support) you can find a list of supported OCI registries. It will be used for storing the container images and policies.
 2. [kwctl](https://github.com/kubewarden/kwctl) 1.3.1 or above
 3. docker v20.10.6 or above

--- a/docs/operator-manual/airgap/02-install.md
+++ b/docs/operator-manual/airgap/02-install.md
@@ -44,7 +44,7 @@ registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5
 ```
 ./kubewarden-save-policies.sh --policies-list policies.txt
 ```
-kwctl downloads all the policies and stores then in `kubewarden-policies.tar.gz`
+kwctl downloads all the policies and stores them as `kubewarden-policies.tar.gz` archive.
 
 ## Helm charts
 
@@ -79,7 +79,7 @@ to the air gap environment.
 :::caution
 The `sources.yaml` file is needed by kwctl to connect to registries that fall into these categories:
 
-* Authentication required
+* Authentication is required
 * Self signed certificate is being used
 * No TLS termination is done
 
@@ -117,7 +117,7 @@ helm install --wait -n kubewarden kubewarden-controller kubewarden-controller.tg
 helm install --wait -n kubewarden kubewarden-defaults kubewarden-defaults.tgz --set common.cattle.systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT>
 ```
 
-Finally, we need to configure PolicyServers to fetch policies from our private registry. See the [using private registry](../policy-servers/private-registry) section of the docs.
+Finally, we need to configure Policy Server to fetch policies from our private registry. See the [using private registry](../policy-servers/private-registry) section of the docs.
 
 Now we can create Kubewarden policies in our cluster! Policies must be available in your private registry.
 
@@ -140,7 +140,7 @@ EOF
 ```
 
 :::caution
-PolicyServers must use the image available in your private registry. Example:
+`PolicyServer` resources must use the image available in your private registry. For example:
 ```
 apiVersion: policies.kubewarden.io/v1
 kind: PolicyServer

--- a/docs/operator-manual/airgap/02-install.md
+++ b/docs/operator-manual/airgap/02-install.md
@@ -33,12 +33,7 @@ When the process completes, your current directory will output a tarball named `
 
 ## Save policies in your workstation
 
-1. Add all the policies you want to use in a `policies.txt` file. 
-Example: (TODO add link to default policies.txt once it is available) 
-```
-registry://ghcr.io/kubewarden/policies/pod-privileged:v0.2.2
-registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5
-```
+1. Add all the policies you want to use in a `policies.txt` file. A file with a list of the default policies can be found in the Kubewarden defaults [release page](https://github.com/kubewarden/helm-charts/releases/)
 2. Download `kubewarden-save-policies.sh` and `kubewarden-load-policies.sh` from the [kwctl repository](https://github.com/kubewarden/kwctl/tree/main/scripts)
 3. Save policies into a .tar.gz file:
 ```

--- a/docs/operator-manual/airgap/02-install.md
+++ b/docs/operator-manual/airgap/02-install.md
@@ -98,10 +98,10 @@ Install `cert-manager` if it is not already installed in the air gap cluster:
 helm install --create-namespace cert-manager ./cert-manager-<Version>.tgz \
     -n kubewarden \
     --set installCRDs=true \
-    --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller \
-    --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-webhook \
-    --set cainjector.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-cainjector \
-    --set startupapicheck.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-ctl
+    --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/jetstack/cert-manager-controller \
+    --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/jetstack/cert-manager-webhook \
+    --set cainjector.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/jetstack/cert-manager-cainjector \
+    --set startupapicheck.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/jetstack/cert-manager-ctl
 ```
 
 Let's install the Kubewarden stack:

--- a/docs/operator-manual/airgap/02-install.md
+++ b/docs/operator-manual/airgap/02-install.md
@@ -107,15 +107,15 @@ helm install --create-namespace cert-manager ./cert-manager-<Version>.tgz \
 Let's install the Kubewarden stack:
 
 ```
-helm install --wait -n kubewarden kubewarden-crds.tgz
+helm install --wait -n kubewarden kubewarden-crds kubewarden-crds.tgz
 ```
 
 ```
-helm install --wait -n kubewarden kubewarden-controller.tgz --set common.cattle.systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT>
+helm install --wait -n kubewarden kubewarden-controller kubewarden-controller.tgz --set common.cattle.systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT>
 ```
 
 ```
-helm install --wait -n kubewarden kubewarden-defaults.tgz --set common.cattle.systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT>
+helm install --wait -n kubewarden kubewarden-defaults kubewarden-defaults.tgz --set common.cattle.systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT>
 ```
 
 Finally, we need to configure PolicyServers to fetch policies from our private registry. See the [using private registry](../policy-servers/private-registry) section of the docs.

--- a/docs/operator-manual/airgap/02-install.md
+++ b/docs/operator-manual/airgap/02-install.md
@@ -5,14 +5,14 @@ title: ""
 
 # Air gap installation
 
-This guide will show you how to install Kubewarden in air gap environments. In an air gap installation of Kubewarden, 
-you will need a private OCI registry that is located somewhere accessible by your kubernetes cluster. Kubewarden Policies 
-are WebAssembly modules, therefore they can be stored inside of an OCI compliant registry as OCI artifacts.
+This guide will show you how to install Kubewarden in air-gapped environments. In an air-gapped installation of Kubewarden, 
+you will need a private OCI registry accessible by your Kubernetes cluster. Kubewarden Policies 
+are WebAssembly modules; therefore, they can be stored inside an OCI-compliant registry as OCI artifacts.
 You need to add Kubewarden's images and policies to this OCI registry. Let's see how to do that.
 
 ## Save container images in your workstation
 
-1. Download `kubewarden-images.txt` from the Kubewarden [release page](https://github.com/kubewarden/helm-charts/releases/). Alternatively, you can find `imagelist.txt` and `policylist.txt` files shipped inside the helm charts, that contain the used container images and policy wasm modules respectively.
+1. Download `kubewarden-images.txt` from the Kubewarden [release page](https://github.com/kubewarden/helm-charts/releases/). Alternatively, the `imagelist.txt` and `policylist.txt` files are shipped inside the helm charts containing the used container images and policy wasm modules, respectively.
 :::note
 Optionally, you can verify the signatures of the [helm charts](../../security/verifying-kubewarden#helm-charts) and [container images](../../security/verifying-kubewarden#container-images)
 :::
@@ -24,12 +24,12 @@ helm pull jetstack/cert-manager
 helm template ./cert-manager-<Version>.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./kubewarden-images.txt
 ```
 3. Download `kubewarden-save-images.sh` and `kubewarden-load-images.sh` from the latest kwctl [release](https://github.com/kubewarden/kwctl/releases).
-4. Save Kubewarden container images into a tar.gz file:
+4. Save Kubewarden container images into a .tar.gz file:
 ```
 ./kubewarden-save-images.sh --image-list ./kubewarden-images.txt --images kubewarden-images.tar.gz
 ```
 Docker begins pulling the images used for an air gap install. Be patient. This process takes a few minutes. 
-When the process completes, your current directory will output a tarball named `kubewarden-images.tar.gz`. Check that the output is in the directory.
+When the process completes, your current directory will output a tarball named `kubewarden-images.tar.gz`. It will be present in the same directory where you executed the command.
 
 ## Save policies in your workstation
 
@@ -40,7 +40,7 @@ registry://ghcr.io/kubewarden/policies/pod-privileged:v0.2.2
 registry://ghcr.io/kubewarden/policies/safe-labels:v0.1.5
 ```
 2. Download `kubewarden-save-policies.sh` and `kubewarden-load-policies.sh` from the [kwctl repository](https://github.com/kubewarden/kwctl/tree/main/scripts)
-3. Save policies into a tar.gz file:
+3. Save policies into a .tar.gz file:
 ```
 ./kubewarden-save-policies.sh --policies-list policies.txt
 ```
@@ -83,7 +83,7 @@ The `sources.yaml` file is needed by kwctl to connect to registries that fall in
 * Self signed certificate is being used
 * No TLS termination is done
 
-Please refer to [this section](../../distributing-policies/custom-certificate-authorities.md) of our documentation to learn more about how to configure the `sources.yaml` file
+Please refer to [the section on custom certificate authorities](../../distributing-policies/custom-certificate-authorities.md) in our documentation to learn more about configuring the `sources.yaml` file
 ::: 
 
 ## Install kubewarden. 

--- a/docs/operator-manual/airgap/02-install.md
+++ b/docs/operator-manual/airgap/02-install.md
@@ -139,3 +139,17 @@ spec:
   mutating: false
 EOF
 ```
+
+:::caution
+PolicyServers must use the image available in your private registry. Example:
+```
+apiVersion: policies.kubewarden.io/v1
+kind: PolicyServer
+metadata:
+  name: reserved-instance-for-tenant-a
+spec:
+  image: <REGISTRY.YOURDOMAIN.COM:PORT>/kubewarden/policy-server:v1.3.0
+  replicas: 2
+  serviceAccountName: sa
+```
+:::

--- a/docs/operator-manual/airgap/02-install.md
+++ b/docs/operator-manual/airgap/02-install.md
@@ -68,11 +68,11 @@ helm pull jetstack/cert-manager
 Move `kubewarden-policies.tar.gz`, `kubewarden-images.tar.gz`, `kubewarden-load-images.sh`, `kubewarden-load-policies.sh` and `policies.txt`
 to the air gap environment.
 
-1. load Kubewarden images into the private registry
+1. Load Kubewarden images into the private registry. Docker client must be authenticated against the local registry
 ```
 ./kubewarden-load-images.sh --image-list ./kubewarden-images.txt --images kubewarden-images.tar.gz --registry <REGISTRY.YOURDOMAIN.COM:PORT>
 ```
-2. load Kubewarden policies into the private registry  
+2. Load Kubewarden policies into the private registry  
 ```
 ./kubewarden-load-policies.sh --policies kubewarden-policies.tar.gz --policies-list policies.txt --registry <REGISTRY.YOURDOMAIN.COM:PORT> --sources-path sources.yml 
 ```

--- a/docs/operator-manual/airgap/02-install.md
+++ b/docs/operator-manual/airgap/02-install.md
@@ -23,8 +23,7 @@ helm repo update
 helm pull jetstack/cert-manager
 helm template ./cert-manager-<Version>.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./kubewarden-images.txt
 ```
-3. Download [kubewarden-save-images.sh](https://github.com/kubewarden/utils/blob/main/scripts/kubewarden-save-images.sh) 
-and [kubewarden-load-images.sh](https://github.com/kubewarden/utils/blob/main/scripts/kubewarden-load-images.sh) from the Kubewarden utils repository.
+3. Download `kubewarden-save-images.sh` and `kubewarden-load-images.sh` from the latest kwctl [release](https://github.com/kubewarden/kwctl/releases).
 4. Save Kubewarden container images into a tar.gz file:
 ```
 ./kubewarden-save-images.sh --image-list ./kubewarden-images.txt --images kubewarden-images.tar.gz

--- a/docs/operator-manual/airgap/02-install.md
+++ b/docs/operator-manual/airgap/02-install.md
@@ -55,10 +55,13 @@ You need to download the following helm charts in your workstation:
 helm pull kubewarden/kubewarden-crds         
 helm pull kubewarden/kubewarden-controller
 helm pull kubewarden/kubewarden-defaults  
-helm pull jetstack/cert-manager         
 ```
 
-Then move the helm chart tar.gz files to your air gap environment.
+Download `cert-manager` if it is not installed in the air gap cluster.
+
+```
+helm pull jetstack/cert-manager
+```
 
 ## Populate private registry
 
@@ -89,10 +92,10 @@ Please refer to [this section](../../distributing-policies/custom-certificate-au
 Let's install Kubewarden now that we have everything we need in our private registry. The only difference with a normal
 Kubewarden installation is that we need to change the registry in the container images and policies to our private registry.
 
-Install cert-manager:
+Install `cert-manager` if it is not already installed in the air gap cluster:
 
 ```
-helm install --create-namespace cert-manager ./cert-manager-v1.7.1.tgz \
+helm install --create-namespace cert-manager ./cert-manager-<Version>.tgz \
     -n kubewarden \
     --set installCRDs=true \
     --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller \

--- a/docs/operator-manual/airgap/02-install.md
+++ b/docs/operator-manual/airgap/02-install.md
@@ -34,8 +34,6 @@ When the process completes, your current directory will output a tarball named `
 
 ## Save policies in your workstation
 
-[kwctl](https://github.com/kubewarden/kwctl/releases) version v1.3.1 or above is required for this step.
-
 1. Add all the policies you want to use in a `policies.txt` file. 
 Example: (TODO add link to default policies.txt once it is available) 
 ```

--- a/docs/operator-manual/airgap/02-install.md
+++ b/docs/operator-manual/airgap/02-install.md
@@ -20,8 +20,8 @@ Optionally, you can verify the signatures of the [helm charts](../../security/ve
 ```
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
-helm pull jetstack/cert-manager --version v1.7.1
-helm template ./cert-manager-v1.7.1.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./kubewarden-images.txt
+helm pull jetstack/cert-manager
+helm template ./cert-manager-<Version>.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./kubewarden-images.txt
 ```
 3. Download [kubewarden-save-images.sh](https://github.com/kubewarden/utils/blob/main/scripts/kubewarden-save-images.sh) 
 and [kubewarden-load-images.sh](https://github.com/kubewarden/utils/blob/main/scripts/kubewarden-load-images.sh) from the Kubewarden utils repository.

--- a/sidebars.js
+++ b/sidebars.js
@@ -170,7 +170,7 @@ module.exports = {
             'operator-manual/verification-config',
           ],
           'Monitor Mode': ['operator-manual/monitor-mode/intro',],
-          'Air gap': ['operator-manual/airgap/install',],
+          'Air gap': ['operator-manual/airgap/requirements','operator-manual/airgap/install',],
         },
       ],
     },

--- a/sidebars.js
+++ b/sidebars.js
@@ -170,7 +170,7 @@ module.exports = {
             'operator-manual/verification-config',
           ],
           'Monitor Mode': ['operator-manual/monitor-mode/intro',],
-          'Airgap': ['operator-manual/airgap/install',],
+          'Air gap': ['operator-manual/airgap/install',],
         },
       ],
     },

--- a/sidebars.js
+++ b/sidebars.js
@@ -170,6 +170,7 @@ module.exports = {
             'operator-manual/verification-config',
           ],
           'Monitor Mode': ['operator-manual/monitor-mode/intro',],
+          'Airgap': ['operator-manual/airgap/install',],
         },
       ],
     },


### PR DESCRIPTION
`common.cattle.systemDefaultRegistry` is still not available until we release the helm charts. Please use `image.repository` for now in the last step when installing with helm.

How to test this PR?

Private local registry is needed. You can create one with:
```
docker run -d -p 5000:5000 --restart=always --name registry registry:2
```
You can reach your registry at `localhost:5000`. You need kubernetes and policy-server to be able to pull from your registry. 
If you are using minikube you can make kubernetes to pull from localhost by forwarding with:
```
ssh -i $(minikube ssh-key) docker@$(minikube ip) -R 5000:localhost:5000
```
Then you can use `host.minikube.internal` for pulling policies. Example:

```
apiVersion: policies.kubewarden.io/v1
kind: ClusterAdmissionPolicy
metadata:
  name: privileged-pods
spec:
  module: registry://host.minikube.internal:5000/kubewarden/policies/pod-privileged:v0.2.2
  rules:
  - apiGroups: [""]
    apiVersions: ["v1"]
    resources: ["pods"]
    operations:
    - CREATE
  mutating: false

```
Fix #121 
