### PR TITLE
remove uninitialized git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/projects-theme"]
-	path = themes/projects-theme
-	url = https://github.com/rancherlabs/projects-theme.git


### PR DESCRIPTION
## Description

Remove uninitialized Git submodule.

My feeling is that this submodule was just added manually instead of running `git submodule add https://github.com/kubewarden/docs/blob/main/.gitmodules themes/projects-theme`

The problem that I am facing is while working on an update policy for this repository, Updatecli fails cloning this repository because it doesn't know how to clone the submodule

While running command such as `git submodule status`, I see nothing neither so 🤷🏾 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Current theme shouldn't be affected by removing this file so the preview environment should look like exactly [kubewarden](https://docs.kubewarden.io/).

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
