### PR TITLE
fix: add .NET policy template to C# page

### DIFF
--- a/docs/tutorials/writing-policies/dotnet.md
+++ b/docs/tutorials/writing-policies/dotnet.md
@@ -29,6 +29,8 @@ Policy authors can use the following resources:
 
 - [Kubewarden .NET Core SDK](https://github.com/kubewarden/policy-sdk-dotnet):
 this provides a set of objects and functions that simplify the process of writing policies.
+- [Kubewarden .NET template project](https://github.com/kubewarden/dotnet-policy-template): use this template to scaffold a .NET-based policy.
+The template comes with a working policy and a set of GitHub Actions to automate its lifecycle.
 - [Kubewarden policy example](https://github.com/kubewarden/policy-sdk-dotnet/tree/main/example):
 this is an example of a working policy.
 
@@ -38,10 +40,3 @@ The SDK enables writing both validating and mutating policies.
 It's possible to use the
 [`KubernetesClient.Models`](https://www.nuget.org/packages/KubernetesClient.Models)
 library to deal with the Kubernetes objects.
-
-## Project template
-
-Currently, we don't have a project template that can scaffold a C# policy.
-
-Please, [open an issue](https://github.com/kubewarden/policy-sdk-dotnet/issues)
-if interested.


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

The [.NET policy template repo](https://github.com/kubewarden/dotnet-policy-template) exists now
  - so describe it following same style/pattern as [the Swift page](https://github.com/kubewarden/docs/blob/bb35cdd8ebc4f5088693ef62aada47d1800ba5b5/docs/tutorials/writing-policies/swift.md?plain=1#L40)
  
Similar to https://github.com/kubewarden/.github/pull/19

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

See the [rich diff](https://github.com/kubewarden/docs/pull/468/files?short_path=472e171#diff-472e1719907b1aea349e0741e6377c48af90190e3679ed0e4bf22d549e3fad82)

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

n/a

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

n/a