### PR TITLE
fix: disable Google analytics when building on Netlify.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,10 +119,6 @@ module.exports = {
         theme: {
           customCss: [require.resolve("./src/css/custom.css")],
         },
-        googleAnalytics: {
-          trackingID: "UA-56382716-13",
-          anonymizeIP: true,
-        },
         gtag: {
           trackingID: "G-PSW07XK7TM", // Google Analytics tracking ID for CNCF
           anonymizeIP: true,

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+# Configuration file to customize the build process of the website when
+# previewing it on Netlify.
+[build]
+publish = "build"
+command = "yarn build -- --dev" # Build in development mode to disable Google Analytics
+
+


### PR DESCRIPTION
## Description

Customizes the Netlify build used to preview the website building in development mode to disable the Google analytics. Therefore, we do not pollute our dashboard with development data.

Fix https://github.com/kubewarden/kubewarden.io/issues/224
