### PR TITLE
Configure GITHUB_TOKEN for Updatecli workflow

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -37,5 +37,5 @@ jobs:
       - name: Run Updatecli in enforce mode
         run: "updatecli compose apply --experimental"
         env:
-          UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I thought the GITHUB_TOKEN was already available by default....