### PR TITLE
fix: extend quickstart instructions

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -31,6 +31,8 @@ The Kubewarden stack can be deployed using `helm` charts as follows:
 ```console
 helm repo add kubewarden https://charts.kubewarden.io
 
+help repo update kubewarden
+
 helm install --wait -n kubewarden --create-namespace kubewarden-crds kubewarden/kubewarden-crds
 
 helm install --wait -n kubewarden kubewarden-controller kubewarden/kubewarden-controller


### PR DESCRIPTION
Ensure the kubewarden helm repo is always refreshed. If a user has already the repository added, he might end up installing an older version of kubewarden.
