### PR TITLE
Fix the name of the get_resource operation

### DIFF
--- a/docs/reference/spec/host-capabilities/06-kubernetes.md
+++ b/docs/reference/spec/host-capabilities/06-kubernetes.md
@@ -34,7 +34,7 @@ waPC has the following function arguments when performing a call from the guest 
 
 - Binding - `kubewarden`
 - Namespace - `kubernetes`
-- Operation - `list_resources_all`, `list_resources_by_namespace`, or `get_resources`
+- Operation - `list_resources_all`, `list_resources_by_namespace`, or `get_resource`
 - Payload - input payload - see below
 
 and returns:
@@ -100,7 +100,7 @@ This API function returns an error when used to fetch cluster-wide resources
 Use the `list_resources_all` when dealing with cluster-wide resources.
 :::
 
-### Operation - `get_resources`
+### Operation - `get_resource`
 
 #### Input
 

--- a/versioned_docs/version-1.15/reference/spec/host-capabilities/06-kubernetes.md
+++ b/versioned_docs/version-1.15/reference/spec/host-capabilities/06-kubernetes.md
@@ -100,7 +100,7 @@ This API function returns an error when used to fetch cluster-wide resources
 Use the `list_resources_all` when dealing with cluster-wide resources.
 :::
 
-### Operation - `get_resources`
+### Operation - `get_resource`
 
 #### Input
 


### PR DESCRIPTION
## Description

Fix Doc issue, the operation is called "get_resource" singular per https://github.com/kubewarden/policy-evaluator/blob/3cd66b932b199037e677e3e204d4d9742e23edc8/src/runtimes/callback.rs#L276


## Test

None

## Additional Information

### Tradeoff

None

### Potential improvement

None
