### PR TITLE
Install cert-manager via Helm in quickstart

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,16 +33,15 @@ The Kubernetes Custom Resource Definitions (CRD) defined by Kubewarden are descr
 ## Installation
 
 :::info Prerequisites
-The Helm chart depends on `cert-manager`. Ensure you install [`cert-manager`](https://cert-manager.io/docs/installation/) *before* the `kubewarden-controller` chart.
+The Helm chart depends on `cert-manager`. Ensure you install [`cert-manager`](https://cert-manager.io/docs/installation/) _before_ the `kubewarden-controller` chart.
 
-You install the latest version of `cert-manager` by running the following commands:
-
-```console
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
-```
+You can install the latest version of `cert-manager` through Helm by running the following commands:
 
 ```console
-kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
+helm repo add jetstack https://charts.jetstack.io
+
+helm install --wait --namespace cert-manager --create-namespace \
+	--set installCRDs=true cert-manager jetstack/cert-manager
 ```
 
 :::

--- a/versioned_docs/version-1.10/quick-start.md
+++ b/versioned_docs/version-1.10/quick-start.md
@@ -32,16 +32,15 @@ The Kubernetes Custom Resource Definitions (CRD) defined by Kubewarden are descr
 ## Installation
 
 :::info Prerequisites
-The Helm chart depends on `cert-manager`. Ensure you install [`cert-manager`](https://cert-manager.io/docs/installation/) *before* the `kubewarden-controller` chart.
+The Helm chart depends on `cert-manager`. Ensure you install [`cert-manager`](https://cert-manager.io/docs/installation/) _before_ the `kubewarden-controller` chart.
 
-You install the latest version of `cert-manager` by running the following commands:
-
-```console
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
-```
+You can install the latest version of `cert-manager` through Helm by running the following commands:
 
 ```console
-kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
+helm repo add jetstack https://charts.jetstack.io
+
+helm install --wait --namespace cert-manager --create-namespace \
+	--set installCRDs=true cert-manager jetstack/cert-manager
 ```
 
 :::


### PR DESCRIPTION

## Description

Upstream docs don't wait via `kubectl wait` anymore (see [here](https://cert-manager.io/docs/installation/kubectl/)), and we know that installing via Helm waits correctly. We are also testing the cert-manager installation via helm, too.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Already tested via E2E tests.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
