### PR TITLE
docs: update telemetry guide

### DIFF
--- a/docs/operator-manual/telemetry/metrics/01-quickstart.md
+++ b/docs/operator-manual/telemetry/metrics/01-quickstart.md
@@ -51,6 +51,16 @@ prometheus:
       endpoints:
         - port: metrics
           interval: 10s
+    - name: kubewarden-controller
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: kubewarden-controller
+      namespaceSelector:
+        matchNames:
+          - kubewarden
+      endpoints:
+        - port: metrics
+          interval: 10s
 ```
 
 The `prometheus-operator` deployed as part of this Helm chart defines the concept of [Service
@@ -58,15 +68,15 @@ Monitors](https://github.com/prometheus-operator/prometheus-operator/blob/master
 used to declaratively define which services should be monitored by Prometheus.
 
 In our case, we are adding a Service monitor targeting the `kubewarden` namespace, for services that
-match labels `app=kubewarden-policy-server-default`. This way, the Prometheus Operator is able to
-inspect which Kubernetes Endpoints are tied to services matching this conditions. The operator will
-then take care of generating a valid configuration file for Prometheus, and reloading it
+match labels `app=kubewarden-policy-server-default` and `app.kubernetes.io/name: kubewarden-controller`.
+This way, the Prometheus Operator is able to inspect which Kubernetes Endpoints are tied to services matching this conditions.
+The operator will then take care of generating a valid configuration file for Prometheus, and reloading it
 automatically after updating its configuration file.
 
 Install the Prometheus stack Helm Chart :
 
 :::note
-At time of writing the latest chart version is `45.27.1`
+At time of writing the latest chart version is `51.0.2`
 :::
 
 ```console
@@ -182,18 +192,18 @@ Once you have the file in your machine you should access the Grafana dashboard a
 [import it](https://grafana.com/docs/grafana/latest/dashboards/export-import/#import-dashboard).
 Visit `/dashboard/import` in the Grafana dashboard and follow these steps:
 
-  1. Copy the JSON file contents and paste them into the `Import via panel json` box in the Grafana UI
-  2. Click the `Load` button
-  3. Choosing `Prometheus` as the source
-  4. Click the `Import` button
+1. Copy the JSON file contents and paste them into the `Import via panel json` box in the Grafana UI
+2. Click the `Load` button
+3. Choosing `Prometheus` as the source
+4. Click the `Import` button
 
 Another option is import it directly from the Grafana.com website. For this:
 
-  1. Copy the dashboard ID from the [dashboard page](https://grafana.com/grafana/dashboards/15314),
-  2. Paste it in the `Import via grafana.com` field
-  3. Click the `load` button.
-  4. After importing the dashboard, define the Prometheus data source to use and finish
-the import process.
+1. Copy the dashboard ID from the [dashboard page](https://grafana.com/grafana/dashboards/15314),
+2. Paste it in the `Import via grafana.com` field
+3. Click the `load` button.
+4. After importing the dashboard, define the Prometheus data source to use and finish
+   the import process.
 
 You should be able to see the dashboard similar to this:
 
@@ -202,10 +212,8 @@ You should be able to see the dashboard similar to this:
 ![Dashboard 3](/img/grafana_dashboard_3.png)
 ![Dashboard 4](/img/grafana_dashboard_4.png)
 
-
 The Grafana dashboard has panes showing the state of all
 the policies managed by Kubewarden. Plus it has policy-specific panels.
 
 Policy detailed metrics can be obtained by changing the value of the `policy_name`
 variable to match the name of the desired policy.
-

--- a/docs/operator-manual/telemetry/opentelemetry/01-quickstart.md
+++ b/docs/operator-manual/telemetry/opentelemetry/01-quickstart.md
@@ -16,8 +16,8 @@ By following this documentation, we will integrate OpenTelemetry using the follo
 - Each Pod of the Kubewarden stack will have a OpenTelemetry sidecar.
 - The sidecar receives tracing and monitoring information from the Kubewarden component via the OpenTelemetry Protocol (OTLP)
 - The OpenTelemetry collector will:
-    - Send the trace events to a central Jaeger instance
-    - Expose Prometheus metrics on a specific port
+  - Send the trace events to a central Jaeger instance
+  - Expose Prometheus metrics on a specific port
 
 For more information about the other deployment modes, please refer to the [OpenTelemetry official
 documentation](https://opentelemetry.io/docs/).
@@ -96,7 +96,7 @@ with Cert Manager, [see the compat chart](https://github.com/open-telemetry/open
 We will install the latest cert-manager Helm chart:
 
 :::note
-At time of writing the latest cert-manager chart version is `v1.11.2`
+At time of writing the latest cert-manager chart version is `v1.13.0`
 :::
 
 ```console
@@ -112,7 +112,7 @@ helm install --wait \
 Once cert-manager is up and running, the OpenTelemetry operator Helm chart can be installed in this way:
 
 :::note
-At time of writing the latest OpenTelemetry chart version is `0.29.0`
+At time of writing the latest OpenTelemetry operator chart version is `0.37.0`
 :::
 
 ```console

--- a/docs/operator-manual/telemetry/tracing/01-quickstart.md
+++ b/docs/operator-manual/telemetry/tracing/01-quickstart.md
@@ -31,7 +31,7 @@ Cert Manager, [see the compat chart](https://github.com/jaegertracing/helm-chart
 To install the Helm chart:
 
 :::note
-At time of writing the latest chart version is `2.43.0`
+At time of writing the latest chart version is `2.46.2`
 
 :::
 
@@ -105,7 +105,7 @@ Now we can deploy the rest of the Kubewarden stack. The official
 want this PolicyServer instance to have tracing enabled.
 
 In order to do that, we have to specify some extra values for the
-`kubewarden-controller` chart.  Let's create a `values.yaml` file with the
+`kubewarden-controller` chart. Let's create a `values.yaml` file with the
 following contents:
 
 ```yaml


### PR DESCRIPTION
## Description
Update the telemetry guide with the latest chart version, 

Add Kubewarden controller Prometheus configuration that was missing even if we were referring to metrics exported by the controller in the guide.
