### PR TITLE
chore: update capability name to fetch OCI image manifest.

### DIFF
--- a/docs/writing-policies/spec/host-capabilities/03-container-registry.md
+++ b/docs/writing-policies/spec/host-capabilities/03-container-registry.md
@@ -79,9 +79,9 @@ the payload would be the following ones:
 * Input payload: `"busybox:latest"`
 * Output payload: `{ "digest": "sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f"}`
 
-## OCI Image manifest
+## OCI manifest
 
-This function fetches OCI images manifest. When available, this information can
+This function fetches OCI objects manifest. When available, this information can
 be used to identify specific images manifests, for one or more platforms. Or a
 single image manifest for the image.
 
@@ -111,7 +111,7 @@ This is the description of the waPC protocol used to expose this capability:
 <tr>
 <td>
 
-`v1/image_manifest`
+`v1/oci_manifest`
 
 </td>
 <td>

--- a/docs/writing-policies/spec/host-capabilities/03-container-registry.md
+++ b/docs/writing-policies/spec/host-capabilities/03-container-registry.md
@@ -81,7 +81,7 @@ the payload would be the following ones:
 
 ## OCI manifest
 
-This function fetches OCI objects manifest. When available, this information can
+This function fetches the OCI objects manifest. When available, this information can
 be used to identify specific images manifests, for one or more platforms. Or a
 single image manifest for the image.
 


### PR DESCRIPTION
## Description

Updates the waPC function name used to fetch OCI image manifest.

The new name is a review request from the policy-evaluator [PR](https://github.com/kubewarden/policy-evaluator/pull/429)