### PR TITLE
Information architecture experimentation.

### DIFF
--- a/docs/info-arch/doc-types/explanation.md
+++ b/docs/info-arch/doc-types/explanation.md
@@ -1,0 +1,7 @@
+---
+sidebar_label: Explanation
+title: Explanation documentation
+description: Explanation documentation
+---
+
+## Explanation placeholder.

--- a/docs/info-arch/doc-types/howto.md
+++ b/docs/info-arch/doc-types/howto.md
@@ -1,0 +1,7 @@
+---
+sidebar_label: How-to
+title: How-to documentation
+description: How-to documentation
+---
+
+## How-to placeholder.

--- a/docs/info-arch/doc-types/reference.md
+++ b/docs/info-arch/doc-types/reference.md
@@ -1,0 +1,7 @@
+---
+sidebar_label: Reference
+title: Reference documentation
+description: Reference documentation
+---
+
+## Reference placeholder.

--- a/docs/info-arch/doc-types/tutorial.md
+++ b/docs/info-arch/doc-types/tutorial.md
@@ -1,13 +1,23 @@
 ---
 sidebar_label: Tutorial
-title: Tutorial
-description: Tutorial materials
+title: Tutorial documentation
+description: Tutorial documentation
 ---
 
 Tutorial materials are introductory and intended to provide grounding in blah, blah, blah.
 
 This is a list of the provided tutorials:
 
+## Introductory
+
 - [What is Kubewarden](introduction.md)
 - [Quickstart](quick-start.md)
 - etc.
+
+## Policy development
+
+- [Policy development in Rust](/writing-policies/rust/intro-rust)
+- [Policy development in Go](/writing-policies/go/intro-go)
+- etc.
+
+## And more

--- a/docs/info-arch/doc-types/tutorial.md
+++ b/docs/info-arch/doc-types/tutorial.md
@@ -1,0 +1,13 @@
+---
+sidebar_label: Tutorial
+title: Tutorial
+description: Tutorial materials
+---
+
+Tutorial materials are introductory and intended to provide grounding in blah, blah, blah.
+
+This is a list of the provided tutorials:
+
+- [What is Kubewarden](introduction.md)
+- [Quickstart](quick-start.md)
+- etc.

--- a/docs/info-arch/ia.md
+++ b/docs/info-arch/ia.md
@@ -52,7 +52,7 @@ We have adopted the [Diátaxis](https://diataxis.fr) approach to document types.
 
 Index? Word cloud with links?
 
-## Documentation organization
+## Document organization
 
 <details>
 <summary>What is Kubewarden?</summary>
@@ -107,3 +107,7 @@ Index? Word cloud with links?
 <details>
 <summary>How-to guides</summary>
 </details>
+
+## Glossary
+
+Should we have one of these. Maybe it's too like the keyword index?

--- a/docs/info-arch/ia.md
+++ b/docs/info-arch/ia.md
@@ -1,0 +1,109 @@
+---
+sidebar_label: Documentation architecture
+title: Documentation architecture
+description: Documentation architecture
+---
+
+The first place to start is the introduction, '[What is Kubewarden?](introduction.md)'.
+
+## Who is this documentation for?
+
+This documentation is for the Kubewarden community.
+We have a few defined personas or user of Kubewarden.
+
+- [Policy user](personas/kubewarden-user).
+Someone who takes a policy and uses it in a cluster.
+They don’t develop policies and may not be software developers.
+Their work is around running a policy in a cluster and seeing the results of that.
+
+- [Operator](personas/kubewarden-operator).
+Someone who operates KW in a cluster.
+The person responsible for installing KW and keeping it up to date.
+This is an ops/devops role.
+
+- [Policy developer](personas/kubewarden-policy-developer).
+Someone who writes a policy. Has software development skills.
+
+- [Policy distributor](personas/kubewarden-distributor).
+Someone who has written a policy and wants to share it with others.
+They want the policy to be easily consumed by the “policy consumer” role.
+
+- [Integrator](personas/kubewarden-integrator).
+Those who want to build on top of Kubewarden.
+This could be a custom UI, a helper tool for generating policies, or something else.
+
+- [Developer](personas/kubewarden-developer).
+People who develop Kubewarden. The project maintainers.
+
+## What topics does the documentation cover?
+
+## What documentation types are there?
+
+We have adopted the [Diátaxis](https://diataxis.fr) approach to document types.
+
+|Type||
+|---|---|
+|[Tutorial](doc-types/tutorial)|Practical learning activities.|
+|[How-to](doc-types/howto)|Getting something *done*.|
+|[Explanation](doc-types/explanation)|Understanding and context.|
+|[Reference](doc-types/reference)|Technical description and information.|
+
+## Keywords used in the documentation
+
+Index? Word cloud with links?
+
+## Documentation organization
+
+<details>
+<summary>What is Kubewarden?</summary>
+
+[A brief introduction to what Kubewarden is all about.](introduction.md)
+
+<details>
+<summary>Metadata</summary>
+
+|metadata-tag|metadata-value|
+|---|---|
+|Title|What is Kubewarden?|
+|Description|A brief introduction to what Kubewarden is all about.|
+|Keywords|[kubewarden](keywords/kubewarden), kubernetes, introduction, about|
+|Persona|[Operator](personas/kubewarden-operator), [Manager](personas/kubewarden-manager), [Policy Developer](personas/kubewarden-policy-developer), [Developer](personas/kubewarden-developer)|
+|Document Type|[Tutorial](doc-types/tutorial)|
+|Document Topic|Introduction|
+
+</details>
+
+</details>
+
+<details>
+<summary>Getting started.</summary>
+
+<details>
+<summary>Overview</summary>
+
+<details>
+<summary>Installation and upgrading</summary>
+</details>
+
+<details>
+<summary>Deploy policies</summary>
+</details>
+
+<details>
+    <summary>Supported upgrade path</summary>
+
+|fm-tag|fm-tag-value|
+|---|---|
+|sidebar_label| Supported upgrade path|
+|title|Supported upgrade path|
+|description|Supported upgrade path|
+
+</details>
+
+</details>
+
+</details>
+
+<details>
+<summary>How-to guides</summary>
+</details>

--- a/docs/info-arch/ia.md
+++ b/docs/info-arch/ia.md
@@ -9,7 +9,7 @@ The first place to start is the introduction, '[What is Kubewarden?](introductio
 ## Who is this documentation for?
 
 This documentation is for the Kubewarden community.
-We have a few defined personas or user of Kubewarden.
+We have a few defined personas or users of Kubewarden.
 
 - [Policy user](personas/kubewarden-user).
 Someone who takes a policy and uses it in a cluster.
@@ -35,8 +35,6 @@ This could be a custom UI, a helper tool for generating policies, or something e
 - [Developer](personas/kubewarden-developer).
 People who develop Kubewarden. The project maintainers.
 
-## What topics does the documentation cover?
-
 ## What documentation types are there?
 
 We have adopted the [Diátaxis](https://diataxis.fr) approach to document types.
@@ -48,65 +46,11 @@ We have adopted the [Diátaxis](https://diataxis.fr) approach to document types.
 |[Explanation](doc-types/explanation)|Understanding and context.|
 |[Reference](doc-types/reference)|Technical description and information.|
 
+## What topics does the documentation cover?
+
 ## Keywords used in the documentation
 
 Index? Word cloud with links?
-
-## Document organization
-
-<details>
-<summary>What is Kubewarden?</summary>
-
-[A brief introduction to what Kubewarden is all about.](introduction.md)
-
-<details>
-<summary>Metadata</summary>
-
-|metadata-tag|metadata-value|
-|---|---|
-|Title|What is Kubewarden?|
-|Description|A brief introduction to what Kubewarden is all about.|
-|Keywords|[kubewarden](keywords/kubewarden), kubernetes, introduction, about|
-|Persona|[Operator](personas/kubewarden-operator), [Manager](personas/kubewarden-manager), [Policy Developer](personas/kubewarden-policy-developer), [Developer](personas/kubewarden-developer)|
-|Document Type|[Tutorial](doc-types/tutorial)|
-|Document Topic|Introduction|
-
-</details>
-
-</details>
-
-<details>
-<summary>Getting started.</summary>
-
-<details>
-<summary>Overview</summary>
-
-<details>
-<summary>Installation and upgrading</summary>
-</details>
-
-<details>
-<summary>Deploy policies</summary>
-</details>
-
-<details>
-    <summary>Supported upgrade path</summary>
-
-|fm-tag|fm-tag-value|
-|---|---|
-|sidebar_label| Supported upgrade path|
-|title|Supported upgrade path|
-|description|Supported upgrade path|
-
-</details>
-
-</details>
-
-</details>
-
-<details>
-<summary>How-to guides</summary>
-</details>
 
 ## Glossary
 

--- a/docs/info-arch/ia.md
+++ b/docs/info-arch/ia.md
@@ -6,10 +6,10 @@ description: Documentation architecture
 
 The first place to start is the introduction, '[What is Kubewarden?](introduction.md)'.
 
-## Who is this documentation for?
+## Who is this documentation for? {#who-for}
 
 This documentation is for the Kubewarden community.
-We have a few defined personas or users of Kubewarden.
+For the community we have defined personas or users of Kubewarden.
 
 - [Policy user](personas/kubewarden-user).
 Someone who takes a policy and uses it in a cluster.
@@ -42,11 +42,17 @@ We have adopted the [Diátaxis](https://diataxis.fr) approach to document types.
 |Type||
 |---|---|
 |[Tutorial](doc-types/tutorial)|Practical learning activities.|
-|[How-to](doc-types/howto)|Getting something *done*.|
 |[Explanation](doc-types/explanation)|Understanding and context.|
+|[How-tos](doc-types/howto)|Getting something *done*.|
 |[Reference](doc-types/reference)|Technical description and information.|
 
+These correspond to the top-level categories in the sidebar to the left.
+
 ## What topics does the documentation cover?
+
+A different way of slicing/dicing or approaching the material.
+For example, if one was interested in policy distribution,
+a heading here could list all policy distribution material from each of the documentation types.
 
 ## Keywords used in the documentation
 
@@ -54,4 +60,26 @@ Index? Word cloud with links?
 
 ## Glossary
 
-Should we have one of these. Maybe it's too like the keyword index?
+Should we have one of these? A set of key terms and their definitions.
+
+Add `definition:` to the front-matter in documents to define them where they (first) occur.
+
+```markdown
+---
+title: Something to do with Kubewarden and OCI
+definition: Kubewarden :: A policy engine for Kubernetes.
+definition: OCI :: Open Container initiative. https://opencontainers.org
+---
+```
+
+A glossary generator can check and report duplicate errors.
+There can be only one.
+
+## Automation
+
+This entire page hierarchy can be programmatically generated from the document source given a structured and sufficiently rich set of metadata tags in the front-matter for each document markdown page.
+
+It's not necessary though.
+It could be a simple rationale for the layout of the documentation and a few pointers.
+
+The most important section is that about [who](#who-for) the documentation is for and to provide a path through the docs for each persona.

--- a/docs/info-arch/personas/kubewarden-developer.md
+++ b/docs/info-arch/personas/kubewarden-developer.md
@@ -1,0 +1,6 @@
+---
+sidebar_label: Developer
+title: Kubewarden developer
+---
+
+## Developer placeholder

--- a/docs/info-arch/personas/kubewarden-distributor.md
+++ b/docs/info-arch/personas/kubewarden-distributor.md
@@ -1,0 +1,6 @@
+---
+sidebar_label: Distributor
+title: Kubewarden distributor
+---
+
+## Distributor placeholder

--- a/docs/info-arch/personas/kubewarden-integrator.md
+++ b/docs/info-arch/personas/kubewarden-integrator.md
@@ -1,0 +1,6 @@
+---
+sidebar_label: Integrator
+title: Kubewarden integrator
+---
+
+## Integrator placeholder

--- a/docs/info-arch/personas/kubewarden-operator.md
+++ b/docs/info-arch/personas/kubewarden-operator.md
@@ -1,0 +1,6 @@
+---
+sidebar_label: Operator
+title: Kubewarden operator
+---
+
+## Operator placeholder

--- a/docs/info-arch/personas/kubewarden-policy-developer.md
+++ b/docs/info-arch/personas/kubewarden-policy-developer.md
@@ -1,0 +1,11 @@
+---
+sidebar_label: Policy developer
+title: Kubewarden policy developer
+---
+
+
+## Policy development
+
+- [Policy development in Rust](/writing-policies/rust/intro-rust)
+- [Policy development in Go](/writing-policies/go/intro-go)
+- etc.

--- a/docs/info-arch/personas/kubewarden-user.md
+++ b/docs/info-arch/personas/kubewarden-user.md
@@ -1,0 +1,6 @@
+---
+sidebar_label: User
+title: Kubewarden user
+---
+
+## User placeholder

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -62,4 +62,4 @@ Kubewarden policies can be stored inside an OCI compliant registry as
 
 ## Documentation
 
-A description of what is documented can be found at the [documentation architecture](./info-arch/ia.md) page.
+A description of what is documented, and who it is for, can be found at the [documentation architecture](./info-arch/ia.md) page.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -59,3 +59,7 @@ better, be published from an OCI compliant registry.
 
 Kubewarden policies can be stored inside an OCI compliant registry as
 [OCI artifacts](https://github.com/opencontainers/artifacts).
+
+## Documentation
+
+A description of what is documented can be found at the [documentation architecture](./info-arch/ia.md) page.

--- a/sidebars.js
+++ b/sidebars.js
@@ -232,5 +232,6 @@ module.exports = {
       collapsed: true,
     },
     `security/disclosure`,
+    `info-arch/ia`,
   ],
 };


### PR DESCRIPTION
**DO NOT MERGE**. Experiment only.

See if this is going to be a useful direction for us.

Trying ideas in the docs to allow exploration of the structure of the docs so a learning path can be plotted by a user (the personas) of the docs.

To have ways apart from the Diataxis sidebar layout to navigate the docs. By persona, by topic, etc. To provide exploration and learning paths.

The idea would be that the entire 'Documentation architecture' hierarchy and content can be programmatically generated. But it can be much simpler than that. What provides the best value solution?

Please take a look at the preview.

https://deploy-preview-348--silly-bunny-8cedd0.netlify.app/next/info-arch/ia
