### PR TITLE
fix: telemetry is enabled only in the controller.

### DIFF
--- a/docs/operator-manual/telemetry/metrics/01-quickstart.md
+++ b/docs/operator-manual/telemetry/metrics/01-quickstart.md
@@ -63,7 +63,12 @@ inspect which Kubernetes Endpoints are tied to services matching this conditions
 then take care of generating a valid configuration file for Prometheus, and reloading it
 automatically after updating its configuration file.
 
-Install the Prometheus stack Helm Chart (version `40.5.0` at time of writing):
+Install the Prometheus stack Helm Chart :
+
+:::note
+At time of writing the latest chart version is `45.27.1`
+:::
+
 ```console
 helm install --wait --create-namespace \
   --namespace prometheus \
@@ -98,7 +103,7 @@ helm install --wait \
 Now we can deploy the rest of the Kubewarden stack. The official helm
 chart will create a PolicyServer named `default`.
 
-Let's configure the values of the Helm Chart so that we have metrics enabled 
+Let's configure the values of the Helm Chart so that we have metrics enabled
 in Kubewarden. Write the `kubewarden-values.yaml` file with the following contents:
 
 ```yaml
@@ -121,8 +126,7 @@ helm install --wait \
   --create-namespace \
   kubewarden-defaults kubewarden/kubewarden-defaults \
   --set recommendedPolicies.enabled=True \
-  --set recommendedPolicies.defaultPolicyMode=monitor \
-  --set policyServer.telemetry.enabled=True
+  --set recommendedPolicies.defaultPolicyMode=monitor
 ```
 
 This leads to the creation of the `default` instance of `PolicyServer`:
@@ -164,8 +168,8 @@ You can now login with the default username `admin` and password `prom-operator`
 
 The Kubewarden developers made available a Grafana dashboard with some basic metrics
 that give an overview about how Kubewarden behaves inside of cluster. This dashboard
-is available in the Kubewarden repository in a [JSON file](https://raw.githubusercontent.com/kubewarden/policy-server/main/kubewarden-dashboard.json) 
-or in the [Grafana website](https://grafana.com/grafana/dashboards/15314). 
+is available in the Kubewarden repository in a [JSON file](https://raw.githubusercontent.com/kubewarden/policy-server/main/kubewarden-dashboard.json)
+or in the [Grafana website](https://grafana.com/grafana/dashboards/15314).
 
 To import the dashboard into your environment, you can download the JSON file
 from the Grafana website or from the repository:
@@ -185,11 +189,11 @@ Visit `/dashboard/import` in the Grafana dashboard and follow these steps:
 
 Another option is import it directly from the Grafana.com website. For this:
 
-  1. Copy the dashboard ID from the [dashboard page](https://grafana.com/grafana/dashboards/15314), 
+  1. Copy the dashboard ID from the [dashboard page](https://grafana.com/grafana/dashboards/15314),
   2. Paste it in the `Import via grafana.com` field
   3. Click the `load` button.
   4. After importing the dashboard, define the Prometheus data source to use and finish
-the import process. 
+the import process.
 
 You should be able to see the dashboard similar to this:
 
@@ -199,7 +203,7 @@ You should be able to see the dashboard similar to this:
 ![Dashboard 4](/img/grafana_dashboard_4.png)
 
 
-The Grafana dashboard has panes showing the state of all 
+The Grafana dashboard has panes showing the state of all
 the policies managed by Kubewarden. Plus it has policy-specific panels.
 
 Policy detailed metrics can be obtained by changing the value of the `policy_name`

--- a/docs/operator-manual/telemetry/opentelemetry/01-quickstart.md
+++ b/docs/operator-manual/telemetry/opentelemetry/01-quickstart.md
@@ -93,7 +93,11 @@ to be installed inside of the cluster.
 At the time of writing, only specific versions of OpenTelemetry are compatible
 with Cert Manager, [see the compat chart](https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-operator-vs-kubernetes-vs-cert-manager).
 
-We will install the latest cert-manager Helm chart (`v1.9.1` at time of writing):
+We will install the latest cert-manager Helm chart:
+
+:::note
+At time of writing the latest cert-manager chart version is `v1.11.2`
+:::
 
 ```console
 helm repo add jetstack https://charts.jetstack.io
@@ -105,7 +109,11 @@ helm install --wait \
     cert-manager jetstack/cert-manager
 ```
 
-Once cert-manager is up and running, the OpenTelemetry operator Helm chart (`0.13.0` at time of writing) can be installed in this way:
+Once cert-manager is up and running, the OpenTelemetry operator Helm chart can be installed in this way:
+
+:::note
+At time of writing the latest OpenTelemetry chart version is `0.29.0`
+:::
 
 ```console
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/docs/operator-manual/telemetry/tracing/01-quickstart.md
+++ b/docs/operator-manual/telemetry/tracing/01-quickstart.md
@@ -28,7 +28,12 @@ to manage all the different Jaeger components. The operator can be installed in 
 At the time of writing, only specific versions of Jaeger are compatible with
 Cert Manager, [see the compat chart](https://github.com/jaegertracing/helm-charts/blob/main/charts/jaeger-operator/COMPATIBILITY.md).
 
-To install the Helm chart: (`v2.36.0` at time of writing)
+To install the Helm chart:
+
+:::note
+At time of writing the latest chart version is `2.43.0`
+
+:::
 
 ```console
 helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
@@ -130,7 +135,6 @@ helm install --wait --namespace kubewarden --create-namespace \
   kubewarden-controller kubewarden/kubewarden-controller
 
 helm install --wait --namespace kubewarden --create-namespace \
-  --set policyServer.telemetry.enabled=true \
   kubewarden-defaults kubewarden/kubewarden-defaults
 ```
 


### PR DESCRIPTION
## Description

Updates the telemetry documentation to reflect the latest changes in the controller where is not necessary to enable telemetry in the policy servers. Now the user just need to enable telemetry on the controller and it will configure policy server to has telemetry as well.

Related to https://github.com/kubewarden/kubewarden-controller/pull/442