### PR TITLE
chore: automate docusaurus versioning based on published Kubewarden version

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,0 +1,42 @@
+---
+name: "Updatecli: Dependency Management"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 * * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      #   cache: yarn
+
+      #  https://github.com/actions/setup-node/issues/490
+      - name: Repair NPM  # Update to latest npm and yarn
+        run: "npm install -g npm yarn"
+
+      - name: Install Dependencies
+        run: "yarn install --frozen-lockfile"
+
+      - name: Install Updatecli Binary
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli in enforce mode
+        run: "updatecli compose apply --experimental"
+        env:
+          UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
-      #   cache: yarn
+          node-version: 20.x
 
       #  https://github.com/actions/setup-node/issues/490
       - name: Repair NPM  # Update to latest npm and yarn

--- a/update-compose.yaml
+++ b/update-compose.yaml
@@ -1,0 +1,9 @@
+policies:
+  # The following policy is designed to work from GitHub action workflows.
+  # This means that before running any Updatecli command, we need the two following environment variables set:
+  # 
+  #   GITHUB_TOKEN: Set to a personal access token
+  #   GITHUB_ACTOR: Set to the username associated with the GITHUB_TOKEN
+  # 
+  # Instruction to retrieve your PAT is documented on https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+  - policy: ghcr.io/olblak/policies/rancher/docusaurus/kubewarden:latest

--- a/update-compose.yaml
+++ b/update-compose.yaml
@@ -6,4 +6,4 @@ policies:
   #   GITHUB_ACTOR: Set to the username associated with the GITHUB_TOKEN
   # 
   # Instruction to retrieve your PAT is documented on https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
-  - policy: ghcr.io/olblak/policies/rancher/docusaurus/kubewarden:latest
+  - policy: ghcr.io/olblak/policies/rancher/docusaurus/kubewarden:0.0.3


### PR DESCRIPTION
This pull request adds a new GitHub action workflow that execute Updatecli every hours.
At the moment we execute only one Updatecli policy defined on  [olblak/updatecli-policy-docusaurus](https://github.com/olblak/updatecli-policy-docusaurus)

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:


```shell
export GITHUB_ACTOR="your GitHub username"
export GITHUB_TOKEN="your GitHub PAT"
updatecli compose diff --experimental
```

<details><summary>Local command execution</summary>

```
Experimental Mode Enabled
Pulling Updatecli policy "ghcr.io/olblak/policies/rancher/docusaurus/kubewarden:latest"


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "/tmp/updatecli/store/d1df02c09193500c8b2497c9ff2ce046f5eac2420f941e6c3c2a35b073cea431/updatecli.d/docusaurus.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



###########################################
# BUMP KUBEWARDEN VERSION IN DOCUMENTATON #
###########################################


SOURCES
=======

version
-------
Searching for version matching pattern ">0.1"
✔ GitHub release version "v1.8.0" found matching pattern ">0.1" of kind "semver"


CHANGELOG:
----------

Release published on the 2023-10-13 15:48:55 +0000 UTC at the url https://github.com/kubewarden/kubewarden-controller/releases/tag/v1.8.0

- docs: Reformat CRD docstrings for automation into main docs site (#557)



CONDITIONS:
===========

yarn
----
The shell 🐚 command "/bin/sh /tmp/updatecli/bin/eedea9fcd61a45e7127d529fa34b4b3437c3a0673d116ec168c6eda5263db2c7.sh" ran successfully with the following output:
----
----
✔ shell condition of type "exitcode", passing


TARGETS
========

docusaurus
----------

**Dry Run enabled**

The shell 🐚 command "/bin/sh /tmp/updatecli/bin/aff4b4f0ec40b65946174fe88ff07364fe3e666d81b111c0dd8a550bf66f20a5.sh" ran successfully with the following output:
----
----
No change detected
✔ - ran shell command "#!/bin/sh\n# Testing that we can run yarn command from the GitHub Runner\nyarn --help > /dev/null\nVERSION='1.8'\nif [ -z \"$VERSION\" ]\nthen\n  echo \"Empty version provided\"\nfi\nif [ ! -d \"versioned_docs/version-$VERSION\" ]\nthen\n  # DRY_RUN is the environment variable used by Updatecli\n  # to know if Updatecli is execute in DRY_RUN mode or APPLY mode\n  if test \"$DRY_RUN\" == \"true\"\n  then\n    echo \"**DRY_RUN** new version $VERSION will be created\"\n  exit 0\n  fi\n  # Install dependencies to tmp directory\n  yarn install --frozen-lockfile\n  yarn run docusaurus docs:version \"$VERSION\"\nfi\n"


ACTIONS
========



REPORT
=======


=============================

REPORTS:



✔ Bump Kubewarden version in documentaton:
	Source:
		✔ [version] Get latest Kubewarden version
	Condition:
		✔ [yarn] Check if yarn is installed
	Target:
		✔ [docusaurus] Set latest docusaurus version


Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	0
  * Skipped:	0
  * Succeeded:	1
  * Total:	1
```
</details>

## Additional Information

### Tradeoff

Updatecli policy stored on ghcr.io is a very new feature (last week), and while the goal is to make it easier to maintain them over time , I am still expecting minor modification in the coming weeks as I learn it.

Also I am still in the process to decide where and how to manage those policies.

### Potential improvement

* Similarly to Epinio, we could leverage a custom release event using [peter-evans/repository-dispatch](https://github.com/peter-evans/repository-dispatch) to trigger Updatecli as soon as a new Kubewarden controller is released
