### PR TITLE
Add `v2/verify SigstoreCertificateVerify` & `v1/crypto` callbacks

### DIFF
--- a/docs/writing-policies/spec/host-capabilities/02-signature-verifier-policies.md
+++ b/docs/writing-policies/spec/host-capabilities/02-signature-verifier-policies.md
@@ -266,6 +266,67 @@ policy that verifies signatures can use:
 
 </td>
 </tr>
+
+<tr>
+<td>
+
+`v2/verify`
+
+</td>
+<td>
+
+```json
+{
+  type: "SigstoreCertificateVerify",
+
+  // mandatory: image URI to verify
+  "image": string,
+  // PEM-encoded certificated used to
+  // verify the signature
+  "certificate": string,
+  // Optional - certificate chain used to
+  // verify the provided certificate.
+  // When not specified, the certificate
+  // is assumed to be trusted
+  "certificate_chain": [
+    string,
+    ...
+    string
+  ], 
+  // Require the signature layer to have
+  // a Rekor bundle.
+  // Having a Rekor bundle allows further
+  // checks to be performed, e.g. ensuring
+  // the signature has been produced during
+  // the validity time frame of the cert.
+  // Recommended to set to `true`
+  require_rekor_bundle: bool,
+  // Optional:
+  "annotations": [
+    // signature annotations
+    {
+      "key": string,
+      "value": string
+    },
+  ]
+}
+```
+
+</td>
+<td> 
+
+```json
+{
+   // true if image verified
+   "is_trusted": boolean,
+   // digest of verified image
+   "digest": string
+}
+```
+
+</td>
+</tr>
+
 </table>
 
 

--- a/docs/writing-policies/spec/host-capabilities/05-crypto.md
+++ b/docs/writing-policies/spec/host-capabilities/05-crypto.md
@@ -1,0 +1,65 @@
+---
+sidebar_label: "Cryptographic Capabilities"
+title: ""
+---
+
+# Cryptographic capabilities
+
+Because of Wasm constraints at the time of writing, some cryptographic libraries
+cannot be compiled to Wasm. In the meantime, Kubewarden policies needing those
+can instead perform these callbacks to evaluate the cryptographic functions
+host-side, receive the result, and continue with their logic.
+
+# WaPC protocol contract
+
+In case you are implementing your own language SDK, these are the functions
+performing cryptographic checks exposed by the host:
+
+<table>
+<tr>
+<td> WaPC function name </td> <td> Input payload </td> <td> Output payload </td>
+</tr>
+<tr>
+<td>
+
+`v1/is_certificate_trusted`
+
+</td>
+<td>
+
+```json
+{
+  // **mandatory**: PEM-encoded certificate to verify
+  "certificate": string,
+  // optional:
+  "cert_chain": [
+      // list of PEM-encoded certs, ordered by trust
+      // usage (intermediates first, root last)
+      // If empty or missing, certificate is assumed
+      // trusted
+      string,
+      ...
+      string,
+    ],
+  // RFC 3339 time format string, to check expiration
+  // against.
+  // If missing, certificate is assumed never expired
+  "not_after": string
+}
+```
+
+</td>
+<td> 
+
+```json
+{
+   // true if certificate verified:
+   "trusted": boolean,
+   // empty if trusted == true:
+   "reason": string
+}
+```
+
+</td>
+</tr>
+</table>

--- a/sidebars.js
+++ b/sidebars.js
@@ -37,7 +37,8 @@ module.exports = {
               items: [
                 'writing-policies/spec/host-capabilities/signature-verifier-policies',
                 'writing-policies/spec/host-capabilities/container-registry',
-                'writing-policies/spec/host-capabilities/net'
+                'writing-policies/spec/host-capabilities/net',
+                'writing-policies/spec/host-capabilities/crypto'
               ]
             }
           ],


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/verify-image-signatures/issues/39

Add SigstoreCertificateVerify callback.
Add v1/crypto host capabilities & sidebar entry.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
