### PR TITLE
Fix helm command typo

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -31,7 +31,7 @@ The Kubewarden stack can be deployed using `helm` charts as follows:
 ```console
 helm repo add kubewarden https://charts.kubewarden.io
 
-help repo update kubewarden
+helm repo update kubewarden
 
 helm install --wait -n kubewarden --create-namespace kubewarden-crds kubewarden/kubewarden-crds
 


### PR DESCRIPTION
## Description

Fix a typo in the Helm command used to refresh the Kubewarden repository

Fixing a typo that I've missed in #179 