### PR TITLE
Redirect for OPA comparison, old link used in Rancher docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -136,4 +136,18 @@ module.exports = {
       },
     ],
   ],
+  plugins: [
+    [
+      "@docusaurus/plugin-client-redirects",
+      {
+        fromExtensions: ["html", "htm"],
+        redirects: [
+          {
+            from: ["/explanations/opa-comparison"],
+            to: "/explanations/comparisons/opa-comparison",
+          },
+        ],
+      },
+    ],
+  ],
 };


### PR DESCRIPTION
Here: 

https://forums.rancher.com/t/rancher-release-v2-8-2/42526#opa-gatekeeper-mapps-42

And probably other places in Rancher notes and docs there is a link to 

https://docs.kubewarden.io/explanations/opa-comparison

which needs to be redirected to the new location

https://docs.kubewarden.io/explanations/comparisons/opa-comparison

