### PR TITLE
Remove AdmissionPolicies from context aware docs

### DIFF
--- a/docs/writing-policies/spec/05-context-aware-policies.mdx
+++ b/docs/writing-policies/spec/05-context-aware-policies.mdx
@@ -32,7 +32,7 @@ That means some information might be stale or missing.
 
 ### ClusterAdmissionPolicies
 
-ClusterAdmissionPolicies have the field [spec.contextAwareResources](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller/policies.kubewarden.io/ClusterAdmissionPolicy/v1#spec-contextAwareResources). This field provides a list a `GroupVersionKind` resources that the policy needs to access. This allows policy writers to ship the "permissions" that the policy needs together with the policy. And allows policy operators to review the "permissions" needed by the policy at deployment time.
+ClusterAdmissionPolicies have the field [spec.contextAwareResources](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller/policies.kubewarden.io/ClusterAdmissionPolicy/v1#spec-contextAwareResources). This field provides a list a `GroupVersionKind` resources that the policy needs to access. This allows policy writers to ship the "permissions" that the policy needs together with the policy. Moreover, this allows policy operators to review the "permissions" needed by the policy at deployment time.
 
 ### Testing context aware policies locally
 

--- a/docs/writing-policies/spec/05-context-aware-policies.mdx
+++ b/docs/writing-policies/spec/05-context-aware-policies.mdx
@@ -30,9 +30,9 @@ The policy server performs caching of the results obtained from the Kubernetes A
 That means some information might be stale or missing.
 :::
 
-### ClusterAdmissionPolicies & AdmissionPolicies
+### ClusterAdmissionPolicies
 
-Both ClusterAdmissionPolicy & AdmissionPolicy CRD have the field [spec.contextAwareResources](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller/policies.kubewarden.io/ClusterAdmissionPolicy/v1#spec-contextAwareResources). This field provides a list a `GroupVersionKind` resources that the policy needs to access. This allows policy writers to ship the "permissions" that the policy needs together with the policy. And allows policy operators to review the "permissions" needed by the policy at deployment time.
+ClusterAdmissionPolicies have the field [spec.contextAwareResources](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller/policies.kubewarden.io/ClusterAdmissionPolicy/v1#spec-contextAwareResources). This field provides a list a `GroupVersionKind` resources that the policy needs to access. This allows policy writers to ship the "permissions" that the policy needs together with the policy. And allows policy operators to review the "permissions" needed by the policy at deployment time.
 
 ### Testing context aware policies locally
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
It seems that AdmissionPolicies lack `spec.ContextAwareResources`. Remove the notion to it in docs.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
