### PR TITLE
Update cert manager to supported v1.15

### DIFF
--- a/docs/howtos/airgap/02-install.md
+++ b/docs/howtos/airgap/02-install.md
@@ -144,7 +144,7 @@ Install `cert-manager`, if not already installed, in the air gap cluster:
 ```shell
 helm install --create-namespace cert-manager ./cert-manager-<Version>.tgz \
     -n kubewarden \
-    --set installCRDs=true \
+    --set crds.enabled=true \
     --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/jetstack/cert-manager-controller \
     --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/jetstack/cert-manager-webhook \
     --set cainjector.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/jetstack/cert-manager-cainjector \

--- a/docs/howtos/telemetry/10-opentelemetry-qs.md
+++ b/docs/howtos/telemetry/10-opentelemetry-qs.md
@@ -103,7 +103,7 @@ with Cert Manager, [see the compat chart](https://github.com/open-telemetry/open
 We will install the latest cert-manager Helm chart:
 
 :::note
-At time of writing the latest cert-manager chart version is `v1.13.1`
+At time of writing the latest cert-manager chart version is `v1.15.1`
 :::
 
 ```console
@@ -112,8 +112,8 @@ helm repo add jetstack https://charts.jetstack.io
 helm install --wait \
     --namespace cert-manager \
     --create-namespace \
-    --set installCRDs=true \
-    --version 1.13.1 \
+    --set crds.enabled=true \
+    --version 1.15.1 \
     cert-manager jetstack/cert-manager
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -53,7 +53,7 @@ You can install the latest version of `cert-manager` through Helm by running the
 helm repo add jetstack https://charts.jetstack.io
 
 helm install --wait --namespace cert-manager --create-namespace \
-	--set installCRDs=true cert-manager jetstack/cert-manager
+	--set crds.enabled=true cert-manager jetstack/cert-manager
 ```
 
 :::
@@ -413,7 +413,7 @@ Now, you are ready to deploy Kubewarden! Have a look at the policies on
 [artifacthub.io](https://artifacthub.io/packages/search?kind=13), on
 [GitHub](https://github.com/topics/kubewarden-policy), or reuse existing Rego
 policies as shown in the [following
-chapters](tutorials/writing-policies/rego/01-intro-rego.md). 
+chapters](tutorials/writing-policies/rego/01-intro-rego.md).
 
 <details>
 <summary>Full list of available policies on ArtifactHub</summary>


### PR DESCRIPTION
v1.13 is out of support, see https://cert-manager.io/docs/releases/.

PR also fixes installation warning: 
```
⚠️  WARNING: `installCRDs` is deprecated, use `crds.enabled` instead.
```