### PR TITLE
Infrastructure for implementing a Kubewarden controlled vocabulary.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-debug.log*
 yarn-error.log*
 
 files_without_canonical.txt
+/tmp

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -13,10 +13,92 @@ doc-topic: [glossary]
   <link rel="canonical" href="https://docs.kubewarden.io/glossary"/>
 </head>
 
-## PolicyServer {#policy-server-component}
+## A
 
-A 'PolicyServer' is something, something.
+### AdmissionPolicy
 
-## ClusterAdmissionPolicy {#cluster-admission-policy-component}
+A namespace-wide resource. The policy processes only requests targeting the
+namespace where the AdmissionPolicy is defined.
 
-Is something else.
+### Annotation
+
+### Artifact
+
+### Artifacthub
+
+## C
+
+### ClusterAdmissionPolicy
+
+A ClusterAdmissionPolicy defines how policies evaluate requests.
+
+### ClusterPolicyReport
+
+### Context aware
+
+### ContextAwareResource
+
+## I
+
+### Ingress
+
+## K
+
+### Kubewarden
+
+### kwctl
+
+## M
+
+### Mutating
+
+### MutatingWebhook
+
+### MutatingWebhookConfiguration
+
+## O
+
+### OpenPolicyAgent
+
+## P
+
+### Policy
+
+### PolicyReport
+
+### PolicyServer {#policy-server}
+
+A PolicyServer validates incoming requests by executing Kubewarden policies against requests.
+
+### PublicResource
+
+## S
+
+### SecurityContext
+
+### SourceAuthorities
+
+## V
+
+### ValidatingWebhook
+
+### ValidatingWebhookConfiguration
+
+### ValidationRequest
+
+### ValidationResponse
+
+### ValidationWebhook
+
+## W
+
+### waPC
+
+### WASI
+
+### WASM or Wasm?
+
+### Wasmtime
+
+### WebAssembly
+

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -24,23 +24,28 @@ the namespace in which the AdmissionPolicy is defined.
 
 ### ClusterAdmissionPolicy
 
-A ClusterAdmissionPolicy defines how policies evaluate requests.
+An [AdmissionPolicy](#admissionpolicy) which targets cluster-wide resources.
 
 ### ClusterPolicyReport
 
 A [PolicyReport](#policyreport) and a ClusterPolicyReport store results of
-policy scans. Which one is used depends on the scope of the resource.
+policy scans. Which one is used, depends on the scope of the resource.
 
 ## K
 
 ### kwctl
 
-A CLI tool allowing administrators to test policies before applying them to a
-cluster.
+A CLI tool to generate and test Kubernetes YAML files for policy deployment.
 
 ## M
 
 ### MutatingWebhookConfiguration
+
+A
+[Kubernetes resource](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#what-are-admission-webhooks)
+created by the Kubewarden controller to let Kubernetes know where to send an `AdmissionReview`.
+In other words,
+this is how a Kubewarden controller informs Kubernetes where to find a resource mutating policy.
 
 ## P
 
@@ -56,6 +61,11 @@ A PolicyServer validates incoming requests by executing Kubewarden policies agai
 ## V
 
 ### ValidatingWebhookConfiguration
+
+A
+[Kubernetes resource](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#what-are-admission-webhooks)
+created by the Kubewarden controller to let Kubernetes know where to send a `AdmissionReview`.
+In other words, this is how Kubewarden informs Kubernetes where to find a resource validating policy.
 
 ## W
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,22 @@
+---
+sidebar_label: Glossary
+sidebar_position: 90
+title: Glossary
+description: Kubewarden glossary
+keywords: [kubewarden, glossary]
+doc-persona: [kubewarden-all]
+doc-type: [explanation]
+doc-topic: [glossary]
+---
+
+<head>
+  <link rel="canonical" href="https://docs.kubewarden.io/glossary"/>
+</head>
+
+## PolicyServer {#policy-server-component}
+
+A 'PolicyServer' is something, something.
+
+## ClusterAdmissionPolicy {#cluster-admission-policy-component}
+
+Is something else.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -17,14 +17,8 @@ doc-topic: [glossary]
 
 ### AdmissionPolicy
 
-A namespace-wide resource. The policy processes only requests targeting the
-namespace where the AdmissionPolicy is defined.
-
-### Annotation
-
-### Artifact
-
-### Artifacthub
+A namespace-wide resource. The policy processes only those requests targeting
+the namespace in which the AdmissionPolicy is defined.
 
 ## C
 
@@ -34,71 +28,50 @@ A ClusterAdmissionPolicy defines how policies evaluate requests.
 
 ### ClusterPolicyReport
 
-### Context aware
-
-### ContextAwareResource
-
-## I
-
-### Ingress
+A [PolicyReport](#policyreport) and a ClusterPolicyReport store results of
+policy scans. Which one is used depends on the scope of the resource.
 
 ## K
 
-### Kubewarden
-
 ### kwctl
+
+A CLI tool allowing administrators to test policies before applying them to a
+cluster.
 
 ## M
 
-### Mutating
-
-### MutatingWebhook
-
 ### MutatingWebhookConfiguration
-
-## O
-
-### OpenPolicyAgent
 
 ## P
 
-### Policy
-
 ### PolicyReport
+
+A PolicyReport and a [ClusterPolicyReport](#clusterpolicyreport) store results of
+policy scans. Which one is used depends on the scope of the resource.
 
 ### PolicyServer {#policy-server}
 
 A PolicyServer validates incoming requests by executing Kubewarden policies against requests.
 
-### PublicResource
-
-## S
-
-### SecurityContext
-
-### SourceAuthorities
-
 ## V
 
-### ValidatingWebhook
-
 ### ValidatingWebhookConfiguration
-
-### ValidationRequest
-
-### ValidationResponse
-
-### ValidationWebhook
 
 ## W
 
 ### waPC
 
+WebAssembly Procedure Calls. https://wapc.io.
+
 ### WASI
 
-### WASM or Wasm?
+WebAssembly System Interface. https://wasi.dev.
+
+### Wasm
+
+A binary instruction format for a stack-based virtual machine. Designed for web
+deployment. https://webassemly.org.
 
 ### Wasmtime
 
-### WebAssembly
-
+A runtime for WebAssembly. https://wasmtime.dev.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -37,7 +37,7 @@ The Kubewarden stack comprises:
 
 :::tip
 
-The Kubernetes Custom Resource Definitions (CRD) defined by Kubewarden are described [here](reference/CRDs.md).
+The Kubernetes Custom Resource Definitions (CRDs) defined by Kubewarden are described [here](reference/CRDs.md).
 
 :::
 
@@ -60,7 +60,7 @@ helm install --wait --namespace cert-manager --create-namespace \
 :::info Authentication
 Kubewarden policies can be retrieved from the GitHub container registry at https://ghcr.io.
 You need authentication to use the repository with the Kubewarden CLI, a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) (PAT).
-Their documentation guides you through creating one if you have not already done so.
+Their documentation guides you through creating one if you haven't already done so.
 Then you authenticate with a command like:
 
 ```console
@@ -112,8 +112,8 @@ Since [`v0.4.0`](https://github.com/kubewarden/kubewarden-controller/releases/ta
 Now a Helm chart called `kubewarden-defaults`, installs
 the default policy server.
 
-This means that if you are not using the latest version of the `kubewarden-controller` and are trying to upgrade or delete,
-your default policy server will not be upgraded or deleted.
+This means that if you aren't using the latest version of the `kubewarden-controller` and are trying to upgrade or delete,
+your default policy server won't be upgraded or deleted.
 So, you might run into issues if you try to install the `kubewarden-defaults` with some conflicting information, for example, the same policy server name.
 To be able to take advantage of future upgrades in the `kubewarden-defaults` Helm chart remove the
 existing `PolicyServer` resource created by the `kubewarden-controller` before installing the new chart.
@@ -128,12 +128,13 @@ The default configuration values are sufficient for most deployments. All option
 Kubewarden has three main components which you will interact with:
 
 - The [[< policy-server >]]
-- The ClusterAdmissionPolicy
-- The AdmissionPolicy
+- The [[< cluster-admission-policy >]]
+- The [[< admission-policy >]]
 
 ### `PolicyServer`
 
-A Kubewarden `PolicyServer` is managed by the `kubewarden-controller` and multiple [[< policy-server >]]s can be deployed in the same Kubernetes cluster.
+A Kubewarden `PolicyServer` is managed by the `kubewarden-controller`.
+Multiple [[< policy-server >]]s can be deployed in the same Kubernetes cluster.
 
 A `PolicyServer` validates incoming requests by executing Kubewarden policies against them.
 
@@ -172,7 +173,7 @@ Changing any of these attributes causes a `PolicyServer` deployment with the new
 
 ### ClusterAdmissionPolicy
 
-The `ClusterAdmissionPolicy` resource is the core of the Kubewarden stack. It defines how policies evaluate requests.
+The [[< cluster-admission-policy >]]`ClusterAdmissionPolicy` resource is the core of the Kubewarden stack. It defines how policies evaluate requests.
 
 Enforcing policies is the most common operation which a Kubernetes administrator performs.
 You can declare as many policies as you want, each will target one or more Kubernetes resources (i.e., `pods`, `Custom Resource`).
@@ -232,7 +233,7 @@ The policy will process only the requests that are targeting the Namespace where
 Other than that, there are no functional differences between the `AdmissionPolicy` and `ClusterAdmissionPolicy` resources.
 
 :::info
-`AdmissionPolicy` requires Kubernetes 1.21.0 or above. This is because we are using the `kubernetes.io/metadata.name` label, which was introduced in Kubernetes 1.21.0
+`AdmissionPolicy` requires Kubernetes 1.21.0 or above. This is because we're using the `kubernetes.io/metadata.name` label, which was introduced in Kubernetes 1.21.0
 :::
 
 The complete documentation of these Custom Resources can be found [here](https://github.com/kubewarden/kubewarden-controller/blob/main/docs/crds/README.asciidoc) or on [docs.crds.dev](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller).
@@ -316,7 +317,7 @@ spec:
 EOF
 ```
 
-This will produce the following output:
+This produces the following output:
 
 ```console
 pod/unprivileged-pod created
@@ -376,8 +377,8 @@ kubectl delete namespace kubewarden
 ```
 
 :::caution
-Kubewarden contains a helm pre-delete hook that will remove all `PolicyServers` and `kubewarden-controller`.
-Then the `kubewarden-controller` will delete all resources, so it is important that `kubewarden-controller` is running when helm uninstall is executed.
+Kubewarden contains a helm pre-delete hook that removes all `PolicyServer`s and `kubewarden-controller`s.
+Then the `kubewarden-controller` will delete all resources, so it's important that `kubewarden-controller` is running when helm uninstall is executed.
 :::
 
 `ValidatingWebhookConfigurations` and `MutatingWebhookConfigurations` created by kubewarden should be deleted, this can be checked with:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -3,7 +3,15 @@ sidebar_label: Quick start
 sidebar_position: 20
 title: Quick start
 description: Getting started with Kubewarden, installing the Kubewarden stack and taking care of prerequisites and authentication
-keywords: [Kubewarden, installation, quick start, policyserver, clusteradmissionpolicy, admissionpolicy]
+keywords:
+  [
+    Kubewarden,
+    installation,
+    quick start,
+    policyserver,
+    clusteradmissionpolicy,
+    admissionpolicy,
+  ]
 doc-persona: [kubewarden-all]
 doc-type: [tutorial]
 doc-topic: [quick-start]
@@ -13,16 +21,15 @@ doc-topic: [quick-start]
   <link rel="canonical" href="https://docs.kubewarden.io/quick-start"/>
 </head>
 
-
 The Kubewarden stack comprises:
 
-* Some `ClusterAdmissionPolicy` resources: this is how policies are defined for Kubernetes clusters
+- Some `ClusterAdmissionPolicy` resources: this is how policies are defined for Kubernetes clusters
 
-* Some `[[< policy-server-component >]]` resources: representing a deployment of a Kubewarden `[[< policy-server-component >]]`. Your administrator's policies are loaded and evaluated by the Kubewarden `[[< policy-server-component >]]`
+- Some '[[< policy-server-component >]]', `[[< c-policy-server-component >]]` resources: representing a deployment of a Kubewarden `[[< c-policy-server-component >]]`. Your administrator's policies are loaded and evaluated by the Kubewarden `[[< c-policy-server-component >]]`
 
-* Some `AdmissionPolicy` resources: policies for a defined namespace
+- Some `AdmissionPolicy` resources: policies for a defined namespace
 
-* A deployment of a `kubewarden-controller`: this controller monitors the `ClusterAdmissionPolicy` resources and interacts with the Kubewarden `[[< policy-server-component >]]` components.
+- A deployment of a `kubewarden-controller`: this controller monitors the `ClusterAdmissionPolicy` resources and interacts with the Kubewarden `[[< c-policy-server-component >]]` components.
 
 :::tip
 
@@ -70,19 +77,19 @@ helm repo update kubewarden
 
 Install the following Helm charts inside the `kubewarden` namespace in your Kubernetes cluster:
 
-* `kubewarden-crds`, which will register the `ClusterAdmissionPolicy`,
-  `AdmissionPolicy` and `[[< policy-server-component >]]` Custom Resource Definitions.  As well as
+- `kubewarden-crds`, which will register the `ClusterAdmissionPolicy`,
+  `AdmissionPolicy` and `[[< c-policy-server-component >]]` Custom Resource Definitions. As well as
   the `PolicyReport` Custom Resource Definitions used by the audit scanner
 
-* `kubewarden-controller`, which will install the Kubewarden controller and the
+- `kubewarden-controller`, which will install the Kubewarden controller and the
   audit scanner
-:::note
-If you want to disable the audit scanner component. Please check out the audit
-scanner installation [docs page](../howtos/audit-scanner).
-:::
+  :::note
+  If you want to disable the audit scanner component. Please check out the audit
+  scanner installation [docs page](../howtos/audit-scanner).
+  :::
 
-* `kubewarden-defaults`, which will create a `[[< policy-server-component >]]` resource named `default`. It can also install a set of
-recommended policies to secure your cluster by enforcing some well known best practices.
+- `kubewarden-defaults`, which will create a `[[< c-policy-server-component >]]` resource named `default`. It can also install a set of
+  recommended policies to secure your cluster by enforcing some well known best practices.
 
 ```console
 helm install --wait -n kubewarden --create-namespace kubewarden-crds kubewarden/kubewarden-crds
@@ -97,7 +104,7 @@ helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defa
 ```
 
 :::caution
-Since [`v0.4.0`](https://github.com/kubewarden/kubewarden-controller/releases/tag/v0.4.0), a `[[< policy-server-component >]]` resource named `default` will not be created using the `kubewarden-controller` chart.
+Since [`v0.4.0`](https://github.com/kubewarden/kubewarden-controller/releases/tag/v0.4.0), a `[[< c-policy-server-component >]]` resource named `default` will not be created using the `kubewarden-controller` chart.
 Now a Helm chart called `kubewarden-defaults`, installs
 the default policy server.
 
@@ -105,9 +112,9 @@ This means that if you are not using the latest version of the `kubewarden-contr
 your default policy server will not be upgraded or deleted.
 So, you might run into issues if you try to install the `kubewarden-defaults` with some conflicting information, for example, the same policy server name.
 To be able to take advantage of future upgrades in the `kubewarden-defaults` Helm chart remove the
-existing `[[< policy-server-component >]]` resource created by the `kubewarden-controller` before installing the new chart.
+existing `[[< c-policy-server-component >]]` resource created by the `kubewarden-controller` before installing the new chart.
 Now you can update your policy server using Helm upgrades without resource conflicts.
-When you remove the `[[< policy-server-component >]]`, all the policies bound to it will be removed as well.
+When you remove the `[[< c-policy-server-component >]]`, all the policies bound to it will be removed as well.
 :::
 
 The default configuration values are sufficient for most deployments. All options are documented [here](https://charts.kubewarden.io/#configuration).
@@ -116,21 +123,21 @@ The default configuration values are sufficient for most deployments. All option
 
 Kubewarden has three main components which you will interact with:
 
-* The [[< policy-server-component >]]
-* The ClusterAdmissionPolicy
-* The AdmissionPolicy
+- The [[< c-policy-server-component >]]
+- The ClusterAdmissionPolicy
+- The AdmissionPolicy
 
-### [[< policy-server-component >]]
+### [[< c-policy-server-component >]]
 
-A Kubewarden `[[< policy-server-component >]]` is managed by the `kubewarden-controller` and multiple `[[< policy-server-component >]]s` can be deployed in the same Kubernetes cluster.
+A Kubewarden `[[< c-policy-server-component >]]` is managed by the `kubewarden-controller` and multiple `[[< c-policy-server-component >]]s` can be deployed in the same Kubernetes cluster.
 
-A `[[< policy-server-component >]]` validates incoming requests by executing Kubewarden policies against them.
+A `[[< c-policy-server-component >]]` validates incoming requests by executing Kubewarden policies against them.
 
-This is the default `[[< policy-server-component >]]` configuration:
+This is the default `[[< c-policy-server-component >]]` configuration:
 
 ```yaml
 apiVersion: policies.kubewarden.io/v1
-kind: [[< policy-server-component >]]
+kind: PolicyServer
 metadata:
   name: reserved-instance-for-tenant-a
 spec:
@@ -138,25 +145,26 @@ spec:
   replicas: 2
   serviceAccountName: ~
   env:
-  - name: KUBEWARDEN_LOG_LEVEL
-    value: debug
+    - name: KUBEWARDEN_LOG_LEVEL
+      value: debug
 ```
 
 :::note
-Check the [latest released `[[< policy-server-component >]]` version](https://github.com/kubewarden/policy-server/pkgs/container/policy-server) and change the tag to match.
+Check the [latest released `[[< c-policy-server-component >]]` version](https://github.com/kubewarden/policy-server/pkgs/container/policy-server) and change the tag to match.
 :::
 
-Overview of the attributes of the `[[< policy-server-component >]]` resource:
+Overview of the attributes of the `[[< c-policy-server-component >]]` resource:
 
+<!-- prettier-ignore -->
 | Required | Placeholder         | Description    |
 |:--------:| ------------------- | ----------------------------- |
 | Y | `image`  | The name of the container image |
 | Y | `replicas`  | The number of desired instances |
-| N | `serviceAccountName` | The name of the `ServiceAccount` to use for the `[[< policy-server-component >]]` deployment. If no value is provided, the default `ServiceAccount` from the namespace, where the `kubewarden-controller` is installed, will be used |
+| N | `serviceAccountName` | The name of the `ServiceAccount` to use for the `[[< c-policy-server-component >]]` deployment. If no value is provided, the default `ServiceAccount` from the namespace, where the `kubewarden-controller` is installed, will be used |
 | N | `env` | The list of environment variables |
 | N | `annotations` | The list of annotations |
 
-Changing any of these attributes causes a `[[< policy-server-component >]]` deployment with the new configuration.
+Changing any of these attributes causes a `[[< c-policy-server-component >]]` deployment with the new configuration.
 
 ### ClusterAdmissionPolicy
 
@@ -178,39 +186,39 @@ spec:
   policyServer: reserved-instance-for-tenant-a
   module: registry://ghcr.io/kubewarden/policies/psp-capabilities:v0.1.9
   rules:
-  - apiGroups: [""]
-    apiVersions: ["v1"]
-    resources: ["pods"]
-    operations:
-    - CREATE
-    - UPDATE
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+      operations:
+        - CREATE
+        - UPDATE
   mutating: true
   settings:
     allowed_capabilities:
-    - CHOWN
+      - CHOWN
     required_drop_capabilities:
-    - NET_ADMIN
+      - NET_ADMIN
 ```
 
 Overview of the attributes of the `ClusterAdmissionPolicy` resource:
 
-| Required | Placeholder         | Description    |
-|:--------:| ------------------- | ----------------------------- |
-| N | `policy-server`  | Identifies an existing `[[< policy-server-component >]]` object. The policy will be served only by this `[[< policy-server-component >]]` instance. A `ClusterAdmissionPolicy` that doesn't have an explicit `[[< policy-server-component >]]`, will be served by the one named `default` |
-| Y | `module`  | The location of the Kubewarden policy. The following schemes are allowed: |
-| N | | - `registry`: The policy is downloaded from an [OCI artifacts](https://github.com/opencontainers/artifacts) compliant container registry. Example: `registry://<OCI registry/policy URL>` |
-| N | | - `http`, `https`: The policy is downloaded from a regular HTTP(s) server. Example: `https://<website/policy URL>` |
-| N | | - `file`: The policy is loaded from a file in the computer file system. Example: `file:///<policy WASM binary full path>` |
-| Y | `resources` | The Kubernetes resources evaluated by the policy |
-| Y | `operations` | What operations for the previously given types should be forwarded to this admission policy by the API server for evaluation. |
-| Y | `mutating` | A boolean value that must be set to `true` for policies that can mutate incoming requests |
-| N | `settings` | A free-form object that contains the policy configuration values |
-| N | `failurePolicy` | The action to take if the request evaluated by a policy results in an error. The following options are allowed: |
-| N | | - `Ignore`: an error calling the webhook is ignored and the API request is allowed to continue |
-| N | | - `Fail`: an error calling the webhook causes the admission to fail and the API request to be rejected |
+| Required | Placeholder     | Description                                                                                                                                                                                                                                                                                     |
+| :------: | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    N     | `policy-server` | Identifies an existing `[[< c-policy-server-component >]]` object. The policy will be served only by this `[[< c-policy-server-component >]]` instance. A `ClusterAdmissionPolicy` that doesn't have an explicit `[[< c-policy-server-component >]]`, will be served by the one named `default` |
+|    Y     | `module`        | The location of the Kubewarden policy. The following schemes are allowed:                                                                                                                                                                                                                       |
+|    N     |                 | - `registry`: The policy is downloaded from an [OCI artifacts](https://github.com/opencontainers/artifacts) compliant container registry. Example: `registry://<OCI registry/policy URL>`                                                                                                       |
+|    N     |                 | - `http`, `https`: The policy is downloaded from a regular HTTP(s) server. Example: `https://<website/policy URL>`                                                                                                                                                                              |
+|    N     |                 | - `file`: The policy is loaded from a file in the computer file system. Example: `file:///<policy WASM binary full path>`                                                                                                                                                                       |
+|    Y     | `resources`     | The Kubernetes resources evaluated by the policy                                                                                                                                                                                                                                                |
+|    Y     | `operations`    | What operations for the previously given types should be forwarded to this admission policy by the API server for evaluation.                                                                                                                                                                   |
+|    Y     | `mutating`      | A boolean value that must be set to `true` for policies that can mutate incoming requests                                                                                                                                                                                                       |
+|    N     | `settings`      | A free-form object that contains the policy configuration values                                                                                                                                                                                                                                |
+|    N     | `failurePolicy` | The action to take if the request evaluated by a policy results in an error. The following options are allowed:                                                                                                                                                                                 |
+|    N     |                 | - `Ignore`: an error calling the webhook is ignored and the API request is allowed to continue                                                                                                                                                                                                  |
+|    N     |                 | - `Fail`: an error calling the webhook causes the admission to fail and the API request to be rejected                                                                                                                                                                                          |
 
 :::note
-The  `ClusterAdmissionPolicy` resources are registered with a `*` webhook `scope`, which means that registered webhooks will forward all requests matching the given `resources` and `operations` -- either namespaced or cluster-wide resources.
+The `ClusterAdmissionPolicy` resources are registered with a `*` webhook `scope`, which means that registered webhooks will forward all requests matching the given `resources` and `operations` -- either namespaced or cluster-wide resources.
 :::
 
 ### AdmissionPolicy
@@ -257,8 +265,8 @@ This produces the following output:
 clusteradmissionpolicy.policies.kubewarden.io/privileged-pods created
 ```
 
-When a `ClusterAdmissionPolicy` is defined, the status is set to `pending`, and it will force a rollout of the targeted `[[< policy-server-component >]]`.
-In our example, it's the `[[< policy-server-component >]]` named `default`. You can monitor the rollout by running the following command:
+When a `ClusterAdmissionPolicy` is defined, the status is set to `pending`, and it will force a rollout of the targeted `[[< c-policy-server-component >]]`.
+In our example, it's the `[[< c-policy-server-component >]]` named `default`. You can monitor the rollout by running the following command:
 
 ```console
 kubectl get clusteradmissionpolicy.policies.kubewarden.io/privileged-pods
@@ -273,7 +281,7 @@ privileged-pods   default         false      pending
 
 Once the new policy is ready to be served, the `kubewarden-controller` will register a [ValidatingWebhookConfiguration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#validatingwebhookconfiguration-v1-admissionregistration-k8s-io) object.
 
-The `ClusterAdmissionPolicy` status will be set to `active` once the Deployment is done for every `[[< policy-server-component >]]` instance.
+The `ClusterAdmissionPolicy` status will be set to `active` once the Deployment is done for every `[[< c-policy-server-component >]]` instance.
 Show `ValidatingWebhookConfiguration` with the following command:
 
 ```console
@@ -289,7 +297,7 @@ clusterwide-privileged-pods   1          9s
 
 Once the `ClusterAdmissionPolicy` is active and the `ValidatingWebhookConfiguration` is registered, you can test the policy.
 
-First, let's create a Pod with a Container *not* in `privileged` mode:
+First, let's create a Pod with a Container _not_ in `privileged` mode:
 
 ```console
 kubectl apply -f - <<EOF
@@ -334,6 +342,7 @@ The creation of the Pod has been denied by the policy and you should see the fol
 ```console
 Error from server: error when creating "STDIN": admission webhook "clusterwide-privileged-pods.kubewarden.admission" denied the request: Privileged container is not allowed
 ```
+
 :::note
 Both examples didn't define a `namespace`, which means the `default` namespace was the target.
 However, as you could see in the second example, the policy is still applied.
@@ -347,9 +356,11 @@ You can remove the resources created by uninstalling the `helm` charts as follow
 ```console
 helm uninstall --namespace kubewarden kubewarden-defaults
 ```
+
 ```console
 helm uninstall --namespace kubewarden kubewarden-controller
 ```
+
 ```console
 helm uninstall --namespace kubewarden kubewarden-crds
 ```
@@ -361,7 +372,7 @@ kubectl delete namespace kubewarden
 ```
 
 :::caution
-Kubewarden contains a helm pre-delete hook that will remove all `[[< policy-server-component >]]s` and `kubewarden-controller`.
+Kubewarden contains a helm pre-delete hook that will remove all `[[< c-policy-server-component >]]s` and `kubewarden-controller`.
 Then the `kubewarden-controller` will delete all resources, so it is important that `kubewarden-controller` is running when helm uninstall is executed.
 :::
 
@@ -370,6 +381,7 @@ Then the `kubewarden-controller` will delete all resources, so it is important t
 ```console
 kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io -l "kubewarden"
 ```
+
 ```console
 kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io -l "kubewarden"
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -18,11 +18,11 @@ The Kubewarden stack comprises:
 
 * Some `ClusterAdmissionPolicy` resources: this is how policies are defined for Kubernetes clusters
 
-* Some `PolicyServer` resources: representing a deployment of a Kubewarden `PolicyServer`. Your administrator's policies are loaded and evaluated by the Kubewarden `PolicyServer`
+* Some `[[< policy-server-component >]]` resources: representing a deployment of a Kubewarden `[[< policy-server-component >]]`. Your administrator's policies are loaded and evaluated by the Kubewarden `[[< policy-server-component >]]`
 
 * Some `AdmissionPolicy` resources: policies for a defined namespace
 
-* A deployment of a `kubewarden-controller`: this controller monitors the `ClusterAdmissionPolicy` resources and interacts with the Kubewarden `PolicyServer` components.
+* A deployment of a `kubewarden-controller`: this controller monitors the `ClusterAdmissionPolicy` resources and interacts with the Kubewarden `[[< policy-server-component >]]` components.
 
 :::tip
 
@@ -71,7 +71,7 @@ helm repo update kubewarden
 Install the following Helm charts inside the `kubewarden` namespace in your Kubernetes cluster:
 
 * `kubewarden-crds`, which will register the `ClusterAdmissionPolicy`,
-  `AdmissionPolicy` and `PolicyServer` Custom Resource Definitions.  As well as
+  `AdmissionPolicy` and `[[< policy-server-component >]]` Custom Resource Definitions.  As well as
   the `PolicyReport` Custom Resource Definitions used by the audit scanner
 
 * `kubewarden-controller`, which will install the Kubewarden controller and the
@@ -81,7 +81,7 @@ If you want to disable the audit scanner component. Please check out the audit
 scanner installation [docs page](../howtos/audit-scanner).
 :::
 
-* `kubewarden-defaults`, which will create a `PolicyServer` resource named `default`. It can also install a set of
+* `kubewarden-defaults`, which will create a `[[< policy-server-component >]]` resource named `default`. It can also install a set of
 recommended policies to secure your cluster by enforcing some well known best practices.
 
 ```console
@@ -97,7 +97,7 @@ helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defa
 ```
 
 :::caution
-Since [`v0.4.0`](https://github.com/kubewarden/kubewarden-controller/releases/tag/v0.4.0), a `PolicyServer` resource named `default` will not be created using the `kubewarden-controller` chart.
+Since [`v0.4.0`](https://github.com/kubewarden/kubewarden-controller/releases/tag/v0.4.0), a `[[< policy-server-component >]]` resource named `default` will not be created using the `kubewarden-controller` chart.
 Now a Helm chart called `kubewarden-defaults`, installs
 the default policy server.
 
@@ -105,9 +105,9 @@ This means that if you are not using the latest version of the `kubewarden-contr
 your default policy server will not be upgraded or deleted.
 So, you might run into issues if you try to install the `kubewarden-defaults` with some conflicting information, for example, the same policy server name.
 To be able to take advantage of future upgrades in the `kubewarden-defaults` Helm chart remove the
-existing `PolicyServer` resource created by the `kubewarden-controller` before installing the new chart.
+existing `[[< policy-server-component >]]` resource created by the `kubewarden-controller` before installing the new chart.
 Now you can update your policy server using Helm upgrades without resource conflicts.
-When you remove the `PolicyServer`, all the policies bound to it will be removed as well.
+When you remove the `[[< policy-server-component >]]`, all the policies bound to it will be removed as well.
 :::
 
 The default configuration values are sufficient for most deployments. All options are documented [here](https://charts.kubewarden.io/#configuration).
@@ -116,21 +116,21 @@ The default configuration values are sufficient for most deployments. All option
 
 Kubewarden has three main components which you will interact with:
 
-* The PolicyServer
+* The [[< policy-server-component >]]
 * The ClusterAdmissionPolicy
 * The AdmissionPolicy
 
-### PolicyServer
+### [[< policy-server-component >]]
 
-A Kubewarden `PolicyServer` is managed by the `kubewarden-controller` and multiple `PolicyServers` can be deployed in the same Kubernetes cluster.
+A Kubewarden `[[< policy-server-component >]]` is managed by the `kubewarden-controller` and multiple `[[< policy-server-component >]]s` can be deployed in the same Kubernetes cluster.
 
-A `PolicyServer` validates incoming requests by executing Kubewarden policies against them.
+A `[[< policy-server-component >]]` validates incoming requests by executing Kubewarden policies against them.
 
-This is the default `PolicyServer` configuration:
+This is the default `[[< policy-server-component >]]` configuration:
 
 ```yaml
 apiVersion: policies.kubewarden.io/v1
-kind: PolicyServer
+kind: [[< policy-server-component >]]
 metadata:
   name: reserved-instance-for-tenant-a
 spec:
@@ -143,20 +143,20 @@ spec:
 ```
 
 :::note
-Check the [latest released `PolicyServer` version](https://github.com/kubewarden/policy-server/pkgs/container/policy-server) and change the tag to match.
+Check the [latest released `[[< policy-server-component >]]` version](https://github.com/kubewarden/policy-server/pkgs/container/policy-server) and change the tag to match.
 :::
 
-Overview of the attributes of the `PolicyServer` resource:
+Overview of the attributes of the `[[< policy-server-component >]]` resource:
 
 | Required | Placeholder         | Description    |
 |:--------:| ------------------- | ----------------------------- |
 | Y | `image`  | The name of the container image |
 | Y | `replicas`  | The number of desired instances |
-| N | `serviceAccountName` | The name of the `ServiceAccount` to use for the `PolicyServer` deployment. If no value is provided, the default `ServiceAccount` from the namespace, where the `kubewarden-controller` is installed, will be used |
+| N | `serviceAccountName` | The name of the `ServiceAccount` to use for the `[[< policy-server-component >]]` deployment. If no value is provided, the default `ServiceAccount` from the namespace, where the `kubewarden-controller` is installed, will be used |
 | N | `env` | The list of environment variables |
 | N | `annotations` | The list of annotations |
 
-Changing any of these attributes causes a `PolicyServer` deployment with the new configuration.
+Changing any of these attributes causes a `[[< policy-server-component >]]` deployment with the new configuration.
 
 ### ClusterAdmissionPolicy
 
@@ -196,7 +196,7 @@ Overview of the attributes of the `ClusterAdmissionPolicy` resource:
 
 | Required | Placeholder         | Description    |
 |:--------:| ------------------- | ----------------------------- |
-| N | `policy-server`  | Identifies an existing `PolicyServer` object. The policy will be served only by this `PolicyServer` instance. A `ClusterAdmissionPolicy` that doesn't have an explicit `PolicyServer`, will be served by the one named `default` |
+| N | `policy-server`  | Identifies an existing `[[< policy-server-component >]]` object. The policy will be served only by this `[[< policy-server-component >]]` instance. A `ClusterAdmissionPolicy` that doesn't have an explicit `[[< policy-server-component >]]`, will be served by the one named `default` |
 | Y | `module`  | The location of the Kubewarden policy. The following schemes are allowed: |
 | N | | - `registry`: The policy is downloaded from an [OCI artifacts](https://github.com/opencontainers/artifacts) compliant container registry. Example: `registry://<OCI registry/policy URL>` |
 | N | | - `http`, `https`: The policy is downloaded from a regular HTTP(s) server. Example: `https://<website/policy URL>` |
@@ -257,8 +257,8 @@ This produces the following output:
 clusteradmissionpolicy.policies.kubewarden.io/privileged-pods created
 ```
 
-When a `ClusterAdmissionPolicy` is defined, the status is set to `pending`, and it will force a rollout of the targeted `PolicyServer`.
-In our example, it's the `PolicyServer` named `default`. You can monitor the rollout by running the following command:
+When a `ClusterAdmissionPolicy` is defined, the status is set to `pending`, and it will force a rollout of the targeted `[[< policy-server-component >]]`.
+In our example, it's the `[[< policy-server-component >]]` named `default`. You can monitor the rollout by running the following command:
 
 ```console
 kubectl get clusteradmissionpolicy.policies.kubewarden.io/privileged-pods
@@ -273,7 +273,7 @@ privileged-pods   default         false      pending
 
 Once the new policy is ready to be served, the `kubewarden-controller` will register a [ValidatingWebhookConfiguration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#validatingwebhookconfiguration-v1-admissionregistration-k8s-io) object.
 
-The `ClusterAdmissionPolicy` status will be set to `active` once the Deployment is done for every `PolicyServer` instance.
+The `ClusterAdmissionPolicy` status will be set to `active` once the Deployment is done for every `[[< policy-server-component >]]` instance.
 Show `ValidatingWebhookConfiguration` with the following command:
 
 ```console
@@ -361,7 +361,7 @@ kubectl delete namespace kubewarden
 ```
 
 :::caution
-Kubewarden contains a helm pre-delete hook that will remove all `PolicyServers` and `kubewarden-controller`.
+Kubewarden contains a helm pre-delete hook that will remove all `[[< policy-server-component >]]s` and `kubewarden-controller`.
 Then the `kubewarden-controller` will delete all resources, so it is important that `kubewarden-controller` is running when helm uninstall is executed.
 :::
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -23,13 +23,17 @@ doc-topic: [quick-start]
 
 The Kubewarden stack comprises:
 
-- Some `ClusterAdmissionPolicy` resources: this is how policies are defined for Kubernetes clusters
+- Some [[< cluster-admission-policy >]] resources: this is how policies are defined for Kubernetes clusters
 
-- Some '[[< policy-server-component >]]', `[[< c-policy-server-component >]]` resources: representing a deployment of a Kubewarden `[[< c-policy-server-component >]]`. Your administrator's policies are loaded and evaluated by the Kubewarden `[[< c-policy-server-component >]]`
+- Some [[< policy-server >]] resources: representing a deployment of a Kubewarden
+`PolicyServer`. Your administrator's policies are loaded and evaluated by the Kubewarden
+`PolicyServer`
 
-- Some `AdmissionPolicy` resources: policies for a defined namespace
+- Some [[< admission-policy >]] resources: policies for a defined namespace
 
-- A deployment of a `kubewarden-controller`: this controller monitors the `ClusterAdmissionPolicy` resources and interacts with the Kubewarden `[[< c-policy-server-component >]]` components.
+- A deployment of a `kubewarden-controller`: this controller monitors the
+[[< cluster-admission-policy >]] resources and interacts with the Kubewarden
+[[< policy-server >]] components.
 
 :::tip
 
@@ -78,7 +82,7 @@ helm repo update kubewarden
 Install the following Helm charts inside the `kubewarden` namespace in your Kubernetes cluster:
 
 - `kubewarden-crds`, which will register the `ClusterAdmissionPolicy`,
-  `AdmissionPolicy` and `[[< c-policy-server-component >]]` Custom Resource Definitions. As well as
+  `AdmissionPolicy` and `PolicyServer` Custom Resource Definitions. As well as
   the `PolicyReport` Custom Resource Definitions used by the audit scanner
 
 - `kubewarden-controller`, which will install the Kubewarden controller and the
@@ -88,7 +92,7 @@ Install the following Helm charts inside the `kubewarden` namespace in your Kube
   scanner installation [docs page](../howtos/audit-scanner).
   :::
 
-- `kubewarden-defaults`, which will create a `[[< c-policy-server-component >]]` resource named `default`. It can also install a set of
+- `kubewarden-defaults`, which will create a `PolicyServer` resource named `default`. It can also install a set of
   recommended policies to secure your cluster by enforcing some well known best practices.
 
 ```console
@@ -104,7 +108,7 @@ helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defa
 ```
 
 :::caution
-Since [`v0.4.0`](https://github.com/kubewarden/kubewarden-controller/releases/tag/v0.4.0), a `[[< c-policy-server-component >]]` resource named `default` will not be created using the `kubewarden-controller` chart.
+Since [`v0.4.0`](https://github.com/kubewarden/kubewarden-controller/releases/tag/v0.4.0), a `PolicyServer` resource named `default` will not be created using the `kubewarden-controller` chart.
 Now a Helm chart called `kubewarden-defaults`, installs
 the default policy server.
 
@@ -112,9 +116,9 @@ This means that if you are not using the latest version of the `kubewarden-contr
 your default policy server will not be upgraded or deleted.
 So, you might run into issues if you try to install the `kubewarden-defaults` with some conflicting information, for example, the same policy server name.
 To be able to take advantage of future upgrades in the `kubewarden-defaults` Helm chart remove the
-existing `[[< c-policy-server-component >]]` resource created by the `kubewarden-controller` before installing the new chart.
+existing `PolicyServer` resource created by the `kubewarden-controller` before installing the new chart.
 Now you can update your policy server using Helm upgrades without resource conflicts.
-When you remove the `[[< c-policy-server-component >]]`, all the policies bound to it will be removed as well.
+When you remove the `PolicyServer`, all the policies bound to it will be removed as well.
 :::
 
 The default configuration values are sufficient for most deployments. All options are documented [here](https://charts.kubewarden.io/#configuration).
@@ -123,17 +127,17 @@ The default configuration values are sufficient for most deployments. All option
 
 Kubewarden has three main components which you will interact with:
 
-- The [[< c-policy-server-component >]]
+- The [[< policy-server >]]
 - The ClusterAdmissionPolicy
 - The AdmissionPolicy
 
-### [[< c-policy-server-component >]]
+### `PolicyServer`
 
-A Kubewarden `[[< c-policy-server-component >]]` is managed by the `kubewarden-controller` and multiple `[[< c-policy-server-component >]]s` can be deployed in the same Kubernetes cluster.
+A Kubewarden `PolicyServer` is managed by the `kubewarden-controller` and multiple [[< policy-server >]]s can be deployed in the same Kubernetes cluster.
 
-A `[[< c-policy-server-component >]]` validates incoming requests by executing Kubewarden policies against them.
+A `PolicyServer` validates incoming requests by executing Kubewarden policies against them.
 
-This is the default `[[< c-policy-server-component >]]` configuration:
+This is the default `PolicyServer` configuration:
 
 ```yaml
 apiVersion: policies.kubewarden.io/v1
@@ -150,21 +154,21 @@ spec:
 ```
 
 :::note
-Check the [latest released `[[< c-policy-server-component >]]` version](https://github.com/kubewarden/policy-server/pkgs/container/policy-server) and change the tag to match.
+Check the [latest released `PolicyServer` version](https://github.com/kubewarden/policy-server/pkgs/container/policy-server) and change the tag to match.
 :::
 
-Overview of the attributes of the `[[< c-policy-server-component >]]` resource:
+Overview of the attributes of the `PolicyServer` resource:
 
 <!-- prettier-ignore -->
 | Required | Placeholder         | Description    |
 |:--------:| ------------------- | ----------------------------- |
 | Y | `image`  | The name of the container image |
 | Y | `replicas`  | The number of desired instances |
-| N | `serviceAccountName` | The name of the `ServiceAccount` to use for the `[[< c-policy-server-component >]]` deployment. If no value is provided, the default `ServiceAccount` from the namespace, where the `kubewarden-controller` is installed, will be used |
+| N | `serviceAccountName` | The name of the `ServiceAccount` to use for the `PolicyServer` deployment. If no value is provided, the default `ServiceAccount` from the namespace, where the `kubewarden-controller` is installed, will be used |
 | N | `env` | The list of environment variables |
 | N | `annotations` | The list of annotations |
 
-Changing any of these attributes causes a `[[< c-policy-server-component >]]` deployment with the new configuration.
+Changing any of these attributes causes a `PolicyServer` deployment with the new configuration.
 
 ### ClusterAdmissionPolicy
 
@@ -204,7 +208,7 @@ Overview of the attributes of the `ClusterAdmissionPolicy` resource:
 
 | Required | Placeholder     | Description                                                                                                                                                                                                                                                                                     |
 | :------: | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|    N     | `policy-server` | Identifies an existing `[[< c-policy-server-component >]]` object. The policy will be served only by this `[[< c-policy-server-component >]]` instance. A `ClusterAdmissionPolicy` that doesn't have an explicit `[[< c-policy-server-component >]]`, will be served by the one named `default` |
+|    N     | `policy-server` | Identifies an existing `PolicyServer` object. The policy will be served only by this `PolicyServer` instance. A `ClusterAdmissionPolicy` that doesn't have an explicit `PolicyServer`, will be served by the one named `default` |
 |    Y     | `module`        | The location of the Kubewarden policy. The following schemes are allowed:                                                                                                                                                                                                                       |
 |    N     |                 | - `registry`: The policy is downloaded from an [OCI artifacts](https://github.com/opencontainers/artifacts) compliant container registry. Example: `registry://<OCI registry/policy URL>`                                                                                                       |
 |    N     |                 | - `http`, `https`: The policy is downloaded from a regular HTTP(s) server. Example: `https://<website/policy URL>`                                                                                                                                                                              |
@@ -265,8 +269,8 @@ This produces the following output:
 clusteradmissionpolicy.policies.kubewarden.io/privileged-pods created
 ```
 
-When a `ClusterAdmissionPolicy` is defined, the status is set to `pending`, and it will force a rollout of the targeted `[[< c-policy-server-component >]]`.
-In our example, it's the `[[< c-policy-server-component >]]` named `default`. You can monitor the rollout by running the following command:
+When a `ClusterAdmissionPolicy` is defined, the status is set to `pending`, and it will force a rollout of the targeted `PolicyServer`.
+In our example, it's the `PolicyServer` named `default`. You can monitor the rollout by running the following command:
 
 ```console
 kubectl get clusteradmissionpolicy.policies.kubewarden.io/privileged-pods
@@ -281,7 +285,7 @@ privileged-pods   default         false      pending
 
 Once the new policy is ready to be served, the `kubewarden-controller` will register a [ValidatingWebhookConfiguration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#validatingwebhookconfiguration-v1-admissionregistration-k8s-io) object.
 
-The `ClusterAdmissionPolicy` status will be set to `active` once the Deployment is done for every `[[< c-policy-server-component >]]` instance.
+The `ClusterAdmissionPolicy` status will be set to `active` once the Deployment is done for every `PolicyServer` instance.
 Show `ValidatingWebhookConfiguration` with the following command:
 
 ```console
@@ -372,7 +376,7 @@ kubectl delete namespace kubewarden
 ```
 
 :::caution
-Kubewarden contains a helm pre-delete hook that will remove all `[[< c-policy-server-component >]]s` and `kubewarden-controller`.
+Kubewarden contains a helm pre-delete hook that will remove all `PolicyServers` and `kubewarden-controller`.
 Then the `kubewarden-controller` will delete all resources, so it is important that `kubewarden-controller` is running when helm uninstall is executed.
 :::
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -81,15 +81,15 @@ helm repo update kubewarden
 
 Install the following Helm charts inside the `kubewarden` namespace in your Kubernetes cluster:
 
-- `kubewarden-crds`, which will register the `ClusterAdmissionPolicy`,
-  `AdmissionPolicy` and `PolicyServer` Custom Resource Definitions. As well as
-  the `PolicyReport` Custom Resource Definitions used by the audit scanner
+- `kubewarden-crds`, which registers the [[< cluster-admission-policy >]],
+  [[< admission-policy >]] and [[< policy-server >]] Custom Resource Definitions. Also,
+  the [[< policy-report >]] Custom Resource Definitions used by the audit scanner.
 
-- `kubewarden-controller`, which will install the Kubewarden controller and the
+- `kubewarden-controller`, which installs the Kubewarden controller and the
   audit scanner
   :::note
-  If you want to disable the audit scanner component. Please check out the audit
-  scanner installation [docs page](../howtos/audit-scanner).
+  If you need to disable the audit scanner component check the audit
+  scanner installation [documentation page](../howtos/audit-scanner).
   :::
 
 - `kubewarden-defaults`, which will create a `PolicyServer` resource named `default`. It can also install a set of
@@ -173,14 +173,14 @@ Changing any of these attributes causes a `PolicyServer` deployment with the new
 
 ### ClusterAdmissionPolicy
 
-The [[< cluster-admission-policy >]]`ClusterAdmissionPolicy` resource is the core of the Kubewarden stack. It defines how policies evaluate requests.
+The [[< cluster-admission-policy >]] resource is the core of the Kubewarden stack. It defines how policies evaluate requests.
 
 Enforcing policies is the most common operation which a Kubernetes administrator performs.
-You can declare as many policies as you want, each will target one or more Kubernetes resources (i.e., `pods`, `Custom Resource`).
-You will also specify the type of operations to be applied to targeted resources.
+You can declare as many policies as you want, each targets one or more Kubernetes resources (that is, `pods`, `Custom Resource` and others).
+You also specify the type of operations applied to targeted resources.
 The operations available are `CREATE`, `UPDATE`, `DELETE` and `CONNECT`.
 
-Default `ClusterAdmissionPolicy` configuration:
+Default [[< cluster-admission-policy >]] configuration:
 
 ```yaml
 apiVersion: policies.kubewarden.io/v1
@@ -205,11 +205,11 @@ spec:
       - NET_ADMIN
 ```
 
-Overview of the attributes of the `ClusterAdmissionPolicy` resource:
+Overview of the attributes of the [[< cluster-admission-policy >]] resource:
 
 | Required | Placeholder     | Description                                                                                                                                                                                                                                                                                     |
 | :------: | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|    N     | `policy-server` | Identifies an existing `PolicyServer` object. The policy will be served only by this `PolicyServer` instance. A `ClusterAdmissionPolicy` that doesn't have an explicit `PolicyServer`, will be served by the one named `default` |
+|    N     | `policy-server` | Identifies an existing `PolicyServer` object. The policy will be served only by this `PolicyServer` instance. A [[< cluster-admission-policy >]] that doesn't have an explicit `PolicyServer`, will be served by the one named `default` |
 |    Y     | `module`        | The location of the Kubewarden policy. The following schemes are allowed:                                                                                                                                                                                                                       |
 |    N     |                 | - `registry`: The policy is downloaded from an [OCI artifacts](https://github.com/opencontainers/artifacts) compliant container registry. Example: `registry://<OCI registry/policy URL>`                                                                                                       |
 |    N     |                 | - `http`, `https`: The policy is downloaded from a regular HTTP(s) server. Example: `https://<website/policy URL>`                                                                                                                                                                              |
@@ -223,17 +223,17 @@ Overview of the attributes of the `ClusterAdmissionPolicy` resource:
 |    N     |                 | - `Fail`: an error calling the webhook causes the admission to fail and the API request to be rejected                                                                                                                                                                                          |
 
 :::note
-The `ClusterAdmissionPolicy` resources are registered with a `*` webhook `scope`, which means that registered webhooks will forward all requests matching the given `resources` and `operations` -- either namespaced or cluster-wide resources.
+The [[< cluster-admission-policy >]] resources are registered with a `*` webhook `scope`, which means that registered webhooks forward all requests matching the given `resources` and `operations` — either namespaced or cluster-wide resources.
 :::
 
 ### AdmissionPolicy
 
-`AdmissionPolicy` is a namespace-wide resource.
-The policy will process only the requests that are targeting the Namespace where the `AdmissionPolicy` is defined.
-Other than that, there are no functional differences between the `AdmissionPolicy` and `ClusterAdmissionPolicy` resources.
+[[< admission-policy >]] is a namespace-wide resource.
+The policy processes only the requests that are targeting the Namespace where the [[< admission-policy >]] is defined.
+Other than that, there are no functional differences between the [[< admission-policy >]] and [[< cluster-admission-policy >]] resources.
 
 :::info
-`AdmissionPolicy` requires Kubernetes 1.21.0 or above. This is because we're using the `kubernetes.io/metadata.name` label, which was introduced in Kubernetes 1.21.0
+[[< admission-policy >]] requires Kubernetes 1.21.0 or greater. This is because we're using the `kubernetes.io/metadata.name` label, which was introduced in Kubernetes 1.21.0
 :::
 
 The complete documentation of these Custom Resources can be found [here](https://github.com/kubewarden/kubewarden-controller/blob/main/docs/crds/README.asciidoc) or on [docs.crds.dev](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller).
@@ -243,7 +243,7 @@ The complete documentation of these Custom Resources can be found [here](https:/
 We will use the [`pod-privileged`](https://github.com/kubewarden/pod-privileged-policy) policy.
 We want to prevent the creation of privileged containers inside our Kubernetes cluster by enforcing this policy.
 
-Let's define a `ClusterAdmissionPolicy` to do that:
+Let's define a [[< cluster-admission-policy >]] to do that:
 
 ```console
 kubectl apply -f - <<EOF
@@ -270,7 +270,7 @@ This produces the following output:
 clusteradmissionpolicy.policies.kubewarden.io/privileged-pods created
 ```
 
-When a `ClusterAdmissionPolicy` is defined, the status is set to `pending`, and it will force a rollout of the targeted `PolicyServer`.
+When a [[< cluster-admission-policy >]] is defined, the status is set to `pending`, and it will force a rollout of the targeted `PolicyServer`.
 In our example, it's the `PolicyServer` named `default`. You can monitor the rollout by running the following command:
 
 ```console
@@ -286,8 +286,8 @@ privileged-pods   default         false      pending
 
 Once the new policy is ready to be served, the `kubewarden-controller` will register a [ValidatingWebhookConfiguration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#validatingwebhookconfiguration-v1-admissionregistration-k8s-io) object.
 
-The `ClusterAdmissionPolicy` status will be set to `active` once the Deployment is done for every `PolicyServer` instance.
-Show `ValidatingWebhookConfiguration` with the following command:
+The [[< cluster-admission-policy >]] status will be set to `active` once the Deployment is done for every `PolicyServer` instance.
+Show [[< validating-webhook-configuration >]]s with the following command:
 
 ```console
 kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io -l kubewarden
@@ -300,7 +300,8 @@ NAME                          WEBHOOKS   AGE
 clusterwide-privileged-pods   1          9s
 ```
 
-Once the `ClusterAdmissionPolicy` is active and the `ValidatingWebhookConfiguration` is registered, you can test the policy.
+Once the [[< cluster-admission-policy >]] is active and the
+[[< validating-webhook-configuration >]] is registered, you can test the policy.
 
 First, let's create a Pod with a Container _not_ in `privileged` mode:
 
@@ -381,7 +382,7 @@ Kubewarden contains a helm pre-delete hook that removes all `PolicyServer`s and 
 Then the `kubewarden-controller` will delete all resources, so it's important that `kubewarden-controller` is running when helm uninstall is executed.
 :::
 
-`ValidatingWebhookConfigurations` and `MutatingWebhookConfigurations` created by kubewarden should be deleted, this can be checked with:
+[[< validating-webhook-configuration >]]s and [[< mutating-webhook-configuration >]]s created by kubewarden should be deleted, this can be checked with:
 
 ```console
 kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io -l "kubewarden"
@@ -403,7 +404,7 @@ kubectl delete -l "kubewarden" mutatingwebhookconfigurations.admissionregistrati
 
 ## Wrapping up
 
-`ClusterAdmissionPolicy` is the core resource that a cluster operator has to manage. The `kubewarden-controller` module automatically takes care of the configuration for the rest of the resources needed to run the policies.
+[[< cluster-admission-policy >]] is the core resource that a cluster operator has to manage. The `kubewarden-controller` module automatically takes care of the configuration for the rest of the resources needed to run the policies.
 
 ## What's next?
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,7 @@
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 
 import dsVariableProcessor from "./js-lib/docusaurus-variables.js";
+import substituteCurrentVersion from "./js-lib/current-version.js";
 
 module.exports = {
   title: "Kubewarden",
@@ -18,6 +19,7 @@ module.exports = {
     preprocessor: ({ filePath, fileContent }) => {
       // Process variables
       fileContent = dsVariableProcessor(fileContent);
+      fileContent = substituteCurrentVersion(fileContent, filePath);
       return fileContent;
     },
   },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,4 +1,7 @@
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
+
+import dsVariableProcessor from "./js-lib/docusaurus-variables.js";
+
 module.exports = {
   title: "Kubewarden",
   tagline: "Kubernetes Dynamic Admission at your fingertips",
@@ -12,6 +15,11 @@ module.exports = {
   trailingSlash: false,
   markdown: {
     mermaid: true,
+    preprocessor: ({ filePath, fileContent }) => {
+      // Process variables
+      fileContent = dsVariableProcessor(fileContent);
+      return fileContent;
+    },
   },
   themes: ["@docusaurus/theme-mermaid"],
   themeConfig: {

--- a/js-lib/current-version.js
+++ b/js-lib/current-version.js
@@ -1,0 +1,36 @@
+function substituteCurrentVersion(fc, fp) {
+  /*
+   * Replace [[< current-version >]] with a version number extracted from
+   * Docusaurus versioned directories.
+   *
+   * The regex extracts a version number in the 'vno' named capture group that
+   * is being used as a part of the directory name.  The assumption is that
+   * version numbers are '/version-n.n.n/' format. There must be at least one
+   * number following the 'version-'.
+   *
+   * Valid examples: /version-1/ /version-1.1/ /version-123.456.789/
+   * /version-1.2.3.4.5.6/
+   *
+   * Invalid: /version-1.2-dev/ /version-1.2rc3/
+   */
+
+  /* cCV(currentCurrentVersion) is the first entry in versions.json.
+   * versions.json is created and managed by Docusaurus when creating
+   * versioned_docs. */
+
+  const cCV = String(require("../versions.json")[0]);
+  const regex = /\/version-(?<vno>(?:\d{1,}\.{0,1})*)\//g;
+  for (const match of fp.matchAll(regex)) {
+    if (match.groups) {
+      fc = fc.replace(/\[\[< current-version >\]\]/g, `${match.groups.vno}`);
+    }
+  }
+
+  /* The next line ensures that any use of [[< current-version >]] outside
+   * a versioned directory, i.e in docs/ will be replaced with the default
+   * cCV (currentCurrentVersion). */
+  fc = fc.replace(/\[\[< current-version >\]\]/g, cCV);
+  return fc;
+}
+
+module.exports = substituteCurrentVersion;

--- a/js-lib/docusaurus-variables.js
+++ b/js-lib/docusaurus-variables.js
@@ -1,0 +1,17 @@
+function dsVariableProcessor(fc) {
+
+  /* A more general scheme for variable processing. Get the variables from
+   * variables.json. Iterate over them, create a regex for each, use it to
+   * replace all instances in the file content, fc, returning fc when complete.
+   */
+
+  const Variables = require("../variables.json");
+  const keys = Object.keys(Variables);
+  keys.forEach((key) => {
+    const re = new RegExp("\\[\\[< " + key + " >\\]\\]", "g");
+    fc = fc.replace(re, Variables[key]);
+  });
+  return fc;
+}
+
+module.exports = dsVariableProcessor;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -44,29 +44,33 @@ html[data-theme='light'] footer {
 html[data-theme='light'] .tooltip {
   position: relative;
   display: inline-block;
-	background-color: lightyellow;
-  border: 0px dashed black;
+	/* background-color: lightyellow; */
+	background-color: #ffeee6;
+  border: 0px;
   border-radius: 6px;
 }
 
 html[data-theme='light'] .tooltip .tooltiptext {
   visibility: hidden;
   width: 240px;
-  background-color: #dddddd;
+  background-color: #eeeeee;
   color: #000000;
   text-align: center;
   padding: 5px 0;
   border-radius: 6px;
-  border: 4px solid magenta;
+  border: 4px solid #fe7c3f;
   position: absolute;
   z-index: 1;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -120px;
 }
 
 html[data-theme='dark'] .tooltip {
   position: relative;
   display: inline-block;
 	background-color: #666666;
-  border: 0px dashed magenta;
+  border: 0px;
   border-radius: 6px;
 }
 
@@ -78,9 +82,12 @@ html[data-theme='dark'] .tooltip .tooltiptext {
   text-align: center;
   padding: 5px 0;
   border-radius: 6px;
-  border: 4px solid orange;
+  border: 4px solid #fe7c3f;
   position: absolute;
   z-index: 1;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -120px;
 }
 
 html[data-theme='light'] .tooltip:hover .tooltiptext {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -41,3 +41,52 @@ html[data-theme='light'] footer {
 	--ifm-link-hover-color: #90ebcd;
 }
 
+html[data-theme='light'] .tooltip {
+  position: relative;
+  display: inline-block;
+	background-color: lightyellow;
+  border: 1px dashed black;
+  border-radius: 6px;
+}
+
+html[data-theme='light'] .tooltip .tooltiptext {
+  visibility: hidden;
+  width: 180px;
+  background-color: #666666;
+  color: #ffffff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+  border: 4px solid violet;
+  position: absolute;
+  z-index: 1;
+}
+
+html[data-theme='dark'] .tooltip {
+  position: relative;
+  display: inline-block;
+	background-color: #666666;
+  border: 1px dashed magenta;
+  border-radius: 6px;
+}
+
+html[data-theme='dark'] .tooltip .tooltiptext {
+  visibility: hidden;
+  width: 180px;
+  background-color: #666666;
+  color: #ffffff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+  border: 4px solid orange;
+  position: absolute;
+  z-index: 1;
+}
+
+html[data-theme='light'] .tooltip:hover .tooltiptext {
+  visibility: visible;
+}
+
+html[data-theme='dark'] .tooltip:hover .tooltiptext {
+  visibility: visible;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -45,19 +45,19 @@ html[data-theme='light'] .tooltip {
   position: relative;
   display: inline-block;
 	background-color: lightyellow;
-  border: 1px dashed black;
+  border: 0px dashed black;
   border-radius: 6px;
 }
 
 html[data-theme='light'] .tooltip .tooltiptext {
   visibility: hidden;
-  width: 180px;
-  background-color: #666666;
-  color: #ffffff;
+  width: 240px;
+  background-color: #dddddd;
+  color: #000000;
   text-align: center;
   padding: 5px 0;
   border-radius: 6px;
-  border: 4px solid violet;
+  border: 4px solid magenta;
   position: absolute;
   z-index: 1;
 }
@@ -66,13 +66,13 @@ html[data-theme='dark'] .tooltip {
   position: relative;
   display: inline-block;
 	background-color: #666666;
-  border: 1px dashed magenta;
+  border: 0px dashed magenta;
   border-radius: 6px;
 }
 
 html[data-theme='dark'] .tooltip .tooltiptext {
   visibility: hidden;
-  width: 180px;
+  width: 240px;
   background-color: #666666;
   color: #ffffff;
   text-align: center;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -44,7 +44,6 @@ html[data-theme='light'] footer {
 html[data-theme='light'] .tooltip {
   position: relative;
   display: inline-block;
-	/* background-color: lightyellow; */
 	background-color: #ffeee6;
   border: 0px;
   border-radius: 6px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -44,9 +44,11 @@ html[data-theme='light'] footer {
 html[data-theme='light'] .tooltip {
   position: relative;
   display: inline-block;
-	background-color: #ffeee6;
-  border: 0px;
-  border-radius: 6px;
+	/* background-color: #ffeee6; */
+  /* border: 0px; */
+  /* border-radius: 6px; */
+  border-bottom: 1px dotted;
+  border-color: #cb6332;
 }
 
 html[data-theme='light'] .tooltip .tooltiptext {
@@ -68,9 +70,11 @@ html[data-theme='light'] .tooltip .tooltiptext {
 html[data-theme='dark'] .tooltip {
   position: relative;
   display: inline-block;
-	background-color: #666666;
-  border: 0px;
-  border-radius: 6px;
+	/* background-color: #666666; */
+  /* border: 0px; */
+  /* border-radius: 6px; */
+  border-bottom: 1px dotted;
+  border-color: #fe7c3f;
 }
 
 html[data-theme='dark'] .tooltip .tooltiptext {

--- a/variables.json
+++ b/variables.json
@@ -1,5 +1,9 @@
 {
   "variable_name": "variable_value",
-  "c-policy-server-component": "PolicyServer",
-  "policy-server-component": "<div class=\"tooltip\">PolicyServer<span class=\"tooltiptext\">A 'PolicyServer' is something. It's really cool! [Glossary](glossary#policy-server-component)</span></div>"
+
+  "admission-policy": "<div class=\"tooltip\">AdmissionServer<span class=\"tooltiptext\">A namespace-wide resource. The policy processes only requests targeting the namespace where the AdmissionPolicy is defined. [Glossary](glossary#admission-policy)</span></div>",
+
+  "policy-server": "<div class=\"tooltip\">PolicyServer<span class=\"tooltiptext\">A PolicyServer validates incoming requests by executing Kubewarden policies against requests. [Glossary](glossary#policy-server)</span></div>",
+
+  "cluster-admission-policy": "<div class=\"tooltip\">ClusterAdmissionPolicy<span class=\"tooltiptext\">A ClusterAdmissionPolicy defines how policies evaluate requests. [Glossary](glossary#cluster-admission-policy)</span></div>"
 }

--- a/variables.json
+++ b/variables.json
@@ -1,6 +1,4 @@
 {
   "variable_name": "variable_value",
-  "foo": "bar",
-  "bob": "alice",
   "policy-server-component": "PolicyServer"
 }

--- a/variables.json
+++ b/variables.json
@@ -1,5 +1,5 @@
 {
   "variable_name": "variable_value",
   "c-policy-server-component": "PolicyServer",
-  "policy-server-component": "<div class=\"tooltip\">PolicyServer<span class=\"tooltiptext\">A 'PolicyServer' is something. It's really cool! [Glossary](https://glossary.link)</span></div>"
+  "policy-server-component": "<div class=\"tooltip\">PolicyServer<span class=\"tooltiptext\">A 'PolicyServer' is something. It's really cool! [Glossary](glossary#policy-server-component)</span></div>"
 }

--- a/variables.json
+++ b/variables.json
@@ -3,7 +3,26 @@
 
   "admission-policy": "<div class=\"tooltip\">AdmissionServer<span class=\"tooltiptext\">A namespace-wide resource. The policy processes only requests targeting the namespace where the AdmissionPolicy is defined. [Glossary](glossary#admission-policy)</span></div>",
 
+  "cluster-admission-policy": "<div class=\"tooltip\">ClusterAdmissionPolicy<span class=\"tooltiptext\">A ClusterAdmissionPolicy defines how policies evaluate requests. [Glossary](glossary#cluster-admission-policy)</span></div>",
+
+  "cluster-policy-report": "<div class=\"tooltip\">ClusterPolicyReport<span class=\"tooltiptext\">A PolicyReport and a ClusterPolicyReport store results of policy scans. Which one is used, depends on the scope of the resource. [Glossary](glossary#clusterpolicyreport)</span></div>",
+
+  "kwctl": "<div class=\"tooltip\">kwctl<span class=\"tooltiptext\">A CLI tool to generate and test Kubernetes YAML files for policy deployment. [Glossary](glossary#kwctl)</span></div>",
+
+  "mutating-webhook-configuration": "<div class=\"tooltip\">MutatingWebhookConfiguration<span class=\"tooltiptext\">A Kubernetes resource created by the Kubewarden controller to let Kubernetes know where to send an `AdmissionReview`. [Glossary](glossary#mutatingwebhookconfiguration)</span></div>",
+
+  "policy-report": "<div class=\"tooltip\">PolicyReport<span class=\"tooltiptext\">A PolicyReport and a ClusterPolicyReport store results of policy scans. Which one is used depends on the scope of the resource. [Glossary](glossary#policyreport)</span></div>",
+
   "policy-server": "<div class=\"tooltip\">PolicyServer<span class=\"tooltiptext\">A PolicyServer validates incoming requests by executing Kubewarden policies against requests. [Glossary](glossary#policy-server)</span></div>",
 
-  "cluster-admission-policy": "<div class=\"tooltip\">ClusterAdmissionPolicy<span class=\"tooltiptext\">A ClusterAdmissionPolicy defines how policies evaluate requests. [Glossary](glossary#cluster-admission-policy)</span></div>"
+  "validating-webhook-configuration": "<div class=\"tooltip\">ValidatingWebhookConfiguration<span class=\"tooltiptext\">A Kubernetes resource created by the Kubewarden controller to let Kubernetes know where to send a `AdmissionReview`. [Glossary](glossary#validatingwebhookconfiguration)</span></div>",
+
+  "waPC": "<div class=\"tooltip\">wapc<span class=\"tooltiptext\">WebAssembly Procedure Calls. https://wapc.io. [Glossary](glossary#wapc)</span></div>",
+
+  "WASI": "<div class=\"tooltip\">wasi<span class=\"tooltiptext\">WebAssembly System Interface. https://wasi.dev. [Glossary](glossary#wasi)</span></div>",
+
+  "Wasm": "<div class=\"tooltip\">wasm<span class=\"tooltiptext\"> A binary instruction format for a stack-based virtual machine. Designed for web deployment. https://webassemly.org.[Glossary](glossary#wasm)</span></div>",
+
+  "Wasmtime": "<div class=\"tooltip\">wasmtime<span class=\"tooltiptext\">A runtime for WebAssembly. https://wasmtime.dev. [Glossary](glossary#wasmtime)</span></div>"
+
 }

--- a/variables.json
+++ b/variables.json
@@ -1,0 +1,6 @@
+{
+  "variable_name": "variable_value",
+  "foo": "bar",
+  "bob": "alice",
+  "policy-server-component": "PolicyServer"
+}

--- a/variables.json
+++ b/variables.json
@@ -1,4 +1,5 @@
 {
   "variable_name": "variable_value",
-  "policy-server-component": "PolicyServer"
+  "c-policy-server-component": "PolicyServer",
+  "policy-server-component": "<div class=\"tooltip\">PolicyServer<span class=\"tooltiptext\">A 'PolicyServer' is something. It's really cool! [Glossary](https://glossary.link)</span></div>"
 }


### PR DESCRIPTION
docusaurus.config.js defines a preprocessor which replaces all instances of the variables defined in `./variables.json` with their values. See the changes in quick-start.md for an example. `[[< policy-server-component >]]' to 'PolicyServer'.

Part of #394.