### PR TITLE
fix: Use correct var substitution for admission-policy

### DIFF
--- a/variables.json
+++ b/variables.json
@@ -1,7 +1,7 @@
 {
   "variable_name": "variable_value",
 
-  "admission-policy": "<div class=\"tooltip\">AdmissionServer<span class=\"tooltiptext\">A namespace-wide resource. The policy processes only requests targeting the namespace where the AdmissionPolicy is defined. [Glossary](glossary#admission-policy)</span></div>",
+  "admission-policy": "<div class=\"tooltip\">AdmissionPolicy<span class=\"tooltiptext\">A namespace-wide resource. The policy processes only requests targeting the namespace where the AdmissionPolicy is defined. [Glossary](glossary#admission-policy)</span></div>",
 
   "cluster-admission-policy": "<div class=\"tooltip\">ClusterAdmissionPolicy<span class=\"tooltiptext\">A ClusterAdmissionPolicy defines how policies evaluate requests. [Glossary](glossary#cluster-admission-policy)</span></div>",
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

Fix correct var name for `admission-policy`, if not it shows as AdmissionServer (e.g: in [quickstart](https://docs.kubewarden.io/quick-start#admissionpolicy)).

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
