### PR TITLE
fix(quick-start): correctly render variables

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,9 +33,9 @@ your administrator's policies.
 
 - Some [[< admission-policy >]] resources: policies for a defined namespace.
 
-- A deployment of a `kubewarden-controller`: this controller monitors the [[<
-cluster-admission-policy >]] resources and interacts with the Kubewarden [[<
-policy-server >]] components.
+- A deployment of a `kubewarden-controller`: this controller monitors the
+[[< cluster-admission-policy >]] resources and interacts with the Kubewarden
+[[< policy-server >]] components.
 
 :::tip
 

--- a/versioned_docs/version-1.22/quick-start.md
+++ b/versioned_docs/version-1.22/quick-start.md
@@ -33,9 +33,9 @@ your administrator's policies.
 
 - Some [[< admission-policy >]] resources: policies for a defined namespace.
 
-- A deployment of a `kubewarden-controller`: this controller monitors the [[<
-cluster-admission-policy >]] resources and interacts with the Kubewarden [[<
-policy-server >]] components.
+- A deployment of a `kubewarden-controller`: this controller monitors the
+[[< cluster-admission-policy >]] resources and interacts with the Kubewarden
+[[< policy-server >]] components.
 
 :::tip
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

In the quick-start (`/quick-start`), a new line was added in between the [required syntax](https://github.com/kubewarden/docs/blob/a1ac1a8b84727bbe7c1f9a2b6956dc3a83688f98/js-lib/docusaurus-variables.js#L11) for two variables, making them erroneously render as plain text
  - move the whole variable to the next line to properly render it, matching how it was before https://github.com/kubewarden/docs/pull/539#discussion_r1976789946
  
<details><summary>Here's how it looked like <i>before</i> this change:</summary>

![Screenshot 2025-03-02 at 8 50 14 PM](https://github.com/user-attachments/assets/5db196b4-61c4-43b5-8054-8d2a20c953df)

</details>


## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

```sh
yarn start &
open http://localhost:3000/quick-start
```

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->
n/a

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
n/a