### PR TITLE
Small reorg of "Operator Manual" sidebar menu

### DIFF
--- a/docs/operator-manual/monitor-mode.md
+++ b/docs/operator-manual/monitor-mode.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: "Introduction to Monitor Mode"
+sidebar_label: "Monitor Mode"
 title: ""
 ---
 

--- a/docs/operator-manual/policy-servers/01-custom-cas.md
+++ b/docs/operator-manual/policy-servers/01-custom-cas.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: "Configuring PolicyServers using Custom CAs"
+sidebar_label: "Using Custom CAs"
 title: ""
 ---
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -157,23 +157,41 @@ module.exports = {
       link: {type: 'doc', id: 'operator-manual/intro'},
       items:[
         {
-          'Configuring Policy Servers': ['operator-manual/policy-servers/custom-cas', 'operator-manual/policy-servers/private-registry'],
-          'Quickstart Guides':
-          [
+          type: 'category',
+          label: 'Quickstart Guides',
+          items: [
             'operator-manual/telemetry/opentelemetry/quickstart',
             'operator-manual/telemetry/metrics/quickstart',
             'operator-manual/telemetry/tracing/quickstart',
           ],
-          'Reference Documentation':
-          [
-            'operator-manual/telemetry/metrics/reference',
+        },
+        {
+          type: 'category',
+          label: 'Configuring Policy Servers',
+          items: [
+            'operator-manual/policy-servers/custom-cas',
+            'operator-manual/policy-servers/private-registry',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Reference Documentation',
+          items: [
             'operator-manual/CRDs',
+            'operator-manual/telemetry/metrics/reference',
             'operator-manual/verification-config',
           ],
-          'Monitor Mode': ['operator-manual/monitor-mode/intro',],
-          'Air gap': ['operator-manual/airgap/requirements','operator-manual/airgap/install',],
-          'Rancher Fleet': ['operator-manual/Rancher-Fleet',],
         },
+        {
+          type: 'category',
+          label: 'Air gap',
+          items: [
+            'operator-manual/airgap/requirements',
+            'operator-manual/airgap/install',
+          ],
+        },
+        { type: 'doc', id: 'operator-manual/monitor-mode'},
+        { type: 'doc', id: 'operator-manual/Rancher-Fleet'},
       ],
     },
     {


### PR DESCRIPTION
These are tiny improvements of the the "Operator Manual" section of the sidebar.

## Sidebar navigation

Prior to this commit, certain entries had a double nested menu.

For example:

```
Operator Manual
\
 `- Rancher Fleet
    \
     `- Rancher Fleet (THE ACTUAL DOC IS SHOWN ONCE THIS IS CLICKED)
```

This applied to other pages as well, making the whole navigation experience a bit cumbersome (too many clicks).

The new sidebar removes this kind of nesting:

```
Operator Manual
\
 `- Rancher Fleet (THE ACTUAL DOC IS SHOWN ONCE THIS IS CLICKED)
```

## Configuring Policy Servers / Custom CA

Use a shorter name for the documentation about how to use custom CAs with Policy Server.

## Small tweaks to monitor mode docs

Apparently we though about writing multiple documents about the monitor     mode, but we never did. Because of that we had a dedicated folder with     just one single markdown file called "intro".
    
The current one seems good, hence we can get rid of this filesystem layout and, most important to the end user, pick a better name for the page.
    
Overall changes:

* Change the sidebar title to be more concise
* On the filesystem, get rid of the folder and have just one single     markdown file

