### PR TITLE
fix: backport fix to audit-scanner ingress docs

### DIFF
--- a/versioned_docs/version-1.10/howtos/audit-scanner.md
+++ b/versioned_docs/version-1.10/howtos/audit-scanner.md
@@ -101,13 +101,15 @@ See this example of an Ingress configuration via the subchart:
 auditScanner:
   policyReporter: true
 policy-reporter: # subchart values settings
-  ingress:
+  ui:
     enabled: true
-    hosts:
-      - host: "*.local"
-        paths:
-          - path: /ui
-            pathType: Exact
+    ingress:
+      enabled: true
+      hosts:
+        - host: "*.local" # change this to your appropriate domain
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
 ```
 
 #### Port-forwarding

--- a/versioned_docs/version-1.11/howtos/audit-scanner.md
+++ b/versioned_docs/version-1.11/howtos/audit-scanner.md
@@ -100,13 +100,15 @@ See this example of an Ingress configuration via the subchart:
 auditScanner:
   policyReporter: true
 policy-reporter: # subchart values settings
-  ingress:
+  ui:
     enabled: true
-    hosts:
-      - host: "*.local"
-        paths:
-          - path: /ui
-            pathType: Exact
+    ingress:
+      enabled: true
+      hosts:
+        - host: "*.local" # change this to your appropriate domain
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
 ```
 
 #### Port-forwarding

--- a/versioned_docs/version-1.12/howtos/audit-scanner.md
+++ b/versioned_docs/version-1.12/howtos/audit-scanner.md
@@ -100,13 +100,15 @@ See this example of an Ingress configuration via the subchart:
 auditScanner:
   policyReporter: true
 policy-reporter: # subchart values settings
-  ingress:
+  ui:
     enabled: true
-    hosts:
-      - host: "*.local"
-        paths:
-          - path: /ui
-            pathType: Exact
+    ingress:
+      enabled: true
+      hosts:
+        - host: "*.local" # change this to your appropriate domain
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
 ```
 
 #### Port-forwarding

--- a/versioned_docs/version-1.13/howtos/audit-scanner.md
+++ b/versioned_docs/version-1.13/howtos/audit-scanner.md
@@ -100,13 +100,15 @@ See this example of an Ingress configuration via the subchart:
 auditScanner:
   policyReporter: true
 policy-reporter: # subchart values settings
-  ingress:
+  ui:
     enabled: true
-    hosts:
-      - host: "*.local"
-        paths:
-          - path: /ui
-            pathType: Exact
+    ingress:
+      enabled: true
+      hosts:
+        - host: "*.local" # change this to your appropriate domain
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
 ```
 
 #### Port-forwarding


### PR DESCRIPTION
Backport the fix done inside of d0d7d8796e6b25c5927081bf57290798af7da135 to the versioned docs of 1.10, 1.11, 1.12 and 1.13.

Without this commit the fix is visible only inside of the "next" docs.
