### PR TITLE
Update update-compose.yaml with docusaurus policy to 0.0.5

### DIFF
--- a/update-compose.yaml
+++ b/update-compose.yaml
@@ -6,4 +6,4 @@ policies:
   #   GITHUB_ACTOR: Set to the username associated with the GITHUB_TOKEN
   # 
   # Instruction to retrieve your PAT is documented on https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
-  - policy: ghcr.io/olblak/policies/rancher/docusaurus/kubewarden:0.0.3
+  - policy: ghcr.io/olblak/policies/rancher/docusaurus/kubewarden:0.0.5


### PR DESCRIPTION
The policy version 0.0.5 allows to automate its own versioning update.

<details>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "policy/updatecli.d/update-compose-policy.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



#######################################
# CI: UPDATE DOCUSAURUS UPDATE POLICY #
#######################################


SOURCES
=======

tag
---
Searching for version matching pattern "latest"
✔ Docker Image Tag "0.0.5" found matching pattern "latest"

digest
------
✔ Docker Image Tag ghcr.io/olblak/policies/rancher/docusaurus/kubewarden:0.0.5 resolved to digest ghcr.io/olblak/policies/rancher/docusaurus/kubewarden:0.0.5@sha256:81488900553174be2348b859f88f35c6ff0a6cab7342d8d4142bfec372fddb95


TARGETS
========

compose
-------

**Dry Run enabled**

"update-compose.yaml" updated with [dry run] content "${1}0.0.5@sha256:81488900553174be2348b859f88f35c6ff0a6cab7342d8d4142bfec372fddb95"

--- update-compose.yaml
+++ update-compose.yaml
@@ -6,4 +6,4 @@
   #   GITHUB_ACTOR: Set to the username associated with the GITHUB_TOKEN
   # 
   # Instruction to retrieve your PAT is documented on https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
-  - policy: ghcr.io/olblak/policies/rancher/docusaurus/kubewarden:0.0.3
+  - policy: ghcr.io/olblak/policies/rancher/docusaurus/kubewarden:0.0.5@sha256:81488900553174be2348b859f88f35c6ff0a6cab7342d8d4142bfec372fddb95

⚠ - 1 file(s) updated with "${1}0.0.5@sha256:81488900553174be2348b859f88f35c6ff0a6cab7342d8d4142bfec372fddb95":
	* update-compose.yaml


ACTIONS
========

[Dry Run] An action of kind "github/pullrequest" is expected.

=============================

REPORTS:



⚠ ci: update docusaurus update policy:
	Source:
		✔ [digest] Get latest docusaurus policy digest
		✔ [tag] Get latest docusaurus policy version
	Target:
		⚠ [compose] ci: bump docusaurus versioning policy to latest digest based on 0.0.5


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1

```

</details>