### PR TITLE
Best to use sentence style capitalization.

### DIFF
--- a/docs/tasksDir/mutating-policies.md
+++ b/docs/tasksDir/mutating-policies.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: "Mutating Policies"
+sidebar_label: "Mutating policies"
 title: "Mutating policies"
 description: Explains mutating policies in the context of Kubewarden
 keywords: [kubewarden policy mutating kubernetes clusteradmissionpolicy admissionpolicy]


### PR DESCRIPTION
So, 'Mutating policies', not 'Mutating Policies' in headings and text.