### PR TITLE
fix(ci): update CLI reference docs only when necessary.

### DIFF
--- a/updatecli/update-cli-ref-docs.yaml
+++ b/updatecli/update-cli-ref-docs.yaml
@@ -1,6 +1,6 @@
 policies:
-  - name: Update kwctl CLI reference documentation
-    policy: ghcr.io/updatecli/policies/file:0.1.1@sha256:ce294b3553e12056235ac98d799366d3c43f8eb527fdf47f7585392e6dd684f0 
+  - name: Copy CLI reference documentation files
+    policy: ghcr.io/jvanz/updatecli/policies/copy:0.1.0
     values:
       - values.d/update-cli-ref-docs.yaml
   - name: Add header to the CLI reference documentation

--- a/updatecli/updatecli.d/headers.yaml
+++ b/updatecli/updatecli.d/headers.yaml
@@ -4,10 +4,7 @@
 # {{ $GitHubPAT := env "GITHUB_TOKEN"}}
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
-name: Add header to the CLI reference documentation
-#{{ if .pipelineid }}
-pipelineid: '{{ .pipelineid }}'
-#{{ end }}
+name: Updates CLI reference documentation files
 
 scms:
   target:
@@ -29,7 +26,6 @@ sources:
 # {{ range $index, $file := .files }}
   file{{ $index }}:
     kind: file
-    scmid: target
     transformers:
       - addprefix: |
           ---
@@ -49,7 +45,7 @@ sources:
 targets:
 # {{ range $index, $file := .files }}
   commit{{ $index }}:
-    name: "Add header to the {{ $file.path }} file"
+    name: "updates {{ $file.path }} file"
     kind: file
     scmid: target
     sourceid: file{{ $index }}
@@ -69,5 +65,11 @@ actions:
 # {{ end }}
 # {{ if .pr.description }}
       description: {{ .pr.description }}
+# {{ end }}
+# {{ if .pr.labels }}
+      labels:
+# {{ range .pr.labels }}
+        - '{{ . }}'
+# {{ end }}
 # {{ end }}
 

--- a/updatecli/values.d/headers.yaml
+++ b/updatecli/values.d/headers.yaml
@@ -1,5 +1,4 @@
 ---
-pipelineid: cli-ref-docs
 files:
   - path: "docs/reference/kwctl-cli.md"
     sidebar_label: kwctl CLI Reference
@@ -15,3 +14,6 @@ scm:
 pr:
   title: "Update CLI Reference Docs"
   description: "Update all the CLI reference documentation"
+  labels:
+    - "kind/chore"
+    - "area/documentation"

--- a/updatecli/values.d/update-cli-ref-docs.yaml
+++ b/updatecli/values.d/update-cli-ref-docs.yaml
@@ -5,4 +5,4 @@ files:
     dst: "docs/reference/kwctl-cli.md"
 src:
   branch: "main"
-  url: "https://github.com/jvanz/kwctl.git"
+  url: "https://github.com/kubewarden/kwctl.git"

--- a/updatecli/values.d/update-cli-ref-docs.yaml
+++ b/updatecli/values.d/update-cli-ref-docs.yaml
@@ -1,18 +1,8 @@
 ---
 # Values.yaml contains settings that be used from Updatecli manifest.
-pipelineid: cli-ref-docs
 files:
   - src: "cli-docs.md"
     dst: "docs/reference/kwctl-cli.md"
 src:
   branch: "main"
-  url: "https://github.com/kubewarden/kwctl.git"
-scm:
-  branch: "main"
-  commitmessage:
-    hidecredit: true
-    footers: "Signed-off-by: Kubewarden bot <cncf-kubewarden-maintainers@lists.cncf.io>"
-pr:
-  labels:
-    - "kind/chore"
-    - "area/documentation"
+  url: "https://github.com/jvanz/kwctl.git"


### PR DESCRIPTION
Updates the updatecli script to update the CLI reference documentation only when there is some change in the file.
