### PR TITLE
Fixes Gatekeeper distribute example command

### DIFF
--- a/docs/writing-policies/rego/gatekeeper/04-distribute.md
+++ b/docs/writing-policies/rego/gatekeeper/04-distribute.md
@@ -68,7 +68,7 @@ pulling policy...
 We can now create a scaffold `ClusterAdmissionPolicy` resource:
 
 ```console
-$ kwctl manifest registry://registry.my-company.com/kubewarden/no-default-namespace-gatekeeper:v0.0.1 --type ClusterAdmissionPolicy
+$ kwctl scaffold manifest registry://registry.my-company.com/kubewarden/no-default-namespace-gatekeeper:v0.0.1 --type ClusterAdmissionPolicy
 ---
 apiVersion: policies.kubewarden.io/v1alpha2
 kind: ClusterAdmissionPolicy


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
It seems that `kwctl manifest` is no longer a valid command and from what I could tell, we should use instead `kwctl scaffold manifest`

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
https://deploy-preview-197--silly-bunny-8cedd0.netlify.app/writing-policies/rego/gatekeeper/distribute#deploying-on-kubernetes

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
