### PR TITLE
policy spec use hcl

### DIFF
--- a/docs/writing-policies/spec/host-capabilities/02-signature-verifier-policies.md
+++ b/docs/writing-policies/spec/host-capabilities/02-signature-verifier-policies.md
@@ -81,7 +81,7 @@ policy that verifies signatures can use:
 
 <table>
 <tr>
-<td> WaPC function name </td> <td> Input payload </td> <td> Output payload </td>
+<th> waPC function name </th> <th> Input payload </th> <th> Output payload </th>
 </tr>
 <tr>
 <td>
@@ -91,19 +91,19 @@ policy that verifies signatures can use:
 </td>
 <td>
 
-```json
+```hcl
 {
   type: "SigstorePubKeyVerify",
 
-  // **mandatory**: image URI to verify
+  # **mandatory**: image URI to verify
   "image": string,
   "pub_keys": [
-    // PEM-encoded public keys
+    # PEM-encoded public keys
     string
     ],
-  // optional:
+  # optional:
   "annotations": [
-      // signature annotations
+      # signature annotations
       {
         "key": string,
         "value": string
@@ -115,11 +115,11 @@ policy that verifies signatures can use:
 </td>
 <td> 
 
-```json
+```hcl
 {
-   // true if image verified
+   # true if image verified
    "is_trusted": boolean,
-   // digest of verified image
+   # digest of verified image
    "digest": string
 }
 ```
@@ -134,24 +134,24 @@ policy that verifies signatures can use:
 </td>
 <td>
 
-```json
+```hcl
 {
   type: "SigstoreKeylessVerify",
 
-  // mandatory: image URI to verify
+  # mandatory: image URI to verify
   "image": string,
   "keyless": [
-    // list of (issuer, subject) tuples
+    # list of (issuer, subject) tuples
     {
-      // OIDC issuer
+      # OIDC issuer
       "issuer": string,
-      // signature subject (mail, CI URL, ...)
+      # signature subject (mail, CI URL, ...)
       "subject": string
     }
   ],
-  // optional:
+  # optional:
   "annotations": [
-    // signature annotations
+    # signature annotations
     {
       "key": string,
       "value": string
@@ -163,11 +163,11 @@ policy that verifies signatures can use:
 </td>
 <td> 
 
-```json
+```hcl
 {
-   // true if image verified
+   # true if image verified
    "is_trusted": boolean,
-   // digest of verified image
+   # digest of verified image
    "digest": string
 }
 ```
@@ -182,24 +182,24 @@ policy that verifies signatures can use:
 </td>
 <td>
 
-```json
+```hcl
 {
   type: "SigstoreKeylessPrefixVerify",
 
-  // mandatory: image URI to verify
+  # mandatory: image URI to verify
   "image": string,
   "keyless_prefix": [
-    // list of (issuer, url_prefix) tuples
+    # list of (issuer, url_prefix) tuples
     {
-      // OIDC issuer
+      # OIDC issuer
       "issuer": string,
-      // URL Prefix of subject (CI URL, ...)
+      # URL Prefix of subject (CI URL, ...)
       "url_prefix": string
     }
   ],
-  // optional:
+  # optional:
   "annotations": [
-    // signature annotations
+    # signature annotations
     {
       "key": string,
       "value": string
@@ -211,11 +211,11 @@ policy that verifies signatures can use:
 </td>
 <td> 
 
-```json
+```hcl
 {
-   // true if image verified
+   # true if image verified
    "is_trusted": boolean,
-   // digest of verified image
+   # digest of verified image
    "digest": string
 }
 ```
@@ -231,19 +231,19 @@ policy that verifies signatures can use:
 </td>
 <td>
 
-```json
+```hcl
 {
   type: "SigstoreGithubActionsVerify",
 
-  // mandatory: image URI to verify
+  # mandatory: image URI to verify
   "image": string,
-  // GitHub owner
+  # GitHub owner
   "owner": string,
-  // optional:
-  // GitHub repository 
+  # optional:
+  # GitHub repository 
   "repo": string
   "annotations": [
-    // signature annotations
+    # signature annotations
     {
       "key": string,
       "value": string
@@ -255,11 +255,11 @@ policy that verifies signatures can use:
 </td>
 <td> 
 
-```json
+```hcl
 {
-   // true if image verified
+   # true if image verified
    "is_trusted": boolean,
-   // digest of verified image
+   # digest of verified image
    "digest": string
 }
 ```
@@ -275,35 +275,35 @@ policy that verifies signatures can use:
 </td>
 <td>
 
-```json
+```hcl
 {
   type: "SigstoreCertificateVerify",
 
-  // mandatory: image URI to verify
+  # mandatory: image URI to verify
   "image": string,
-  // PEM-encoded certificated used to
-  // verify the signature
+  # PEM-encoded certificated used to
+  # verify the signature
   "certificate": string,
-  // Optional - certificate chain used to
-  // verify the provided certificate.
-  // When not specified, the certificate
-  // is assumed to be trusted
+  # Optional - certificate chain used to
+  # verify the provided certificate.
+  # When not specified, the certificate
+  # is assumed to be trusted
   "certificate_chain": [
     string,
     ...
     string
   ], 
-  // Require the signature layer to have
-  // a Rekor bundle.
-  // Having a Rekor bundle allows further
-  // checks to be performed, e.g. ensuring
-  // the signature has been produced during
-  // the validity time frame of the cert.
-  // Recommended to set to `true`
+  # Require the signature layer to have
+  # a Rekor bundle.
+  # Having a Rekor bundle allows further
+  # checks to be performed, e.g. ensuring
+  # the signature has been produced during
+  # the validity time frame of the cert.
+  # Recommended to set to `true`
   require_rekor_bundle: bool,
-  // Optional:
+  # Optional:
   "annotations": [
-    // signature annotations
+    # signature annotations
     {
       "key": string,
       "value": string
@@ -315,11 +315,11 @@ policy that verifies signatures can use:
 </td>
 <td> 
 
-```json
+```hcl
 {
-   // true if image verified
+   # true if image verified
    "is_trusted": boolean,
-   // digest of verified image
+   # digest of verified image
    "digest": string
 }
 ```
@@ -344,17 +344,17 @@ Marked for deprecation:
 </td>
 <td>
 
-```json
+```hcl
 {
-  // **mandatory**: image URI to verify
+  # **mandatory**: image URI to verify
   "image": string,
   "pub_keys": [
-    // PEM-encoded public keys
+    # PEM-encoded public keys
     string
     ],
-  // optional:
+  # optional:
   "annotations": [
-      // signature annotations
+      # signature annotations
       {
         "key": string,
         "value": string
@@ -366,11 +366,11 @@ Marked for deprecation:
 </td>
 <td> 
 
-```json
+```hcl
 {
-   // true if image verified
+   # true if image verified
    "is_trusted": boolean,
-   // digest of verified image
+   # digest of verified image
    "digest": string
 }
 ```
@@ -385,22 +385,22 @@ Marked for deprecation:
 </td>
 <td>
 
-```json
+```hcl
 {
-  // mandatory: image URI to verify
+  # mandatory: image URI to verify
   "image": string,
   "keyless": [
-    // list of (issuer, subject) tuples
+    # list of (issuer, subject) tuples
     {
-      // OIDC issuer
+      # OIDC issuer
       "issuer": string,
-      // signature subject (mail, CI URL, ...)
+      # signature subject (mail, CI URL, ...)
       "subject": string
     }
   ],
-  // optional:
+  # optional:
   "annotations": [
-    // signature annotations
+    # signature annotations
     {
       "key": string,
       "value": string
@@ -412,11 +412,11 @@ Marked for deprecation:
 </td>
 <td> 
 
-```json
+```hcl
 {
-   // true if image verified
+   # true if image verified
    "is_trusted": boolean,
-   // digest of verified image
+   # digest of verified image
    "digest": string
 }
 ```

--- a/docs/writing-policies/spec/host-capabilities/02-signature-verifier-policies.md
+++ b/docs/writing-policies/spec/host-capabilities/02-signature-verifier-policies.md
@@ -266,6 +266,67 @@ policy that verifies signatures can use:
 
 </td>
 </tr>
+
+<tr>
+<td>
+
+`v2/verify`
+
+</td>
+<td>
+
+```json
+{
+  type: "SigstoreCertificateVerify",
+
+  // mandatory: image URI to verify
+  "image": string,
+  // PEM-encoded certificated used to
+  // verify the signature
+  "certificate": string,
+  // Optional - certificate chain used to
+  // verify the provided certificate.
+  // When not specified, the certificate
+  // is assumed to be trusted
+  "certificate_chain": [
+    string,
+    ...
+    string
+  ], 
+  // Require the signature layer to have
+  // a Rekor bundle.
+  // Having a Rekor bundle allows further
+  // checks to be performed, e.g. ensuring
+  // the signature has been produced during
+  // the validity time frame of the cert.
+  // Recommended to set to `true`
+  require_rekor_bundle: bool,
+  // Optional:
+  "annotations": [
+    // signature annotations
+    {
+      "key": string,
+      "value": string
+    },
+  ]
+}
+```
+
+</td>
+<td> 
+
+```json
+{
+   // true if image verified
+   "is_trusted": boolean,
+   // digest of verified image
+   "digest": string
+}
+```
+
+</td>
+</tr>
+
 </table>
 
 

--- a/docs/writing-policies/spec/host-capabilities/03-container-registry.md
+++ b/docs/writing-policies/spec/host-capabilities/03-container-registry.md
@@ -36,10 +36,41 @@ from the remote registry.
 
 This is the description of the waPC protocol used to expose this capability:
 
+<table>
+<tr>
+<th> waPC function name </th> <th> Input payload </th> <th> Output payload </th>
+</tr>
 
-| **waPC function name** | **Input payload** | **Output payload** |
-|--------------------|---------------|----------------|
-| `v1/manifest_digest` | <code>// OCI URI<br/>// JSON encoded string<br/>string</code>  | <code>{<br/>   // digest of the OCI object<br/>   "digest": string<br/>}</code> |
+<tr>
+<td>
+
+`v1/manifest_digest`
+
+</td>
+<td>
+
+```hcl
+# OCI URI
+string,
+#JSON encoded string
+string
+```
+
+</td>
+
+<td>
+
+```hcl
+{
+  # digest of the OCI object
+  "digest": string
+}
+```
+
+</td>
+</tr>
+
+</table>
 
 For example, when requesting the manifest digest of the `busybox:latest` image,
 the payload would be the following ones:

--- a/docs/writing-policies/spec/host-capabilities/04-net.md
+++ b/docs/writing-policies/spec/host-capabilities/04-net.md
@@ -23,11 +23,39 @@ Lookup results are cached for 1 minute.
 
 This is the description of the waPC protocol used to expose this capability:
 
+<table>
+<tr>
+<th> waPC function name </th> <th> Input payload </th> <th> Output payload </th>
+</tr>
 
-| **waPC function name** | **Input payload** | **Output payload** |
-|--------------------|---------------|----------------|
-| `v1/dns_lookup_host` | <code>// hostname<br/>// JSON encoded string<br/>string</code>  | <code>{<br/>   // list of IPs<br/>   "ips": [<br/>     string<br/>   ]<br/>}</code> |
+<tr>
+<td>
 
+`v1/dns_lookup_host`
+
+</td>
+<td>
+
+```hcl
+# hostname - JSON encoded string
+string
+```
+
+</td>
+
+<td>
+
+```hcl
+
+{
+  # list of IPs
+  "ips": [string]
+}
+```
+
+</td>
+</tr>
+</table>
 
 All the IPs associated with the given FQDN, are going to be returned as strings
 inside of the response. Both IPv4 and IPv6 entries are going to be returned as

--- a/docs/writing-policies/spec/host-capabilities/05-crypto.md
+++ b/docs/writing-policies/spec/host-capabilities/05-crypto.md
@@ -17,7 +17,7 @@ performing cryptographic checks exposed by the host:
 
 <table>
 <tr>
-<td> WaPC function name </td> <td> Input payload </td> <td> Output payload </td>
+<th> waPC function name </th> <th> Input payload </th> <th> Output payload </th>
 </tr>
 <tr>
 <td>
@@ -27,23 +27,23 @@ performing cryptographic checks exposed by the host:
 </td>
 <td>
 
-```json
+```hcl
 {
-  // **mandatory**: PEM-encoded certificate to verify
+  # **mandatory**: PEM-encoded certificate to verify
   "certificate": string,
-  // optional:
+  # optional:
   "cert_chain": [
-      // list of PEM-encoded certs, ordered by trust
-      // usage (intermediates first, root last)
-      // If empty or missing, certificate is assumed
-      // trusted
+      # list of PEM-encoded certs, ordered by trust
+      # usage (intermediates first, root last)
+      # If empty or missing, certificate is assumed
+      # trusted
       string,
       ...
       string,
     ],
-  // RFC 3339 time format string, to check expiration
-  // against.
-  // If missing, certificate is assumed never expired
+  # RFC 3339 time format string, to check expiration
+  # against.
+  # If missing, certificate is assumed never expired
   "not_after": string
 }
 ```
@@ -51,11 +51,11 @@ performing cryptographic checks exposed by the host:
 </td>
 <td> 
 
-```json
+```hcl
 {
-   // true if certificate verified:
+   # true if certificate verified:
    "trusted": boolean,
-   // empty if trusted == true:
+   # empty if trusted == true:
    "reason": string
 }
 ```

--- a/docs/writing-policies/spec/host-capabilities/05-crypto.md
+++ b/docs/writing-policies/spec/host-capabilities/05-crypto.md
@@ -1,0 +1,65 @@
+---
+sidebar_label: "Cryptographic Capabilities"
+title: ""
+---
+
+# Cryptographic capabilities
+
+Because of Wasm constraints at the time of writing, some cryptographic libraries
+cannot be compiled to Wasm. In the meantime, Kubewarden policies needing those
+can instead perform these callbacks to evaluate the cryptographic functions
+host-side, receive the result, and continue with their logic.
+
+# WaPC protocol contract
+
+In case you are implementing your own language SDK, these are the functions
+performing cryptographic checks exposed by the host:
+
+<table>
+<tr>
+<td> WaPC function name </td> <td> Input payload </td> <td> Output payload </td>
+</tr>
+<tr>
+<td>
+
+`v1/is_certificate_trusted`
+
+</td>
+<td>
+
+```json
+{
+  // **mandatory**: PEM-encoded certificate to verify
+  "certificate": string,
+  // optional:
+  "cert_chain": [
+      // list of PEM-encoded certs, ordered by trust
+      // usage (intermediates first, root last)
+      // If empty or missing, certificate is assumed
+      // trusted
+      string,
+      ...
+      string,
+    ],
+  // RFC 3339 time format string, to check expiration
+  // against.
+  // If missing, certificate is assumed never expired
+  "not_after": string
+}
+```
+
+</td>
+<td> 
+
+```json
+{
+   // true if certificate verified:
+   "trusted": boolean,
+   // empty if trusted == true:
+   "reason": string
+}
+```
+
+</td>
+</tr>
+</table>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,6 +36,7 @@ module.exports = {
     prism: {
       // Enable extra languages when doing syntax highlighting
       additionalLanguages: [
+        'hcl',
         'rust',
         'rego',
       ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -37,7 +37,8 @@ module.exports = {
               items: [
                 'writing-policies/spec/host-capabilities/signature-verifier-policies',
                 'writing-policies/spec/host-capabilities/container-registry',
-                'writing-policies/spec/host-capabilities/net'
+                'writing-policies/spec/host-capabilities/net',
+                'writing-policies/spec/host-capabilities/crypto'
               ]
             }
           ],


### PR DESCRIPTION
**Note:** this PR is based on top of https://github.com/kubewarden/docs/pull/154

Better layout of the waPC host capabilities

* use `hcl` when documenting the API instead of JSON
* reqwrite some tables using html. It's painful, but the end result is       so much better

