### PR TITLE
Update otel chart dep to >= 0.65

### DIFF
--- a/docs/howtos/telemetry/10-opentelemetry-qs.md
+++ b/docs/howtos/telemetry/10-opentelemetry-qs.md
@@ -120,7 +120,7 @@ helm install --wait \
 Once cert-manager is up and running, the OpenTelemetry operator Helm chart can be installed in this way:
 
 :::note
-At time of writing the latest OpenTelemetry operator chart version is `0.65.0`
+At the time of writing (2024-11-11) the latest OpenTelemetry operator chart version is `0.65.0`
 :::
 
 ```console

--- a/docs/howtos/telemetry/10-opentelemetry-qs.md
+++ b/docs/howtos/telemetry/10-opentelemetry-qs.md
@@ -120,7 +120,7 @@ helm install --wait \
 Once cert-manager is up and running, the OpenTelemetry operator Helm chart can be installed in this way:
 
 :::note
-At time of writing the latest OpenTelemetry operator chart version is `0.56.0`
+At time of writing the latest OpenTelemetry operator chart version is `0.65.0`
 :::
 
 ```console
@@ -129,7 +129,7 @@ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm
 helm install --wait \
   --namespace open-telemetry \
   --create-namespace \
-  --version 0.56.0 \
+  --version 0.65.0 \
   --set "manager.collectorImage.repository=otel/opentelemetry-collector-contrib" \
   my-opentelemetry-operator open-telemetry/opentelemetry-operator
 ```

--- a/docs/reference/dependency-matrix.md
+++ b/docs/reference/dependency-matrix.md
@@ -31,7 +31,7 @@ Needed for specific features.
 
 | Chart dependency                                   | Helm chart `appVersion` |             Helm chart `version`             |      Feature      |
 | -------------------------------------------------- | :---------------------: | :------------------------------------------: | :---------------: |
-| `open-telemetry/opentelemetry-operator` chart      |        `>= 0.98`        |              Example: `0.56.0`               |       OTLM        |
+| `open-telemetry/opentelemetry-operator` chart      |       `>= 0.104`        |              Example: `0.65.0`               |       OTLM        |
 | `prometheus-community/kube-prometheus-stack` chart |       `>= v0.69`        |              Example: `51.5.3`               |      Metrics      |
 | `jaegertracing/jaeger-operator` chart              |      `>= 1.49 < 2`      |              Example: `2.49.0`               |      Tracing      |
 | `kyverno/policy-reporter` chart                    |       `>= 2 < 3`        | In `kubewarden-controller` chart as subchart | Policy Reports UI |


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
From Kubewarden 1.18 We need minimum open-telemetry/opentelemetry-operator >= 0.104, shipped in the opentelemetry-operator chart 0.65.0, as we make use of opentelemetry.io/v1beta1 CRDs.

See: https://github.com/kubewarden/helm-charts/issues/579

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
This dep bump was untested, but we run the e2e tests against latest otel charts.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
