### PR TITLE
fix: labels for PR updating CLI docs.

### DIFF
--- a/updatecli/values.d/update-cli-ref-docs.yaml
+++ b/updatecli/values.d/update-cli-ref-docs.yaml
@@ -12,3 +12,7 @@ scm:
   commitmessage:
     hidecredit: true
     footers: "Signed-off-by: Kubewarden bot <cncf-kubewarden-maintainers@lists.cncf.io>"
+pr:
+  labels:
+    - "kind/chore"
+    - "area/documentation"


### PR DESCRIPTION
## Description

Updates the updatecli values file to use the right labels in the PR created to update the CLI reference documentation.
