### PR TITLE
Update 07-build-and-distribute.md

### DIFF
--- a/docs/writing-policies/rust/07-build-and-distribute.md
+++ b/docs/writing-policies/rust/07-build-and-distribute.md
@@ -14,7 +14,7 @@ file.
 This can be done with a simple command:
 
 ```shell
-make build
+make policy.wasm
 ```
 
 This command will build the code in release mode, with WebAssembly as


### PR DESCRIPTION
This PR merely updates the `make` command in `07-build-and-distribute.md` to more closely resemble the structure of [rust-policy-template](https://github.com/kubewarden/rust-policy-template/) in order to prevent confusion.

When looking at [the Makefile of rust-policy-template](https://github.com/kubewarden/rust-policy-template/blob/main/Makefile), it quickly becomes apparent that the `build` target was removed quite a while ago.
