### PR TITLE
docs: add raw policies documentation

### DIFF
--- a/docs/howtos/raw-policies.md
+++ b/docs/howtos/raw-policies.md
@@ -80,7 +80,10 @@ Raw policies can access context-aware[ capabilities](../explanations/context-awa
 
 ## Running a Policy Server inside Kubernetes without the Kubewarden controller
 
-Alternatively, the Policy Server can be deployed in Kubernetes without the Kubewarden controller.
+It's not possible to use a Policy Server instance managed by the Kubewarden controller to host raw policies.
+The controller will not allow the user to change the Policy Server ConfigMap to add a raw policy,
+since it will try to reconcile it reverting the changes.
+Because of that, a dedicated Policy Server has to be started.
 
 Create a `policy-server.yaml` file with the following content:
 
@@ -163,12 +166,14 @@ Apply the configuration:
 ```bash
 kubectl apply -f policy-server.yaml
 ```
+
 :::info
 The Policy Server instance deployed will have access to Kubernetes resources that could be leveraged by context aware policies.
-The access level to the Kubernetes resources is determined by the Service Account used to run the Policy Server workload. 
+The access level to the Kubernetes resources is determined by the Service Account used to run the Policy Server workload.
 
 In the previous example, no Service Account is defined inside of the Deployment specification; hence the `default` Service Account is going to be used.
 :::
+
 ## Using the validate_raw endpoint
 
 ### Validation

--- a/docs/howtos/raw-policies.md
+++ b/docs/howtos/raw-policies.md
@@ -1,0 +1,278 @@
+---
+sidebar_label: "Raw policies"
+title: "Raw policies"
+---
+
+# Raw policies
+
+From `v1.9.0` onwards, Kubewarden supports the ability to write and execute policies
+outside a Kubernetes cluster, as a generic policy evaluation engine.
+The Policy Server exposes the `/validate_raw` endpoint that can be used to validate
+arbitrary JSON documents against a Kubewarden policy.
+
+For this guide, we will use the following raw policies:
+
+- [raw-validation-policy](https://github.com/kubewarden/raw-validation-policy)
+- [raw-mutation-policy](https://github.com/kubewarden/raw-mutation-policy)
+
+:::note
+Please ensure that the policy author has marked the policy as `policyType: raw` in the metadata.
+You can inspect the metadata by using `kwctl`
+
+```bash
+kwctl inpect ghcr.io/kubewarden/tests/raw-mutation-policy:v0.1.0
+```
+
+:::
+
+## Running the policy server outside Kubernetes
+
+The Policy Server can be run outside Kubernetes as a standalone container.
+
+First, create a `policies.yml` file with the following content:
+
+```yaml
+raw-validation:
+  url: ghcr.io/kubewarden/tests/raw-validation-policy:v0.1.0
+  settings:
+    validUsers:
+      - alice
+      - bob
+    validActions:
+      - read
+      - write
+    validResources:
+      - orders
+      - products
+
+raw-mutation:
+  url: ghcr.io/kubewarden/tests/raw-mutation-policy:v0.1.0
+  allowedToMutate: true
+  settings:
+    forbiddenResources:
+      - privateResource
+      - secretResource
+    defaultResource: publicResource
+```
+
+To start the policy server:
+
+```bash
+# Create a docker volume to store the policies
+docker volume create --driver local \
+                --opt type=tmpfs \
+                --opt device=tmpfs \
+                --opt o=ui=65533 \
+                policy-store
+
+# Start the policy server
+docker run --rm -it \
+    -p 3000:3000 \
+    -v $(pwd)/policies.yml:/policies.yml \
+    -v policy-store:/registry \
+    ghcr.io/kubewarden/policy-server:1.9.0 \
+    --ignore-kubernetes-connection-failure=true
+```
+
+NOTE: the flag `--ignore-kubernetes-connection-failure=true` is required to start the policy server without Kubernetes.
+However, it is possible to start the Policy Server with/inside Kubernetes and use the raw validation endpoint.
+Raw policies can access context-aware[ capabilities](../explanations/context-aware-policies.md) like standard policies.
+
+## Running a Policy Server inside Kubernetes without the Kubewarden controller
+
+Alternatively, the Policy Server can be deployed in Kubernetes without the Kubewarden controller.
+
+Create a `policy-server.yaml` file with the following content:
+
+```yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-server-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: policy-server
+  template:
+    metadata:
+      labels:
+        app: policy-server
+    spec:
+      containers:
+        - name: policy-server
+          image: ghcr.io/kubewarden/policy-server:1.9.0
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: policy-store
+              mountPath: /registry
+            - name: policies-config
+              mountPath: /policies.yml
+              subPath: policies.yml
+      volumes:
+        - name: policy-store
+          emptyDir: {}
+        - name: policies-config
+          configMap:
+            name: policies-configmap
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-server-service
+spec:
+  selector:
+    app: policy-server
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: policies-configmap
+data:
+  policies.yml: |
+    raw-validation:
+      url: ghcr.io/kubewarden/tests/raw-validation-policy:v0.1.0
+      settings: 
+        validUsers:
+          - alice
+          - bob
+        validActions:
+          - read
+          - write
+        validResources:
+          - orders
+          - products
+    raw-mutation:
+      url: ghcr.io/kubewarden/tests/raw-mutation-policy:v0.1.0
+      allowedToMutate: true
+      settings:
+        forbiddenResources:
+          - privateResource
+          - secretResource
+        defaultResource: publicResource
+```
+
+Apply the configuration:
+
+```bash
+kubectl apply -f policy-server.yaml
+```
+:::info
+The Policy Server instance deployed will have access to Kubernetes resources that could be leveraged by context aware policies.
+The access level to the Kubernetes resources is determined by the Service Account used to run the Policy Server workload. 
+
+In the previous example, no Service Account is defined inside of the Deployment specification; hence the `default` Service Account is going to be used.
+:::
+## Using the validate_raw endpoint
+
+### Validation
+
+The raw validation endpoint is exposed at `/validate_raw` and accepts `POST` requests.
+
+Let's try to validate a JSON document against the `raw-validation` policy:
+
+```bash
+curl -X POST \
+  http://localhost:3000/validate_raw/raw-validation \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "request": {
+    "user": "alice",
+    "action": "read",
+    "resource": "customers"
+  }
+}'
+```
+
+The request will be not accepted, since `alice` has not been granted access to the `customers` resource:
+
+```json
+{
+  "response": {
+    "uid": "",
+    "allowed": false,
+    "auditAnnotations": null,
+    "warnings": null
+  }
+}
+```
+
+Let's try again with a valid resource:
+
+```bash
+curl -X POST \
+  http://localhost:3000/validate_raw/raw-validation \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "request": {
+    "user": "alice",
+    "action": "read",
+    "resource": "orders"
+  }
+}'
+```
+
+This time, the request will be accepted:
+
+```json
+{
+  "response": {
+    "uid": "",
+    "allowed": true,
+    "auditAnnotations": null,
+    "warnings": null
+  }
+}
+```
+
+:::note
+If the `uid` field is provided in the request payload, it will be returned as part of the response.
+:::
+
+### Mutation
+
+Now, let's try to mutate a JSON document against the `raw-mutation` policy:
+
+```bash
+curl -X POST \
+  http://localhost:3000/validate_raw/raw-mutation \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "request": {
+    "user": "alice",
+    "action": "read",
+    "resource": "privateResource"
+  }
+}'
+```
+
+The request will be mutated and the response will contain a JSONPatch:
+
+```json
+{
+  "response": {
+    "uid": "",
+    "allowed": true,
+    "patchType": "JSONPatch",
+    "patch": "W3sib3AiOiJyZXBsYWNlIiwicGF0aCI6Ii9yZXNvdXJjZSIsInZhbHVlIjoicHVibGljUmVzb3VyY2UifV0=",
+    "auditAnnotations": null,
+    "warnings": null
+  }
+}
+```
+
+## Writing raw policies
+
+Similarly to policies that validate Kubernetes resources, raw policies are written in WebAssembly using Kubewarden SDKs.
+If you are interested in writing raw policies, please refer to language-specific documentation for more information:
+
+- [Go](../writing-policies/go/10-raw-policies.md)
+- [Rust](../writing-policies/rust/08-raw-policies.md)
+- [OPA](../writing-policies/rego/open-policy-agent/05-raw-policies.md)
+- [WASI](../writing-policies/wasi/02-raw-policies.md)

--- a/docs/writing-policies/go/10-raw-policies.md
+++ b/docs/writing-policies/go/10-raw-policies.md
@@ -1,0 +1,234 @@
+---
+sidebar_label: "Raw policies"
+title: "Raw policies"
+---
+
+# Writing raw policies
+
+Raw policies are policies that can evaluate arbitrary JSON documents.
+For more information about raw policies, please refer to the [raw policies](../../howtos/raw-policies.md) page.
+
+## Examples
+
+The following examples should look familiar if you completed the [validation](04-validation.md) page of this tutorial.
+
+:::note
+Remember to mark the policy as `raw` by using the `policyType` field in the `metadata.yml` configuration.
+Please refer to the [metadata](../metadata.md) specification for more information.
+:::
+
+### Validation
+
+Let's write a policy that accepts a request in the following format:
+
+```json
+{
+  "request": {
+    "user": "alice",
+    "action": "delete",
+    "resource": "products"
+  }
+}
+```
+
+and validates that:
+
+- `user` is in the list of valid users
+- `action` is in the list of valid actions
+- `resource` is in the list of valid resources
+
+Start by scaffolding the policy by using the [go policy template](https://github.com/kubewarden/go-policy-template).
+
+First, we define the types that represent the payload of the request.
+
+We will declare a custom `RawValidationRequest` type that contains the `Request` and the `Settings`,
+instead of using the `ValidationRequest` type that is provided by the SDK:
+
+```go
+// RawValidationRequest represents the request that is sent to the validate function by the Policy Server.
+type RawValidationRequest struct {
+	Request Request `json:"request"`
+	// Raw policies can have settings.
+	Settings Settings `json:"settings"`
+}
+
+// Request represents the payload of the request.
+type Request struct {
+	User     string `json:"user"`
+	Action   string `json:"action"`
+	Resource string `json:"resource"`
+}
+```
+
+Then we need to define the `Settings` type and the `validateSettings` function:
+
+```go
+// Settings represents the settings of the policy.
+type Settings struct {
+	ValidUsers     []string `json:"validUsers"`
+	ValidActions   []string `json:"validActions"`
+	ValidResources []string `json:"validResources"`
+}
+
+// Valid returns true if the settings are valid.
+func (s *Settings) Valid() (bool, error) {
+	if len(s.ValidUsers) == 0 {
+		return false, fmt.Errorf("validUsers cannot be empty")
+	}
+
+	if len(s.ValidActions) == 0 {
+		return false, fmt.Errorf("validActions cannot be empty")
+	}
+
+	if len(s.ValidResources) == 0 {
+		return false, fmt.Errorf("validResources cannot be empty")
+	}
+
+	return true, nil
+}
+
+// validateSettings validates the settings.
+func validateSettings(payload []byte) ([]byte, error) {
+	logger.Info("validating settings")
+
+	settings := Settings{}
+	err := json.Unmarshal(payload, &settings)
+	if err != nil {
+		return kubewarden.RejectSettings(kubewarden.Message(fmt.Sprintf("Provided settings are not valid: %v", err)))
+	}
+
+	valid, err := settings.Valid()
+	if err != nil {
+		return kubewarden.RejectSettings(kubewarden.Message(fmt.Sprintf("Provided settings are not valid: %v", err)))
+	}
+	if valid {
+		return kubewarden.AcceptSettings()
+	}
+
+	logger.Warn("rejecting settings")
+	return kubewarden.RejectSettings(kubewarden.Message("Provided settings are not valid"))
+}
+```
+
+Finally, we define the `validate` function:
+
+```go
+func validate(payload []byte) ([]byte, error) {
+	// Unmarshal the payload into a RawValidationRequest instance
+	validationRequest := RawValidationRequest{}
+	err := json.Unmarshal(payload, &validationRequest)
+	if err != nil {
+		// If the payload is not valid, reject the request
+		return kubewarden.RejectRequest(
+			kubewarden.Message(err.Error()),
+			kubewarden.Code(400))
+	}
+
+	request := validationRequest.Request
+	settings := validationRequest.Settings
+
+	// Validate the payload
+	if slices.Contains(settings.ValidUsers, request.User) &&
+		slices.Contains(settings.ValidActions, request.Action) &&
+		slices.Contains(settings.ValidResources, request.Resource) {
+		return kubewarden.AcceptRequest()
+	}
+
+	return kubewarden.RejectRequest(
+		kubewarden.Message("The request cannot be accepted."),
+		kubewarden.Code(400))
+}
+```
+
+### Mutation
+
+Let's modify the previous example to mutate the request instead of rejecting it.
+In this case, the settings will contain the `defaultUser`, `defaultAction` and `defaultRequest` that will be used to mutate the request if the user, the action or the resource is not valid.
+
+We need to update the `Settings` type with the new fields:
+
+```go
+// Settings defines the settings of the policy.
+type Settings struct {
+	ValidUsers      []string `json:"validUsers"`
+	ValidActions    []string `json:"validActions"`
+	ValidResources  []string `json:"validResources"`
+	DefaultUser     string   `json:"defaultUser"`
+	DefaultAction   string   `json:"defaultAction"`
+	DefaultResource string   `json:"defaultResource"`
+}
+
+// Valid returns true if the settings are valid.
+func (s *Settings) Valid() (bool, error) {
+	if len(s.ValidUsers) == 0 {
+		return false, fmt.Errorf("validUsers cannot be empty")
+	}
+
+	if len(s.ValidActions) == 0 {
+		return false, fmt.Errorf("validActions cannot be empty")
+	}
+
+	if len(s.ValidResources) == 0 {
+		return false, fmt.Errorf("validResources cannot be empty")
+	}
+
+	if s.DefaultUser == "" {
+		return false, fmt.Errorf("defaultUser cannot be empty")
+	}
+
+	if s.DefaultAction == "" {
+		return false, fmt.Errorf("defaultUser cannot be empty")
+	}
+
+	if s.DefaultResource == "" {
+		return false, fmt.Errorf("defaultResource cannot be empty")
+	}
+
+	return true, nil
+}
+```
+
+and the `validate` function to introduce the mutation:
+
+```go
+func validate(payload []byte) ([]byte, error) {
+	// Unmarshal the payload into a RawValidationRequest instance
+	validationRequest := RawValidationRequest{}
+	err := json.Unmarshal(payload, &validationRequest)
+	if err != nil {
+		// If the payload is not valid, reject the request
+		return kubewarden.RejectRequest(
+			kubewarden.Message(err.Error()),
+			kubewarden.Code(400))
+	}
+
+	request := validationRequest.Request
+	settings := validationRequest.Settings
+
+	logger.Info("validating request")
+
+	// Accept the request without mutating it if it is valid
+	if slices.Contains(settings.ValidUsers, request.User) &&
+		slices.Contains(settings.ValidActions, request.Action) &&
+		slices.Contains(settings.ValidResources, request.Resource) {
+		return kubewarden.AcceptRequest()
+	}
+
+	logger.Info("mutating request")
+
+	// Mutate the request if it is not valid
+	if !slices.Contains(settings.ValidUsers, request.User) {
+		request.User = settings.DefaultUser
+	}
+
+	if !slices.Contains(settings.ValidActions, request.Action) {
+		request.Action = settings.DefaultAction
+	}
+
+	if !slices.Contains(settings.ValidResources, request.Resource) {
+		request.Resource = settings.DefaultResource
+	}
+
+	return kubewarden.MutateRequest(request)
+}
+```

--- a/docs/writing-policies/metadata.md
+++ b/docs/writing-policies/metadata.md
@@ -11,7 +11,7 @@ used within Kubewarden. This documentation provides an overview of the
 purpose and usage of the metadata file.
 
 The policy `metadata.yaml` file contains defaults for the policy, in addition
-to metadata such as author and description, set by the policy author.  The file
+to metadata such as author and description, set by the policy author. The file
 is used by the `kwctl annonate` command to, as the name suggests, annotates the
 `.wasm` file containing the policy. Therefore, all the relevant information required to run
 the policy will be available. More information about how to annotate the policy
@@ -27,16 +27,16 @@ scaffolding of your policy.
 
 See the following example of a `metadata.yaml`:
 
-
 ```yaml
 rules:
-- apiGroups: [""]
-  apiVersions: ["v1"]
-  resources: ["pods"]
-  operations: ["CREATE"]
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    operations: ["CREATE"]
 mutating: false
 contextAwareResources: []
 executionMode: kubewarden-wapc
+policyType: kubernetes
 backgroundAudit: true
 annotations:
   # artifacthub specific:
@@ -58,10 +58,9 @@ annotations:
   io.kubewarden.policy.category: Resource validation
 ```
 
-
 **1. Enabling Background Audit Checks:**
 
-The metadata file includes a flag, `backgroundAudit`,  that enables the
+The metadata file includes a flag, `backgroundAudit`, that enables the
 background audit checks for a specific policy. By default, this flag is set to
 `true`.
 
@@ -85,16 +84,26 @@ contextAwareResources:
 [...]
 ```
 
-**3. Specifying Policy Type: Mutating or Non-Mutating:**
+**3. Specifying Policy as Mutating or Non-Mutating:**
 
-The metadata file contains a flag, `mutating`,  that allows users to designate
+The metadata file contains a flag, `mutating`, that allows users to designate
 a policy as either mutating or non-mutating. A mutating
 policy modifies the incoming requests or the resources being managed. A
 non-mutating one observes and enforces restrictions without making any
 changes. This distinction is crucial in determining how policies interact with
 the Kubernetes resources and their impact on the cluster.
 
-**4. Defining Resource Type Targets:**
+**4. Specify Policy Type: Kubernetes or Raw**
+
+The metadata file contains a flag, `policyType`, that allows users to mark
+a policy as either `kubernetes` or `raw`. A Kubernetes policy is a policy that
+validates Kubernetes resources. A Raw policy is a policy that validates
+arbitrary JSON documents.
+By default, if not specified by the user, this field is set to `kubernetes`
+when annotating a policy.
+Refer to the [Raw Policies](../howtos/raw-policies.md) section for more information.
+
+**5. Defining Resource Type Targets:**
 
 The metadata file provides users with the ability to define the rules within
 the `rules` field, which determine the resource types to which the policy
@@ -105,4 +114,3 @@ are targeted accurately, aligning with their specific requirements and avoiding
 any unintended application to unrelated resource types.
 
 ---
-

--- a/docs/writing-policies/rego/open-policy-agent/05-raw-policies.md
+++ b/docs/writing-policies/rego/open-policy-agent/05-raw-policies.md
@@ -1,0 +1,82 @@
+---
+sidebar_label: "Raw policies"
+title: "Raw policies"
+---
+
+# Writing raw policies
+
+Raw policies are policies that can evaluate arbitrary JSON documents.
+For more information about raw policies, please refer to the [raw policies](../../../howtos/raw-policies.md) page.
+
+## Example
+
+The following examples should look familiar if you completed the [validation](02-create-policy.md) page of this tutorial.
+
+:::note
+Remember to mark the policy as `raw` by using the `policyType` field in the `metadata.yml` configuration.
+Please refer to the [metadata](../../metadata.md) specification for more information.
+:::
+
+### Validation
+
+We are going to write a policy that accepts a request in the following format:
+
+```json
+{
+  "request": {
+    "user": "alice",
+    "action": "read",
+    "resource": "products"
+  }
+}
+```
+
+and validates that only the `admin` user can delete resources.
+
+Let's start by scaffolding a policy by using the [OPA policy template](https://github.com/kubewarden/opa-policy-template).
+
+First, we need to modify the `policy.rego` file to look like this:
+
+```rego
+package validation
+
+deny[msg] {
+    input.request.action == "delete"
+    input.request.user != "admin"
+    msg := sprintf("user %v is not allowed to delete resources", [input.request.user])
+}
+```
+
+The `utility/policy.rego` module must be modified to remove Kubernetes-specific code:
+
+```rego
+package policy
+
+import data.validation
+
+main = {
+	"response": response,
+}
+
+// highlight-start
+# OPA policy responses need the uid field to be set.
+# If the request doesn't contain a uid, set it to an empty string.
+default uid = ""
+
+uid = input.request.uid
+// highlight-end
+
+response = {
+	"uid": uid,
+	"allowed": false,
+	"status": {"message": reason},
+} {
+	reason = concat(", ", validation.deny)
+	reason != ""
+} else = {
+	"uid": uid,
+	"allowed": true,
+} {
+	true
+}
+```

--- a/docs/writing-policies/rust/08-raw-policies.md
+++ b/docs/writing-policies/rust/08-raw-policies.md
@@ -1,0 +1,234 @@
+---
+sidebar_label: "Raw policies"
+title: "Raw policies"
+---
+
+# Writing raw policies
+
+Raw policies are policies that can evaluate arbitrary JSON documents.
+For more information about raw policies, please refer to the [raw policies](../../howtos/raw-policies.md) page.
+
+## Examples
+
+The following examples should look familiar if you completed the [validation](05-mutation-policy.md) page of this tutorial.
+
+:::note
+Remember to mark the policy as `raw` by using the `policyType` field in the `metadata.yml` configuration.
+Please refer to the [metadata](../metadata.md) specification for more information.
+:::
+
+### Validation
+
+Let's write a policy that accepts a request in the following format:
+
+```json
+{
+  "request": {
+    "user": "alice",
+    "action": "delete",
+    "resource": "products"
+  }
+}
+```
+
+and validates that:
+
+- `user` is in the list of valid users
+- `action` is in the list of valid actions
+- `resource` is in the list of valid resources
+
+Start by scaffolding the policy by using the [rust policy template](https://github.com/kubewarden/rust-policy-template).
+
+First, we define the types that represent the payload of the request.
+We will declare a custom `RawValidationRequest` type that contains the `Request` and the `Settings`,
+instead of using the `ValidationRequest` type that is provided by the SDK:
+
+```rust
+/// RawValidationRequest represents the request that is sent to the validate function by the Policy Server.
+#[derive(Deserialize)]
+pub(crate) struct RawValidationRequest {
+    pub(crate) request: Request,
+    pub(crate) settings: Settings,
+}
+
+#[derive(Serialize, Deserialize)]
+/// Request represents the payload of the request.
+pub(crate) struct Request {
+    pub(crate) user: String,
+    pub(crate) resource: String,
+    pub(crate) action: String,
+}
+```
+
+Then we need to define the `Settings` type and implement the `Validatable` trait:
+
+```rust
+/// Settings represents the settings of the policy.
+#[derive(Serialize, Deserialize, Default, Debug)]
+#[serde(default, rename_all = "camelCase")]
+pub(crate) struct Settings {
+    pub(crate) valid_users: Vec<String>,
+    pub(crate) valid_actions: Vec<String>,
+    pub(crate) valid_resources: Vec<String>,
+}
+
+impl kubewarden::settings::Validatable for Settings {
+    fn validate(&self) -> Result<(), String> {
+        info!(LOG_DRAIN, "starting settings validation");
+
+        if self.valid_users.is_empty() {
+            return Err("validUsers cannot be empty".to_string());
+        }
+
+        if self.valid_actions.is_empty() {
+            return Err("validActions cannot be empty".to_string());
+        }
+
+        if self.valid_resources.is_empty() {
+            return Err("validResources cannot be empty".to_string());
+        }
+
+        Ok(())
+    }
+}
+```
+
+Finally, we define the `validate` function:
+
+```rust
+fn validate(payload: &[u8]) -> CallResult {
+    let validation_request: RawValidationRequest =
+        if let Ok(validation_request) = serde_json::from_slice(payload) {
+            validation_request
+        } else {
+            return kubewarden::reject_request(
+                Some("cannot unmarshal request".to_string()),
+                None,
+                None,
+                None,
+            );
+        };
+
+    info!(LOG_DRAIN, "starting validation");
+
+    let request = validation_request.request;
+    let settings = validation_request.settings;
+
+    if settings.valid_users.contains(&request.user)
+        && settings.valid_actions.contains(&request.action)
+        && settings.valid_resources.contains(&request.resource)
+    {
+        info!(LOG_DRAIN, "accepting resource");
+        kubewarden::accept_request()
+    } else {
+        kubewarden::reject_request(
+            Some("this request is not accepted".to_string()),
+            None,
+            None,
+            None,
+        )
+    }
+}
+```
+
+### Mutation
+
+Let's modify the previous example to mutate the request instead of rejecting it.
+In this case, the settings will contain the `defaultUser`, `defaultAction` and `defaultRequest` that will be used to mutate the request if the user, the action or the resource is not valid.
+
+We need to update the `Settings` type with the new fields:
+
+```rust
+/// Settings represents the settings of the policy.
+#[derive(Serialize, Deserialize, Default, Debug)]
+#[serde(default, rename_all = "camelCase")]
+pub(crate) struct Settings {
+    pub(crate) valid_users: Vec<String>,
+    pub(crate) valid_actions: Vec<String>,
+    pub(crate) valid_resources: Vec<String>,
+    pub(crate) default_user: String,
+    pub(crate) default_action: String,
+    pub(crate) default_resource: String,
+}
+
+impl kubewarden::settings::Validatable for Settings {
+    fn validate(&self) -> Result<(), String> {
+        info!(LOG_DRAIN, "starting settings validation");
+
+        if self.valid_users.is_empty() {
+            return Err("validUsers cannot be empty".to_string());
+        }
+
+        if self.valid_actions.is_empty() {
+            return Err("validActions cannot be empty".to_string());
+        }
+
+        if self.valid_resources.is_empty() {
+            return Err("validResources cannot be empty".to_string());
+        }
+
+        if self.default_user.is_empty() {
+            return Err("defaultUser cannot be empty".to_string());
+        }
+
+        if self.default_action.is_empty() {
+            return Err("defaultAction cannot be empty".to_string());
+        }
+
+        if self.default_resource.is_empty() {
+            return Err("defaultResource cannot be empty".to_string());
+        }
+
+        Ok(())
+    }
+}
+```
+
+and the `validate` function to introduce the mutation:
+
+```rust
+fn validate(payload: &[u8]) -> CallResult {
+    let validation_request: RawValidationRequest =
+        if let Ok(validation_request) = serde_json::from_slice(payload) {
+            validation_request
+        } else {
+            return kubewarden::reject_request(
+                Some("cannot unmarshal request".to_string()),
+                None,
+                None,
+                None,
+            );
+        };
+
+    info!(LOG_DRAIN, "starting validation");
+
+    let request = validation_request.request;
+    let settings = validation_request.settings;
+
+    if settings.valid_users.contains(&request.user)
+        && settings.valid_actions.contains(&request.action)
+        && settings.valid_resources.contains(&request.resource)
+    {
+        info!(LOG_DRAIN, "accepting request");
+        return kubewarden::accept_request();
+    }
+
+    info!(LOG_DRAIN, "mutating request");
+    let mut request = request;
+
+    if !settings.valid_users.contains(&request.user) {
+        request.user = settings.default_user;
+    }
+
+    if !settings.valid_actions.contains(&request.action) {
+        request.action = settings.default_action;
+    }
+
+    if !settings.valid_resources.contains(&request.resource) {
+        request.resource = settings.default_resource;
+    }
+
+    let mutated_request = serde_json::to_value(request)?;
+    kubewarden::mutate_request(mutated_request)
+}
+```

--- a/docs/writing-policies/spec/03-validating-policies.md
+++ b/docs/writing-policies/spec/03-validating-policies.md
@@ -4,12 +4,20 @@ title: ""
 ---
 # Validating policies
 
-The Kubewarden policy server receives
-[`AdmissionReview`](https://godoc.org/k8s.io/api/admission/v1#AdmissionReview)
+The Kubewarden policy server receives:
+
+
+- Kubernetes [`AdmissionReview`](https://godoc.org/k8s.io/api/admission/v1#AdmissionReview)
 objects from the Kubernetes API server. It then forwards the value of
 its `request` attribute (of type
-[`AdmissionRequest`](https://godoc.org/k8s.io/api/admission/v1#AdmissionRequest)
-key to the policy to be evaluated.
+[`AdmissionRequest`](https://godoc.org/k8s.io/api/admission/v1#AdmissionRequest))
+to the policy to be evaluated.
+
+or:
+
+- a JSON with a `request` attribute containing the free-form request document, 
+in case of a raw policy. Check the [Raw policies](../../howtos/raw-policies.md) section for more details.
+
 
 The policy has to evaluate the `request` and state whether it should be
 accepted or not. When the request is rejected, the policy might provide the
@@ -29,7 +37,7 @@ The `ValidationRequest` is a simple JSON object that is received by the
 
 ```yaml
 {
-  "request": <AdmissionReview.request data>,
+  "request": <AdmissionReview.request data> | <RawReviewRequest.request data>,
   "settings": {
     # your policy configuration
   }
@@ -222,8 +230,3 @@ client that issued the rejected request.
 
 The `mutated_object` is an optional field used only by mutating policies.
 This is going to be covered inside of the next chapter.
-
-# Recap
-
-These are the functions a validating policy must implement:
-

--- a/docs/writing-policies/wasi/01-intro-wasi.md
+++ b/docs/writing-policies/wasi/01-intro-wasi.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: "WASI"
+sidebar_label: "Introduction to WASI"
 title: ""
 ---
 
@@ -29,7 +29,7 @@ produce WebAssembly modules that targets the WASI interfaces.
 However, Kubewarden policies leverage the [waPC](https://github.com/wapc)
 project to implement a bi-directional communication between the
 policy and the policy runtime (`kwctl` or `policy-server`); this communication
-protocol is described [here](./spec/01-intro-spec.md).
+protocol is described [here](../spec/01-intro-spec.md).
 
 There are however some special cases when the waPC project cannot be
 used yet. In these limited circumstances it's possible to write a policy
@@ -41,9 +41,9 @@ WASI policies should not be used under regular circumstances because
 they suffer from the following limitations:
 
 - No bi-directional communication, hence
-  [host capabilities](./spec/host-capabilities/01-intro-host-capabilities.md)
+  [host capabilities](../spec/host-capabilities/01-intro-host-capabilities.md)
   are not available
-- No [context-aware](../explanations/context-aware-policies.md) capabilities
+- No [context-aware](../../explanations/context-aware-policies.md) capabilities
 - Inferior performance at evaluation time compared to waPC/Rego based policies
 
 ## Use cases
@@ -61,7 +61,7 @@ export functions to the WebAssembly runtime. This limitation, tracked by
 the adoption of the waPC protocol.
 
 Generally speaking, we advice to write Kubewarden Go policies using the TinyGo
-compiler, as described [here](./go/01-intro-go.md).
+compiler, as described [here](../go/01-intro-go.md).
 
 However, some complex Go code bases cannot be compiled using the TinyGo compiler.
 This includes, for example, code bases like [CEL-go](https://github.com/google/cel-go)
@@ -94,7 +94,7 @@ The policy must to write to the STDOUT a JSON document that contains a
 `ValidationResponse` object.
 
 Both the `ValidationRequest` and `ValidationResponse` objects are described
-[here](./spec/03-validating-policies.md).
+[here](../spec/03-validating-policies.md).
 
 ### Mutation
 
@@ -106,11 +106,11 @@ The policy must to write to the STDOUT a JSON document that contains a
 `ValidationResponse` object.
 
 Both the `ValidationRequest` and `ValidationResponse` objects are described
-[here](./spec/03-validating-policies.md).
+[here](../spec/03-validating-policies.md).
 
 When a mutation has to be done, the `ValidationResponse` object must have a
 key `mutated_object` that contains the object that has to be created.
-This is described [here](./spec/04-mutating-policies.md).
+This is described [here](../spec/04-mutating-policies.md).
 
 ### Settings validation
 
@@ -123,7 +123,7 @@ It will then validate them and write a `SettingsValidationResponse` object
 to the STDOUT.
 
 The format of the `SettingsValidationResponse` and the settings validation
-process is described [here](./spec/02-settings.md).
+process is described [here](../spec/02-settings.md).
 
 ## Policy metadata
 

--- a/docs/writing-policies/wasi/02-raw-policies.md
+++ b/docs/writing-policies/wasi/02-raw-policies.md
@@ -1,0 +1,255 @@
+---
+sidebar_label: "Raw policies"
+title: "Raw policies"
+---
+
+# Writing raw policies
+
+Raw policies are policies that can evaluate arbitrary JSON documents.
+For more information about raw policies, please refer to the [raw policies](../../howtos/raw-policies.md) page.
+
+## Examples
+
+Please refer to [Introduction to WASI](01-intro-wasi.md) for an overview of the WASI execution mode.
+
+:::note
+Remember to mark the policy as `raw` by using the `policyType` field in the `metadata.yml` configuration.
+Please refer to the [metadata](../metadata.md) specification for more information.
+:::
+
+### Validation
+
+Let's write a policy that accepts a request in the following format:
+
+```json
+{
+  "request": {
+    "user": "alice",
+    "action": "delete",
+    "resource": "products"
+  }
+}
+```
+
+and validates that:
+
+- `user` is in the list of valid users
+- `action` is in the list of valid actions
+- `resource` is in the list of valid resources
+
+Start by scaffolding the policy by using the [go WASI policy template](https://github.com/kubewarden/go-wasi-policy-template).
+
+First, we need to define the types that represent the payload of the request.
+
+We will declare a custom `RawValidationRequest` type that contains the `Request` and the `Settings`,
+instead of using the `ValidationRequest` type that is provided by the `kw_sdk.go`:
+
+```go
+// RawValidationRequest represents the request that is sent to the validate function by the Policy Server.
+type RawValidationRequest struct {
+	Request Request `json:"request"`
+	// Raw policies can have settings.
+	Settings Settings `json:"settings"`
+}
+
+// Request represents the payload of the request.
+type Request struct {
+	User     string `json:"user"`
+	Action   string `json:"action"`
+	Resource string `json:"resource"`
+}
+```
+
+Then we need to define the `Settings` type and the `validateSettings` function in the `settings.go` file:
+
+```go
+// Settings represents the settings of the policy.
+type Settings struct {
+	ValidUsers     []string `json:"validUsers"`
+	ValidActions   []string `json:"validActions"`
+	ValidResources []string `json:"validResources"`
+}
+
+func validateSettings(input []byte) []byte {
+	var response SettingsValidationResponse
+
+	settings := &Settings{}
+	if err := json.Unmarshal(input, &settings); err != nil {
+		response = RejectSettings(Message(fmt.Sprintf("cannot unmarshal settings: %v", err)))
+	} else {
+		response = validateCliSettings(settings)
+	}
+
+	responseBytes, err := json.Marshal(&response)
+	if err != nil {
+		log.Fatalf("canno marshal validation response: %v", err)
+	}
+	return responseBytes
+}
+
+func validateCliSettings(settings *Settings) SettingsValidationResponse {
+	if len(settings.ValidUsers) == 0 {
+		return RejectSettings(Message(
+			"At least one valid user must be specified"))
+	}
+
+	if len(settings.ValidActions) == 0 {
+		return RejectSettings(Message(
+			"At least one valid action must be specified"))
+	}
+
+	if len(settings.ValidResources) == 0 {
+		return RejectSettings(Message(
+			"At least one valid resource must be specified"))
+	}
+
+	return AcceptSettings()
+}
+```
+
+Finally, we update the validation logic in `validate.go`:
+
+```go
+func validate(input []byte) []byte {
+	var validationRequest RawValidationRequest
+	validationRequest.Settings = Settings{}
+	decoder := json.NewDecoder(strings.NewReader(string(input)))
+	decoder.DisallowUnknownFields()
+	err := decoder.Decode(&validationRequest)
+	if err != nil {
+		return marshalValidationResponseOrFail(
+			RejectRequest(
+				Message(fmt.Sprintf("Error deserializing validation request: %v", err)),
+				Code(400)))
+	}
+
+	return marshalValidationResponseOrFail(
+		validateRequest(validationRequest.Settings, validationRequest.Request))
+}
+
+func marshalValidationResponseOrFail(response ValidationResponse) []byte {
+	responseBytes, err := json.Marshal(&response)
+	if err != nil {
+		log.Fatalf("cannot marshal validation response: %v", err)
+	}
+	return responseBytes
+}
+
+func validateRequest(settings Settings, request Request) ValidationResponse {
+	if slices.Contains(settings.ValidUsers, request.User) &&
+		slices.Contains(settings.ValidActions, request.Action) &&
+		slices.Contains(settings.ValidResources, request.Resource) {
+		return AcceptRequest()
+	}
+
+	return RejectRequest(
+		Message("The request cannot be accepted."),
+		Code(403))
+}
+```
+
+### Mutation
+
+Let's modify the previous example to mutate the request instead of rejecting it.
+In this case, the settings will contain the `defaultUser`, `defaultAction` and `defaultRequest` that will be used to mutate the request if the user, the action or the resource is not valid.
+
+We need to update the `Settings` type with the new fields:
+
+```go
+// Settings represents the settings of the policy.
+type Settings struct {
+    ValidUsers []string `json:"validUsers"`
+    ValidActions []string `json:"validActions"`
+    ValidResources []string `json:"validResources"`
+    DefaultUser string `json:"defaultUser"`
+    DefaultAction string `json:"defaultAction"`
+    DefaultResource string `json:"defaultResource"`
+}
+
+func validateCliSettings(settings *Settings) SettingsValidationResponse {
+	if len(settings.ValidUsers) == 0 {
+		return RejectSettings(Message(
+			"At least one valid user must be specified"))
+	}
+
+	if len(settings.ValidActions) == 0 {
+		return RejectSettings(Message(
+			"At least one valid action must be specified"))
+	}
+
+	if len(settings.ValidResources) == 0 {
+		return RejectSettings(Message(
+			"At least one valid resource must be specified"))
+	}
+
+    if settings.DefaultUser == "" {
+        return RejectSettings(Message(
+            "Default user must be specified"))
+    }
+
+    if settings.DefaultAction == "" {
+        return RejectSettings(Message(
+            "Default action must be specified"))
+    }
+
+    if settings.DefaultResource == "" {
+        return RejectSettings(Message(
+            "Default resource must be specified"))
+    }
+
+	return AcceptSettings()
+}
+```
+
+We also need to update the `ValidationResponse` struct and the `MutateRequest` function in `kw_sdk.go`
+to remove the Kubernetes-specific types and use our custom types instead:
+
+```go
+// ValidationResponse defines the response given when validating a request
+type ValidationResponse struct {
+	Accepted bool `json:"accepted"`
+	// Optional - ignored if accepted
+	Message *string `json:"message,omitempty"`
+	// Optional - ignored if accepted
+	Code *uint16 `json:"code,omitempty"`
+	// Optional - used only by mutating policies
+	// highlight-next-line
+	MutatedObject *Request `json:"mutated_object,omitempty"`
+}
+
+// MutateRequest accepts the request. The given `mutatedObject` is how
+// the evaluated object must look once accepted
+// highlight-next-line
+func MutateRequest(mutatedObject *Request) ValidationResponse {
+	return ValidationResponse{
+		Accepted:      true,
+		MutatedObject: mutatedObject,
+	}
+}
+```
+
+Now we can update the `validate` function to mutate the request if it is not valid:
+
+```go
+func validateRequest(settings Settings, request Request) ValidationResponse {
+	if slices.Contains(settings.ValidUsers, request.User) &&
+		slices.Contains(settings.ValidActions, request.Action) &&
+		slices.Contains(settings.ValidResources, request.Resource) {
+		return AcceptRequest()
+	}
+
+	if !slices.Contains(settings.ValidUsers, request.User) {
+		request.User = settings.DefaultUser
+	}
+
+	if !slices.Contains(settings.ValidActions, request.Action) {
+		request.Action = settings.DefaultAction
+	}
+
+	if !slices.Contains(settings.ValidResources, request.Resource) {
+		request.Resource = settings.DefaultResource
+	}
+
+	return MutateRequest(&request)
+}
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -23,6 +23,7 @@ module.exports = {
                 "writing-policies/rust/mutation-policy",
                 "writing-policies/rust/logging",
                 "writing-policies/rust/build-and-distribute",
+                "writing-policies/rust/raw-policies",
               ],
             },
             {
@@ -38,6 +39,7 @@ module.exports = {
                 "writing-policies/go/automate",
                 "writing-policies/go/distribute",
                 "writing-policies/go/validation-with-queries",
+                "writing-policies/go/raw-policies",
               ],
             },
             {
@@ -54,6 +56,7 @@ module.exports = {
                     "writing-policies/rego/open-policy-agent/create-policy",
                     "writing-policies/rego/open-policy-agent/build-and-run",
                     "writing-policies/rego/open-policy-agent/distribute",
+                    "writing-policies/rego/open-policy-agent/raw-policies",
                   ],
                 },
                 {
@@ -89,8 +92,8 @@ module.exports = {
             {
               type: "category",
               label: "WASI",
-              link: { type: "doc", id: "writing-policies/wasi" },
-              items: [],
+              link: { type: "doc", id: "writing-policies/wasi/intro-wasi" },
+              items: ["writing-policies/wasi/raw-policies"],
             },
             "writing-policies/metadata",
           ],
@@ -155,6 +158,7 @@ module.exports = {
             },
           ],
         },
+        "howtos/raw-policies",
         "howtos/audit-scanner",
       ],
       collapsed: true,


### PR DESCRIPTION
## Description

Adds raw policies documentation

TODO:
- [x] go tutorial: (see: https://github.com/kubewarden/raw-mutation-policy)
- [x] rust tutorial: (see: https://github.com/kubewarden/raw-validation-policy as reference)
- [x] WASI tutorial: (see: https://github.com/kubewarden/raw-validation-wasi-policy and https://github.com/kubewarden/raw-mutation-wasi-policy)
- [x] rego/opa tutorial (see https://github.com/kubewarden/raw-validation-opa-policy, OPA cannot mutate)
 