### PR TITLE
fix: Add missing slack-room link

### DIFF
--- a/docs/disclosure.md
+++ b/docs/disclosure.md
@@ -49,3 +49,5 @@ On receipt the security team will:
 Please, refer to the [community
 repository](https://github.com/kubewarden/community) to find more about the
 project Governance and Security Policy.
+
+[slack-room]: https://kubernetes.slack.com/archives/C03L52JRAFM


### PR DESCRIPTION
## Description

Fix missing link introduced with https://github.com/kubewarden/docs/pull/437.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
