### PR TITLE
Pass reference to ObjectMeta

### DIFF
--- a/docs/writing-policies/go/04-validation.md
+++ b/docs/writing-policies/go/04-validation.md
@@ -240,7 +240,7 @@ func TestValidateLabel(t *testing.T) {
 		}
 
 		pod := corev1.Pod{
-			Metadata: metav1.ObjectMeta{
+			Metadata: &metav1.ObjectMeta{
 				Name:      "test-pod",
 				Namespace: "default",
 				Labels:    testCase.podLabels,


### PR DESCRIPTION
Pod struct expects a pointer to ObjectMeta.

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #184 

<!-- Please provide the link to the documentation related to your change, if applicable -->
[Documentation](https://docs.kubewarden.io/writing-policies/go/validation)

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, run `make test` with and without the change.

```shell
make test
```

## Additional Information

### Tradeoff

None

### Potential improvement

Makes the docs easier to follow and lowers the bar to entry. 
