### PR TITLE
feat: Tell users about automationg for `artifacthub-pkg.yml`

### DIFF
--- a/docs/distributing-policies/publish-policy-to-artifact-hub.md
+++ b/docs/distributing-policies/publish-policy-to-artifact-hub.md
@@ -56,8 +56,25 @@ the [website](https://artifacthub.io/).
 
 Before publishing the policy, ensure your Git repository has the proper layout.
 
-If you created the policy using one of our templates, ensure the `artifacthub-pkg.yml` file
-has correct data inside of it.
+If you created the policy using one of our templates, then you have a `make
+artifacthub-pkg.yml` target. Execute that target to generate the
+`artifacthub-pkg.yml` file programmatically from `metadata.yml` and other
+inputs.
+
+The `artifacthub-pkg.yml` contains fields such as `version: `, `createdAt: `,
+that need to match specific format, and be up-to-date. You can enable automated
+checking of the `artifacthub-pkg.yml` file in the provided GitHub workflows.
+Change the `artifacthhub` input variable to `true` in the test.yml workflow:
+
+```diff
+--- # .github/workflows/test.yml
+     name: run tests and linters
+     uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rego.yml@v1
+     with:
+-      artifacthub: false # change to true to check artifacthub-pkg.yml
++      artifacthub: true
+```
+
 The format of the `artifacthub-pkg.yml` is described [here](https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-pkg.yml).
 
 Finally, ensure your policy is published inside of a container registry or on a


### PR DESCRIPTION
## Description

Relates to https://github.com/kubewarden/kubewarden-controller/issues/389.

Tell users to execute `make artifacthub-pkg.yml`.
Tell users to activate checking of the file via the GHA workflow.

## Test

Tested in https://github.com/kubewarden/verify-image-signatures/pull/62.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
