### PR TITLE
A better layout than tables in spec/host-capabilities 

### DIFF
--- a/docs/reference/spec/host-capabilities/02-signature-verifier-policies.md
+++ b/docs/reference/spec/host-capabilities/02-signature-verifier-policies.md
@@ -100,10 +100,7 @@ these are the functions a policy, that verifies signatures, can use:
 
 ### waPC function - `v2/verify`
 
-#### type - `SigstorePubKeyVerify`
-
-<details>
-<summary>Input payload `SigstorePubKeyVerify`</summary>
+#### `SigstorePubKeyVerify` input
 
 ```hcl
 {
@@ -126,10 +123,7 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
-<details>
-<summary>Output - `SigstorePubKeyVerify`</summary>
+#### `SigstorePubKeyVerify` output
 
 ```hcl
 {
@@ -140,12 +134,7 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
-#### type - `SigstoreKeylessVerify`
-
-<details>
-<summary>Input payload `SigstoreKeylessVerify`</summary>
+#### `SigstoreKeylessVerify` input
 
 ```hcl
 {
@@ -173,10 +162,7 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
-<details>
-<summary>Output - `SigstoreKeylessVerify`</summary>
+#### `SigstoreKeylessVerify` output
 
 ```hcl
 {
@@ -187,12 +173,7 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
-#### type - `SigstoreKeylessPrefixVerify`
-
-<details>
-<summary>Input payload `SigstoreKeylessPrefixVerify`</summary>
+#### `SigstoreKeylessPrefixVerify` input
 
 ```hcl
 {
@@ -220,10 +201,7 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
-<details>
-<summary>Output - `SigstoreKeylessPrefixVerify`</summary>
+#### `SigstoreKeylessPrefixVerify` output
 
 ```hcl
 {
@@ -234,12 +212,7 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
-#### type - `SigstoreGithubActionsVerify`
-
-<details>
-<summary>Input payload `SigstoreGithubActionsVerify`</summary>
+#### `SigstoreGithubActionsVerify` input
 
 ```hcl
 {
@@ -262,10 +235,7 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
-<details>
-<summary>Output - `SigstoreGithubActionsVerify`</summary>
+#### `SigstoreGithubActionsVerify` output
 
 ```hcl
 {
@@ -276,12 +246,7 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
-#### type - `SigstoreCertificateVerify`
-
-<details>
-<summary>Input payload `SigstoreCertificateVerify`</summary>
+#### `SigstoreCertificateVerify` input
 
 ```hcl
 {
@@ -326,10 +291,7 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
-<details>
-<summary>Output - `SigstoreCertificateVerify`</summary>
+#### `SigstoreCertificateVerify` output
 
 ```hcl
 {
@@ -340,14 +302,9 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
 ### waPC function - `v1/verify`
 
-#### type - `SigstorePubKeyVerify`
-
-<details>
-<summary>Input payload `SigstorePubKeyVerify`</summary>
+#### `SigstorePubKeyVerify` input
 
 ```hcl
 {
@@ -370,10 +327,7 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
-<details>
-<summary>Output - `SigstorePubKeyVerify`</summary>
+#### `SigstorePubKeyVerify` output
 
 ```hcl
 {
@@ -384,12 +338,7 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
-#### type - `SigstoreKeylessVerify`
-
-<details>
-<summary>Input payload `SigstoreKeylessVerify`</summary>
+#### `SigstoreKeylessVerify` input
 
 ```hcl
 {
@@ -417,10 +366,7 @@ these are the functions a policy, that verifies signatures, can use:
 }
 ```
 
-</details>
-
-<details>
-<summary>Output - `SigstoreKeylessVerify`</summary>
+#### `SigstoreKeylessVerify` output
 
 ```hcl
 {
@@ -430,5 +376,3 @@ these are the functions a policy, that verifies signatures, can use:
    "digest": string
 }
 ```
-
-</details>

--- a/docs/reference/spec/host-capabilities/02-signature-verifier-policies.md
+++ b/docs/reference/spec/host-capabilities/02-signature-verifier-policies.md
@@ -5,7 +5,13 @@ description: Signature verifier policies.
 keywords: [kubewarden, kubernetes, policy specification, signature verifier]
 doc-persona: [kubewarden-policy-developer]
 doc-type: [reference]
-doc-topic: [writing-policies, specification, host-capabilities, signature-verifier-policies]
+doc-topic:
+  [
+    writing-policies,
+    specification,
+    host-capabilities,
+    signature-verifier-policies,
+  ]
 ---
 
 <head>
@@ -87,27 +93,17 @@ Check the documentation for specifics.
 This policy may cover all your needs, but in case you would prefer a different
 UX, of course you can build on top of it or any of the other SDKs.
 
-# WaPC protocol contract
+## WaPC protocol contract
 
 In case you are implementing your own language SDK,
 these are the functions a policy, that verifies signatures, can use:
 
-<!--TODO:
-This all needs taking out of a table.
-It's too bulky, forces horizontal scrolling.
--->
+### waPC function - `v2/verify`
 
-<table>
-<tr>
-<th> waPC function name </th> <th> Input payload </th> <th> Output payload </th>
-</tr>
-<tr>
-<td>
+#### type - `SigstorePubKeyVerify`
 
-`v2/verify`
-
-</td>
-<td>
+<details>
+<summary>Input payload `SigstorePubKeyVerify`</summary>
 
 ```hcl
 {
@@ -130,8 +126,10 @@ It's too bulky, forces horizontal scrolling.
 }
 ```
 
-</td>
-<td>
+</details>
+
+<details>
+<summary>Output - `SigstorePubKeyVerify`</summary>
 
 ```hcl
 {
@@ -142,15 +140,12 @@ It's too bulky, forces horizontal scrolling.
 }
 ```
 
-</td>
-</tr>
-<tr>
-<td>
+</details>
 
-`v2/verify`
+#### type - `SigstoreKeylessVerify`
 
-</td>
-<td>
+<details>
+<summary>Input payload `SigstoreKeylessVerify`</summary>
 
 ```hcl
 {
@@ -178,8 +173,10 @@ It's too bulky, forces horizontal scrolling.
 }
 ```
 
-</td>
-<td>
+</details>
+
+<details>
+<summary>Output - `SigstoreKeylessVerify`</summary>
 
 ```hcl
 {
@@ -190,15 +187,12 @@ It's too bulky, forces horizontal scrolling.
 }
 ```
 
-</td>
-</tr>
-<tr>
-<td>
+</details>
 
-`v2/verify`
+#### type - `SigstoreKeylessPrefixVerify`
 
-</td>
-<td>
+<details>
+<summary>Input payload `SigstoreKeylessPrefixVerify`</summary>
 
 ```hcl
 {
@@ -226,8 +220,10 @@ It's too bulky, forces horizontal scrolling.
 }
 ```
 
-</td>
-<td>
+</details>
+
+<details>
+<summary>Output - `SigstoreKeylessPrefixVerify`</summary>
 
 ```hcl
 {
@@ -238,16 +234,12 @@ It's too bulky, forces horizontal scrolling.
 }
 ```
 
-</td>
-</tr>
+</details>
 
-<tr>
-<td>
+#### type - `SigstoreGithubActionsVerify`
 
-`v2/verify`
-
-</td>
-<td>
+<details>
+<summary>Input payload `SigstoreGithubActionsVerify`</summary>
 
 ```hcl
 {
@@ -270,8 +262,10 @@ It's too bulky, forces horizontal scrolling.
 }
 ```
 
-</td>
-<td>
+</details>
+
+<details>
+<summary>Output - `SigstoreGithubActionsVerify`</summary>
 
 ```hcl
 {
@@ -282,16 +276,12 @@ It's too bulky, forces horizontal scrolling.
 }
 ```
 
-</td>
-</tr>
+</details>
 
-<tr>
-<td>
+#### type - `SigstoreCertificateVerify`
 
-`v2/verify`
-
-</td>
-<td>
+<details>
+<summary>Input payload `SigstoreCertificateVerify`</summary>
 
 ```hcl
 {
@@ -336,8 +326,10 @@ It's too bulky, forces horizontal scrolling.
 }
 ```
 
-</td>
-<td>
+</details>
+
+<details>
+<summary>Output - `SigstoreCertificateVerify`</summary>
 
 ```hcl
 {
@@ -348,24 +340,14 @@ It's too bulky, forces horizontal scrolling.
 }
 ```
 
-</td>
-</tr>
+</details>
 
-</table>
+### waPC function - `v1/verify`
 
-Marked for deprecation:
+#### type - `SigstorePubKeyVerify`
 
-<table>
-<tr>
-<td> WaPC function name </td> <td> Input payload </td> <td> Output payload </td>
-</tr>
-<tr>
-<td>
-
-`v1/verify`
-
-</td>
-<td>
+<details>
+<summary>Input payload `SigstorePubKeyVerify`</summary>
 
 ```hcl
 {
@@ -388,8 +370,10 @@ Marked for deprecation:
 }
 ```
 
-</td>
-<td>
+</details>
+
+<details>
+<summary>Output - `SigstorePubKeyVerify`</summary>
 
 ```hcl
 {
@@ -400,15 +384,12 @@ Marked for deprecation:
 }
 ```
 
-</td>
-</tr>
-<tr>
-<td>
+</details>
 
-`v1/verify`
+#### type - `SigstoreKeylessVerify`
 
-</td>
-<td>
+<details>
+<summary>Input payload `SigstoreKeylessVerify`</summary>
 
 ```hcl
 {
@@ -436,8 +417,10 @@ Marked for deprecation:
 }
 ```
 
-</td>
-<td>
+</details>
+
+<details>
+<summary>Output - `SigstoreKeylessVerify`</summary>
 
 ```hcl
 {
@@ -448,7 +431,4 @@ Marked for deprecation:
 }
 ```
 
-</td>
-</tr>
-
-</table>
+</details>

--- a/docs/reference/spec/host-capabilities/03-container-registry.md
+++ b/docs/reference/spec/host-capabilities/03-container-registry.md
@@ -5,7 +5,8 @@ description: Container registry capabilities.
 keywords: [kubewarden, kubernetes, policy specification, registry capabilities]
 doc-persona: [kubewarden-policy-developer]
 doc-type: [reference]
-doc-topic: [writing-policies, specification, host-capabilities, container-registry]
+doc-topic:
+  [writing-policies, specification, host-capabilities, container-registry]
 ---
 
 <head>
@@ -43,31 +44,14 @@ from the remote registry.
 
 This is the description of the waPC protocol used to expose this capability:
 
-<!--TODO:
-Try to remove the HTML tables.
--->
-
-<table>
-<tr>
-<th> waPC function name </th> <th> Input payload </th> <th> Output payload </th>
-</tr>
-
-<tr>
-<td>
-
-`v1/manifest_digest`
-
-</td>
-<td>
+#### waPC function name `v1/manifest_digest` input
 
 ```hcl
 # OCI URI - JSON encoded string
 string
 ```
 
-</td>
-
-<td>
+#### waPC finction name `v1/manifest_digest` output
 
 ```hcl
 {
@@ -76,16 +60,11 @@ string
 }
 ```
 
-</td>
-</tr>
-
-</table>
-
 For example, when requesting the manifest digest of the `busybox:latest` image,
 the payload would be:
 
-* Input payload: `"busybox:latest"`
-* Output payload: `{ "digest": "sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f"}`
+- Input payload: `"busybox:latest"`
+- Output payload: `{ "digest": "sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f"}`
 
 ## OCI manifest
 
@@ -112,27 +91,14 @@ from the remote registry.
 
 This is the description of the waPC protocol used to expose this capability:
 
-<table>
-<tr>
-<th> waPC function name </th> <th> Input payload </th> <th> Output payload </th>
-</tr>
-
-<tr>
-<td>
-
-`v1/oci_manifest`
-
-</td>
-<td>
+#### waPC function name `v1/oci_manifest` input
 
 ```hcl
 # OCI URI - JSON encoded string
 string
 ```
 
-</td>
-
-<td>
+#### waPC function name `v1/oci_manifest` output
 
 ```hcl
 {
@@ -219,21 +185,14 @@ OR
         }
 }
 
-
-
 ```
-
-</td>
-</tr>
-
-</table>
 
 For example, when requesting the manifest digest of the
 `ghcr.io/kubewarden/policy-server:v1.10.0` image,
 the payload would be:
 
-* Input payload: `"ghcr.io/kubewarden/policy-server:v1.10.0"`
-* Output payload: the body of the successful response obtained from the
+- Input payload: `"ghcr.io/kubewarden/policy-server:v1.10.0"`
+- Output payload: the body of the successful response obtained from the
   registry.
   It can be an [OCI index image](https://github.com/opencontainers/image-spec/blob/main/image-index.md)
   or an [OCI image manifest](https://github.com/opencontainers/image-spec/blob/main/manifest.md).

--- a/docs/reference/spec/host-capabilities/03-container-registry.md
+++ b/docs/reference/spec/host-capabilities/03-container-registry.md
@@ -44,14 +44,14 @@ from the remote registry.
 
 This is the description of the waPC protocol used to expose this capability:
 
-#### waPC function name `v1/manifest_digest` input
+#### waPC function - `v1/manifest_digest` input
 
 ```hcl
 # OCI URI - JSON encoded string
 string
 ```
 
-#### waPC finction name `v1/manifest_digest` output
+#### waPC finction - `v1/manifest_digest` output
 
 ```hcl
 {
@@ -91,14 +91,14 @@ from the remote registry.
 
 This is the description of the waPC protocol used to expose this capability:
 
-#### waPC function name `v1/oci_manifest` input
+#### waPC function - `v1/oci_manifest` input
 
 ```hcl
 # OCI URI - JSON encoded string
 string
 ```
 
-#### waPC function name `v1/oci_manifest` output
+#### waPC function - `v1/oci_manifest` output
 
 ```hcl
 {

--- a/docs/reference/spec/host-capabilities/04-net.md
+++ b/docs/reference/spec/host-capabilities/04-net.md
@@ -5,7 +5,8 @@ description: Network capabilities.
 keywords: [kubewarden, kubernetes, policy specification, network capabilities]
 doc-persona: [kubewarden-policy-developer]
 doc-type: [reference]
-doc-topic: [writing-policies, specification, host-capabilities, network-capabilities]
+doc-topic:
+  [writing-policies, specification, host-capabilities, network-capabilities]
 ---
 
 <head>
@@ -28,31 +29,14 @@ Lookup results are cached for 1 minute.
 
 This is the description of the waPC protocol used to expose this capability:
 
-<!--TODO:
-Remove HTML tables.
--->
-
-<table>
-<tr>
-<th> waPC function name </th> <th> Input payload </th> <th> Output payload </th>
-</tr>
-
-<tr>
-<td>
-
-`v1/dns_lookup_host`
-
-</td>
-<td>
+#### waPC function name `v1/dns_lookup_host` input
 
 ```hcl
 # hostname - JSON encoded string
 string
 ```
 
-</td>
-
-<td>
+#### waPC function name `v1/dns_lookup_host` output
 
 ```hcl
 
@@ -62,10 +46,6 @@ string
 }
 ```
 
-</td>
-</tr>
-</table>
-
 All the IP addresses associated with the given FQDN,
 are going to be returned as strings in the response.
 Both IPv4 and IPv6 entries are returned as part of the same response.
@@ -74,5 +54,5 @@ For example, when requesting the manifest digest of the
 `busybox:latest` image,
 the payloads would be:
 
-* Input payload: `"google.com"`
-* Output payload: `{ "ips": ["127.0.0.1"]}`
+- Input payload: `"google.com"`
+- Output payload: `{ "ips": ["127.0.0.1"]}`

--- a/docs/reference/spec/host-capabilities/04-net.md
+++ b/docs/reference/spec/host-capabilities/04-net.md
@@ -29,14 +29,14 @@ Lookup results are cached for 1 minute.
 
 This is the description of the waPC protocol used to expose this capability:
 
-#### waPC function name `v1/dns_lookup_host` input
+#### waPC function - `v1/dns_lookup_host` input
 
 ```hcl
 # hostname - JSON encoded string
 string
 ```
 
-#### waPC function name `v1/dns_lookup_host` output
+#### waPC function - `v1/dns_lookup_host` output
 
 ```hcl
 

--- a/docs/reference/spec/host-capabilities/05-crypto.md
+++ b/docs/reference/spec/host-capabilities/05-crypto.md
@@ -30,7 +30,7 @@ They receive the result, and continue with their tasks.
 If you are implementing your own language SDK,
 these are the functions performing cryptographic checks exposed by the host:
 
-#### waPC function name `v1/is_certificate_trusted` input
+#### waPC function - `v1/is_certificate_trusted` input
 
 ```hcl
 # Certificate:
@@ -65,7 +65,7 @@ these are the functions performing cryptographic checks exposed by the host:
 }
 ```
 
-#### waPC function name `v1/is_certificate_trusted` output
+#### waPC function - `v1/is_certificate_trusted` output
 
 ```hcl
 {

--- a/docs/reference/spec/host-capabilities/05-crypto.md
+++ b/docs/reference/spec/host-capabilities/05-crypto.md
@@ -2,10 +2,17 @@
 sidebar_label: Cryptographic capabilities
 title: Cryptographic capabilities
 description: Cryptographic capabilities.
-keywords: [kubewarden, kubernetes, policy specification, cryptographic capabilities]
+keywords:
+  [kubewarden, kubernetes, policy specification, cryptographic capabilities]
 doc-persona: [kubewarden-policy-developer]
 doc-type: [reference]
-doc-topic: [writing-policies, specification, host-capabilities, cryptographic-capabilities]
+doc-topic:
+  [
+    writing-policies,
+    specification,
+    host-capabilities,
+    cryptographic-capabilities,
+  ]
 ---
 
 <head>
@@ -23,21 +30,7 @@ They receive the result, and continue with their tasks.
 If you are implementing your own language SDK,
 these are the functions performing cryptographic checks exposed by the host:
 
-<!--TODO:
-Try to remove HTML tables.
--->
-
-<table>
-<tr>
-<th> waPC function name </th> <th> Input payload </th> <th> Output payload </th>
-</tr>
-<tr>
-<td>
-
-`v1/is_certificate_trusted`
-
-</td>
-<td>
+#### waPC function name `v1/is_certificate_trusted` input
 
 ```hcl
 # Certificate:
@@ -72,8 +65,7 @@ Try to remove HTML tables.
 }
 ```
 
-</td>
-<td>
+#### waPC function name `v1/is_certificate_trusted` output
 
 ```hcl
 {
@@ -83,7 +75,3 @@ Try to remove HTML tables.
    "reason": string
 }
 ```
-
-</td>
-</tr>
-</table>

--- a/docs/reference/spec/host-capabilities/06-kubernetes.md
+++ b/docs/reference/spec/host-capabilities/06-kubernetes.md
@@ -2,10 +2,12 @@
 sidebar_label: Kubernetes capabilities
 title: Kubernetes capabilities
 description: Kubernetes capabilities.
-keywords: [kubewarden, kubernetes, policy specification, kubernetes capabilities]
+keywords:
+  [kubewarden, kubernetes, policy specification, kubernetes capabilities]
 doc-persona: [kubewarden-policy-developer]
 doc-type: [reference]
-doc-topic: [writing-policies, specification, host-capabilities, kubernetes-capabilities]
+doc-topic:
+  [writing-policies, specification, host-capabilities, kubernetes-capabilities]
 ---
 
 <head>
@@ -20,9 +22,9 @@ For that, the Kubewarden SDKs expose functions that use the waPC communication p
 Internally, the SDKs rely on these functions exposed by the policy host environment:
 
 - `list_resources_by_namespace` : Given a resource type and a namespace, list all the resources of that type that are defined in it.
-This cannot be used to list cluster-wide resources, like `Namespace`.
+  This cannot be used to list cluster-wide resources, like `Namespace`.
 - `list_resources_all`: Given a resource type, list all the resources of that type that are defined inside the whole cluster.
-This can be used to list cluster-wide resources, like `Namespace`.
+  This can be used to list cluster-wide resources, like `Namespace`.
 - `get_resource`: Find the exact resource identified by the given resource type, given name and an optional namespace identifier.
 
 This guest-host communication is performed using the standard waPC host calling mechanism.
@@ -30,31 +32,21 @@ Any guest implementing the waPC intercommunication mechanism is able to request 
 
 waPC has the following function arguments when performing a call from the guest to the host:
 
-- Binding
-- Namespace
-- Operation
-- Payload
+- Binding - `kubewarden`
+- Namespace - `kubernetes`
+- Operation - `list_resources_all`, `list_resources_by_namespace`, or `get_resources`
+- Payload - input payload - see below
+
+and returns:
+
+- Payload - output payload - see below
 
 By contract, or by convention,
 policies can retrieve the Kubernetes cluster information by calling the host in the following ways:
 
-<!--TODO:
-More HTML tables to try to remove. Too bulky, force horizontal scrolling.
--->
+### Operation - `list_resources_all`
 
-<table>
-<tr>
-<th>Binding</th>
-<th>Namespace</th>
-<th>Operation</th>
-<th>Input payload</th>
-<th>Output payload (JSON format)</th>
-</tr>
-<tr>
-<td><code>kubewarden</code></td>
-<td><code>kubernetes</code></td>
-<td><code>list_resources_all</code></td>
-<td>
+#### Input
 
 ```hcl
 {
@@ -69,8 +61,7 @@ More HTML tables to try to remove. Too bulky, force horizontal scrolling.
 }
 ```
 
-</td>
-<td>
+#### Output
 
 Return a Kubernetes
 [`List`](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds),
@@ -80,13 +71,9 @@ which is a collection of Kubernetes objects of the same type.
 Use this API function to fetch cluster-wide resources (e.g. namespaces)
 :::
 
-</td>
-</tr>
-<tr>
-<td><code>kubewarden</code></td>
-<td><code>kubernetes</code></td>
-<td><code>list_resources_by_namespace</code></td>
-<td>
+### Operation `list_resources_by_namespace`
+
+#### Input
 
 ```hcl
 {
@@ -103,8 +90,7 @@ Use this API function to fetch cluster-wide resources (e.g. namespaces)
 }
 ```
 
-</td>
-<td>
+#### Output
 
 Return a Kubernetes [`List`](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds), which is a collection of Kubernetes objects of the same type.
 
@@ -114,13 +100,9 @@ This API function returns an error when used to fetch cluster-wide resources
 Use the `list_resources_all` when dealing with cluster-wide resources.
 :::
 
-</td>
-</tr>
-<tr>
-<td><code>kubewarden</code></td>
-<td><code>kubernetes</code></td>
-<td><code>get_resource</code></td>
-<td>
+### Operation - `get_resources`
+
+#### Input
 
 ```hcl
 {
@@ -137,8 +119,6 @@ Use the `list_resources_all` when dealing with cluster-wide resources.
 }
 ```
 
-</td>
-<td>Result of <code>GET /apis/$api_version/namespaces/$namespace/$kind/$name </code></td>
-</tr>
+#### Output
 
-</table>
+Result of `GET /apis/$api_version/namespaces/$namespace/$kind/$name`

--- a/docs/reference/spec/host-capabilities/06-kubernetes.md
+++ b/docs/reference/spec/host-capabilities/06-kubernetes.md
@@ -71,7 +71,7 @@ which is a collection of Kubernetes objects of the same type.
 Use this API function to fetch cluster-wide resources (e.g. namespaces)
 :::
 
-### Operation `list_resources_by_namespace`
+### Operation - `list_resources_by_namespace`
 
 #### Input
 


### PR DESCRIPTION
Closes #374.

I had noticed that the host-capabilities pages in policy specification reference used tables for layout. Due to the fixed width content, these tables required a lot of horizontal scrolling and appear to be quite ugly.

Maybe something like this approach is better? As developers, which would you prefer? 

I've used sections, rather than tables, and put the code parts in expandable details. Unfortunately, Ctrl-f doesn't work on strings inside unexpanded details sections, so that's not great.

When we have decided on an approach (or decide to keep the current layout), I'll do the rest of the files in this section that have similar layout.

So, experimental, draft PR. Preferences?

New page: https://deploy-preview-375--silly-bunny-8cedd0.netlify.app/next/reference/spec/host-capabilities/signature-verifier-policies

Old page: https://deploy-preview-375--silly-bunny-8cedd0.netlify.app/writing-policies/spec/host-capabilities/signature-verifier-policies