### PR TITLE
Testing policies. Review and refresh.

### DIFF
--- a/docs/testing-policies/01-intro.md
+++ b/docs/testing-policies/01-intro.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: "Policy testing personas"
+sidebar_label: "Policy testers"
 title: "Policy testing personas"
 description: The two personas using Kubewarden policies are policy authors and cluster operators.
 keywords: [kubewarden, persons, policy author, cluster operator]

--- a/docs/testing-policies/01-intro.md
+++ b/docs/testing-policies/01-intro.md
@@ -1,9 +1,11 @@
 ---
-sidebar_label: "Policy testers"
-title: "Policy testing personas"
+sidebar_label: "Policy testing"
+title: "Policy testing"
 description: The two personas using Kubewarden policies are policy authors and cluster operators.
 keywords: [kubewarden, persons, policy author, cluster operator]
 ---
+
+## Policy testing personas
 
 This section covers the topic of testing Kubewarden Policies.
 We define two personas interested in testing policies:

--- a/docs/testing-policies/01-intro.md
+++ b/docs/testing-policies/01-intro.md
@@ -1,18 +1,16 @@
 ---
-sidebar_label: "Testing Policies"
-title: ""
+sidebar_label: "Policy testing personas"
+title: "Policy testing personas"
+description: The two personas using Kubewarden policies are policy authors and cluster operators.
+keywords: [kubewarden, persons, policy author, cluster operator]
 ---
 
-# Testing Policies
+This section covers the topic of testing Kubewarden Policies.
+We define two personas interested in testing policies:
 
-This section covers the topic of testing Kubewarden Policies. There are two possible
-personas interested in testing policies:
+- **policy author**: you're writing a Kubewarden Policy and you want to ensure your code behaves the way you expect.
 
-  * As a policy author: you're writing a Kubewarden Policy and you want to ensure
-    your code behaves the way you expect.
-  * As an end user: you found a Kubewarden Policy and you want to tune/test the policy
-    settings before deploying it, maybe you want to keep testing these settings
-    inside of your CI/CD pipelines,...
+- **cluster operator**: you found a Kubewarden Policy and you want to test and tune the policy settings before deploying it.
+Maybe you want to keep testing these settings inside of your CI/CD pipelines,...
 
-The next sections of the documentation will show how Kubewarden policies can
-be tested by these two personas.
+The next sections of the documentation shows how Kubewarden policies might be tested by these personas.

--- a/docs/testing-policies/02-policy-authors.md
+++ b/docs/testing-policies/02-policy-authors.md
@@ -8,20 +8,20 @@ keywords: [kubewarden, policy testing, policy author, rust, go, assemblyscript, 
 Kubewarden policies are regular programs compiled as WebAssembly (Wasm).
 As with any kind of program, good test coverage is important.
 
-Policy authors can use their favorite development environments, tools and, testing frameworks to verify their development.
+Policy authors can use their favorite development environments. You can use familiar tools, and testing frameworks to verify development.
 
 These two Kubewarden policies provide an example written in [Rust](/writing-policies/rust/01-intro-rust.md) and [Go](/writing-policies/go/01-intro-go.md):
 
 - [psp-apparmor](https://github.com/kubewarden/psp-apparmor)
 - [ingress-policy](https://github.com/kubewarden/ingress-policy)
 
-These policies have integrated test suites using the regular testing libraries of their development environments.
+They both have test suites using standard testing for their development environments.
 
-Also, the projects that develop these policies use GitHub Actions to implement their CI pipelines.
+The policies use GitHub Actions for their CI pipelines.
 
 ## End-to-end tests
 
-Policy authors can also write tests that are executed against the actual Wasm binary containing your policy.
+You can also write tests that execute against the Wasm binary containing your policy.
 This can be done without having to deploy a Kubernetes cluster by using these tools:
 
 - [bats](https://github.com/bats-core/bats-core): is used to write tests and automate their execution.
@@ -30,17 +30,16 @@ This can be done without having to deploy a Kubernetes cluster by using these to
 To use `kwctl run` the following input is needed:
 
 1. Wasm binary file reference of the policy to be run.
-The Kubewarden policy can be loaded from the local filesystem (`file://`), an HTTP(s) server (`https://`) or an OCI registry (`registry://`).
-1. The admission request object to be evaluated.
-This is provided via the `--request-path` argument.
-The request can be provided on `stdin` by setting `--request-path` to `-`.
-1. The policy settings to be used at evaluation time, can be provided as an inline JSON via `--settings-json` flag.
+The Kubewarden policy can be loaded from the local filesystem (`file://`), an HTTP(s) server (`https://`), or an OCI registry (`registry://`).
+1. The admission request object to be tested.
+You provide it via the `--request-path` argument.
+Or you can provide it on `stdin` by setting `--request-path` to `-`.
+1. Provide policy settings for run time as an inline JSON via `--settings-json` flag.
 Or a JSON, or a YAML file loaded from the filesystem via `--settings-path`.
 
-Once the policy evaluation is done, `kwctl` prints the `ValidationResponse` object to the standard output.
+After the test `kwctl` prints the `ValidationResponse` object to standard output.
 
-For example, this is how `kwctl` can be used to test the Wasm
-binary of the `ingress-policy` linked above:
+This is how you use `kwctl` to test the Wasm binary of `ingress-policy` linked to above:
 
 ```
 $ curl https://raw.githubusercontent.com/kubewarden/ingress-policy/v0.1.8/test_data/ingress-wildcard.json 2> /dev/null | \

--- a/docs/testing-policies/02-policy-authors.md
+++ b/docs/testing-policies/02-policy-authors.md
@@ -51,6 +51,10 @@ $ curl https://raw.githubusercontent.com/kubewarden/ingress-policy/v0.1.8/test_d
 
 Using `bats` you can write a test that runs this command and looks for the expected outputs:
 
+<details>
+
+<summary>A <code>bats</code> test</summary>
+
 ```bash
 @test "all is good" {
   run kwctl run \
@@ -68,6 +72,8 @@ Using `bats` you can write a test that runs this command and looks for the expec
   [[ "$output" == *"allowed: true"* ]]
 }
 ```
+
+</details>
 
 You can put the code in a file, `e2e.bats`, for example, and then invoke `bats` by:
 

--- a/docs/testing-policies/02-policy-authors.md
+++ b/docs/testing-policies/02-policy-authors.md
@@ -10,11 +10,10 @@ As with any kind of program, good test coverage is important.
 
 Policy authors can use their favorite development environments, tools and, testing frameworks to verify their development.
 
-These three Kubewarden policies provide an example written in each of [Rust](/writing-policies/rust/01-intro-rust.md), [Go](/writing-policies/go/01-intro-go.md) and [AssemblyScript](https://www.assemblyscript.org/) respectively:
+These two Kubewarden policies provide an example written in [Rust](/writing-policies/rust/01-intro-rust.md) and [Go](/writing-policies/go/01-intro-go.md):
 
 - [psp-apparmor](https://github.com/kubewarden/psp-apparmor)
 - [ingress-policy](https://github.com/kubewarden/ingress-policy)
-- [pod-privileged-policy](https://github.com/kubewarden/pod-privileged-policy)
 
 These policies have integrated test suites using the regular testing libraries of their development environments.
 

--- a/docs/testing-policies/02-policy-authors.md
+++ b/docs/testing-policies/02-policy-authors.md
@@ -1,60 +1,46 @@
 ---
-sidebar_label: "Policy Authors"
-title: ""
+sidebar_label: "Policy authors"
+title: "Testing for policy authors"
+description: An introduction to testing Kubewarden policies for policy authors.
+keywords: [kubewarden, policy testing, policy author, rust, go, assemblyscript, development environment]
 ---
 
-# While creating a policy
+Kubewarden policies are regular programs compiled as WebAssembly (Wasm).
+As with any kind of program, good test coverage is important.
 
-Kubewarden Policies are regular programs compiled as WebAssembly. As with any kind
-of program, it's important to have good test coverage.
+Policy authors can use their favorite development environments, tools and, testing frameworks to verify their development.
 
-Policy authors can leverage the testing frameworks and tools of their language
-of choice to verify the behaviour of their policies.
+These three Kubewarden policies provide an example written in each of [Rust](/writing-policies/rust/01-intro-rust.md), [Go](/writing-policies/go/01-intro-go.md) and [AssemblyScript](https://www.assemblyscript.org/) respectively:
 
-As an example, you can take a look at these Kubewarden policies:
+- [psp-apparmor](https://github.com/kubewarden/psp-apparmor)
+- [ingress-policy](https://github.com/kubewarden/ingress-policy)
+- [pod-privileged-policy](https://github.com/kubewarden/pod-privileged-policy)
 
-* [psp-apparmor](https://github.com/kubewarden/psp-apparmor): this
-  is a Kubewarden Policy written using [Rust](/writing-policies/rust/01-intro-rust.md).
-* [ingress-policy](https://github.com/kubewarden/ingress-policy): this is
-  a Kubewarden Policy written using [Go](/writing-policies/go/01-intro-go.md).
-* [pod-privileged-policy](https://github.com/kubewarden/pod-privileged-policy): this
-  is a Kubewarden Policy written using [AssemblyScript](https://www.assemblyscript.org/).
+These policies have integrated test suites using the regular testing libraries of their development environments.
 
-All these policies have integrated test suites built using the regular testing libraries
-of Rust, Go and AssemblyScript.
-
-Finally, all these projects rely on GitHub Actions to implement their CI pipelines.
+Also, the projects that develop these policies use GitHub Actions to implement their CI pipelines.
 
 ## End-to-end tests
 
-As a policy author you can also write tests that are executed against the actual
-WebAssembly binary containing your policy. This can be done without having
-to deploy a Kubernetes cluster by using these tools:
+Policy authors can also write tests that are executed against the actual Wasm binary containing your policy.
+This can be done without having to deploy a Kubernetes cluster by using these tools:
 
-* [bats](https://github.com/bats-core/bats-core): used to write the
-  tests and automate their execution.
-* [kwctl](https://github.com/kubewarden/kwctl): Kubewarden go-to CLI
-  tool that helps you with policy related operations such as pull,
-  inspect, annotate, push and run.
+- [bats](https://github.com/bats-core/bats-core): is used to write tests and automate their execution.
+- [kwctl](https://github.com/kubewarden/kwctl): Kubewarden's default CLI tool that helps you with policy-related operations; pull, inspect, annotate, push, and run.
 
-`kwctl run` usage is quite simple, we just have to invoke it with the
-following data as input:
+To use `kwctl run` the following input is needed:
 
-1. WebAssembly binary file reference of the policy to be run. The
-   Kubewarden policy can be loaded from the local filesystem
-   (`file://`), an HTTP(s) server (`https://`) or an OCI registry
-   (`registry://`).
-1. The admission request object to be evaluated.  This is provided via
-  the `--request-path` argument. The request can be provided through
-  `stdin` by setting `--request-path` to `-`.
-1. The policy settings to be used at evaluation time, they can be
-  provided as an inline JSON via `--settings-json` flag, or a JSON or
-  YAML file loaded from the filesystem via `--settings-path`.
+1. Wasm binary file reference of the policy to be run.
+The Kubewarden policy can be loaded from the local filesystem (`file://`), an HTTP(s) server (`https://`) or an OCI registry (`registry://`).
+1. The admission request object to be evaluated.
+This is provided via the `--request-path` argument.
+The request can be provided on `stdin` by setting `--request-path` to `-`.
+1. The policy settings to be used at evaluation time, can be provided as an inline JSON via `--settings-json` flag.
+Or a JSON, or a YAML file loaded from the filesystem via `--settings-path`.
 
-Once the policy evaluation is done, `kwctl` prints the
-`ValidationResponse` object to the standard output.
+Once the policy evaluation is done, `kwctl` prints the `ValidationResponse` object to the standard output.
 
-For example, this is how `kwctl` can be used to test the WebAssembly
+For example, this is how `kwctl` can be used to test the Wasm
 binary of the `ingress-policy` linked above:
 
 ```
@@ -65,8 +51,7 @@ $ curl https://raw.githubusercontent.com/kubewarden/ingress-policy/v0.1.8/test_d
         registry://ghcr.io/kubewarden/policies/ingress:v0.1.8 | jq
 ```
 
-Using `bats` we can can write a test that runs this command and looks for the
-expected outputs:
+Using `bats` you can write a test that runs this command and looks for the expected outputs:
 
 ```bash
 @test "all is good" {
@@ -86,8 +71,7 @@ expected outputs:
 }
 ```
 
-We can copy the snippet from above inside of a file called `e2e.bats`,
-and then invoke `bats` in this way:
+You can put the code in a file, `e2e.bats`, for example, and then invoke `bats` by:
 
 ```
 $ bats e2e.bats
@@ -96,6 +80,4 @@ $ bats e2e.bats
 1 tests, 0 failures
 ```
 
-Checkout [this section](/writing-policies/go/05-e2e-tests.md)
-of the documentation to learn more about writing end-to-end
-tests of your policies.
+[This](/writing-policies/go/05-e2e-tests.md) section of the documentation has more about writing end-to-end tests of your policies.

--- a/docs/testing-policies/03-cluster-operators.md
+++ b/docs/testing-policies/03-cluster-operators.md
@@ -22,11 +22,11 @@ To use `kwctl` we invoke it with following inputs:
 1. A WebAssembly binary file URI of the policy to be run.
 The Kubewarden policy can be loaded from the local filesystem `file://`, an HTTP(s) server `https://`, or an OCI registry `registry://`.
 1. The admission request object to be evaluated.
-This is provided via the `--request-path` argument.
+You provide it with the `--request-path` argument.
 Use `stdin` by setting `--request-path` to `-`.
-1. Policy settings to be used at evaluation time can be provided as an inline JSON via `--settings-json` flag, or a JSON or YAML file loaded from the filesystem using `--settings-path`.
+1. You provide run time policy settings as inline JSON via `--settings-json` flag. Or with a JSON or YAML file from the filesystem using `--settings-path`.
 
-Once the policy evaluation is done, `kwctl` prints the `ValidationResponse` object to the standard output.
+After the test `kwctl` prints the `ValidationResponse` object to the standard output.
 
 You can download pre-built binaries of `kwctl` from [here](https://github.com/kubewarden/kwctl/releases).
 
@@ -36,8 +36,7 @@ This section describes how to test the [psp-apparmor](https://github.com/kubewar
 
 ### Create `AdmissionReview` requests
 
-We have to create some files holding the `AdmissionReview` objects
-that will be evaluated by the policy.
+We have to create files holding the `AdmissionReview` objects to test the policy.
 
 You can create a file named `pod-req-no-specific-apparmor-profile.json` with the following contents:
 
@@ -168,7 +167,7 @@ Now you can create a file named `pod-req-apparmor-custom.json` with the followin
 
 :::note
 These are all simplified `AdmissionReview` objects.
-We left only the fields relevant to our testing of the policy.
+We have only the fields relevant to our testing of the policy.
 :::
 
 ### Test the policy
@@ -182,7 +181,7 @@ $ kwctl run \
     | jq
 ```
 
-The policy will accept the request and produce output similar to:
+The policy will accept the request and produce output like:
 
 ```console
 {
@@ -226,7 +225,7 @@ $ kwctl run \
 }
 ```
 
-We can change the default behavior and allow some chosen AppArmor to be used:
+You can change the default behavior, allowing some chosen AppArmor to be used:
 
 ```console
 $ kwctl run \
@@ -236,7 +235,7 @@ $ kwctl run \
     | jq
 ```
 
-This time the request is accepted:
+Now the request succeeds:
 
 ```console
 {
@@ -247,7 +246,7 @@ This time the request is accepted:
 
 ## Automation
 
-All these steps shown above can be automated using [bats](https://github.com/bats-core/bats-core).
+All these steps, shown above, can be automated using [bats](https://github.com/bats-core/bats-core).
 
 You can write a series of tests and integrate their execution inside your existing CI and CD pipelines.
 

--- a/docs/testing-policies/03-cluster-operators.md
+++ b/docs/testing-policies/03-cluster-operators.md
@@ -295,4 +295,4 @@ $ bats e2e.bats
 2 tests, 0 failures
 ```
 
-[This](/writing-policies/go/05-e2e-tests.md) section has more about writing end-to-end tests of your policies.
+[This](/writing-policies/go/05-e2e-tests.md) section has more about writing end-to-end tests for your policies.

--- a/sidebars.js
+++ b/sidebars.js
@@ -100,9 +100,10 @@ module.exports = {
           ]
         },
         {
-          'Testing policies':
-          [
-            'testing-policies/intro',
+          type: 'category',
+          label: 'Testing policies',
+          link: {type: 'doc', id: 'testing-policies/intro'},
+          items: [
             'testing-policies/policy-authors',
             'testing-policies/cluster-operators',
           ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -99,6 +99,14 @@ module.exports = {
             }
           ]
         },
+        {
+          'Testing policies':
+          [
+            'testing-policies/intro',
+            'testing-policies/policy-authors',
+            'testing-policies/cluster-operators',
+          ],
+        },
         'distributing-policies/publish-policy-to-artifact-hub',
         'security/verifying-kubewarden',
       ],
@@ -110,14 +118,7 @@ module.exports = {
       items: [
         'tasksDir/mutating-policies',
         'distributing-policies',
-        {
-          'Policies Testing roles':
-          [
-            'testing-policies/policy-authors',
-            'testing-policies/cluster-operators',
-          ],
-        },
-	"explanations/context-aware-policies"
+        "explanations/context-aware-policies"
       ],
       collapsed: true,
     },


### PR DESCRIPTION
Part one, restructure and move to be immediately after 'Writing policies'. More logical placing than under Explanations.

