### PR TITLE
deps: update nodejs to 20.x in GitHub action workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Docusaurus
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: yarn
       - name: Build website
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Docusaurus
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: yarn
       - name: Build website
         run: |


### PR DESCRIPTION
## Description

Node 16 is out of maintenance.

## Test

Let's hope that the website still build :) 

## Additional Information

### Tradeoff

/

### Potential improvement

/