### PR TITLE
Open telemetry chart requires image repo

### DIFF
--- a/docs/howtos/telemetry/10-opentelemetry-qs.md
+++ b/docs/howtos/telemetry/10-opentelemetry-qs.md
@@ -129,7 +129,8 @@ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm
 helm install --wait \
   --namespace open-telemetry \
   --create-namespace \
-  --version 0.39.2 \
+  --version 0.56.0 \
+  --set "manager.collectorImage.repository=otel/opentelemetry-collector-contrib" \
   my-opentelemetry-operator open-telemetry/opentelemetry-operator
 ```
 


### PR DESCRIPTION
## Description

Latest [open-telemetry chart](https://github.com/open-telemetry/opentelemetry-helm-charts/releases/tag/opentelemetry-operator-0.56.0) requires collector image be set. Change is described in [their documentation](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md#0553-to-0560).

We have 2 options. I tried both and only `collector-contrib` works with our current setup.
 - `otel/opentelemetry-collector-k8s`
 - `otel/opentelemetry-collector-contrib`
