### PR TITLE
fix: enable right policy-reporter UI ingress.

### DIFF
--- a/docs/howtos/audit-scanner.md
+++ b/docs/howtos/audit-scanner.md
@@ -100,13 +100,15 @@ See this example of an Ingress configuration via the subchart:
 auditScanner:
   policyReporter: true
 policy-reporter: # subchart values settings
-  ingress:
+  ui:
     enabled: true
-    hosts:
-      - host: "*.local"
-        paths:
-          - path: /ui
-            pathType: Exact
+    ingress:
+      enabled: true
+      hosts:
+        - host: "*.local" # change this to your appropriate domain
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
 ```
 
 #### Port-forwarding


### PR DESCRIPTION
## Description

In the audit scanner the ingress configuration provided enabled the ingress to the policy-reporter service not for its UI. As stated in the documentation. This commit fix that by updating the example ingress configuration enabling the UI one.

Fix https://github.com/kubewarden/helm-charts/issues/463
