### PR TITLE
migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/docs/operator-manual/telemetry/opentelemetry/01-quickstart.md
+++ b/docs/operator-manual/telemetry/opentelemetry/01-quickstart.md
@@ -74,9 +74,9 @@ This will produce an output similar to the following one:
 
 ```console
 $ minikube addons enable ingress
-    ▪ Using image k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0
-    ▪ Using image k8s.gcr.io/ingress-nginx/controller:v1.0.0-beta.3
-    ▪ Using image k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0
+    ▪ Using image registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.0
+    ▪ Using image registry.k8s.io/ingress-nginx/controller:v1.0.0-beta.3
+    ▪ Using image registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.0
 🔎  Verifying ingress addon...
 🌟  The 'ingress' addon is enabled
 ```

--- a/docs/tasksDir/mutating-policies.md
+++ b/docs/tasksDir/mutating-policies.md
@@ -58,7 +58,7 @@ metadata:
 spec:
   containers:
     - name: pause
-      image: k8s.gcr.io/pause
+      image: registry.k8s.io/pause
 EOF
 
 # Output
@@ -124,7 +124,7 @@ metadata:
 spec:
   containers:
     - name: pause
-      image: k8s.gcr.io/pause
+      image: registry.k8s.io/pause
 EOF
 
 # Output


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix  https://github.com/kubernetes/k8s.io/issues/4780






## Additional Information
This PR migrate from k8s.gcr.io to registry.k8s.io


