### PR TITLE
doc: rename webhooks' hardening page

### DIFF
--- a/docs/reference/security-hardening/webhooks-hardening.md
+++ b/docs/reference/security-hardening/webhooks-hardening.md
@@ -1,7 +1,7 @@
 ---
-sidebar_label: Webhook Mutual TLS
-title: Secure webhooks with mutual TLS
-description: Harden the webhook configuration.
+sidebar_label: Webhooks
+title: Harderning the Kubewarden webhooks
+description: Limit access to Kubewarden webhooks.
 keywords: [kubewarden, kubernetes, security]
 doc-persona: [kubewarden-operator, kubewarden-integrator]
 doc-type: [reference]
@@ -9,7 +9,7 @@ doc-topic: [reference, security]
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.kubewarden.io/reference/security-hardening/webhook-mtls"/>
+  <link rel="canonical" href="https://docs.kubewarden.io/reference/security-hardening/webhooks-hardening"/>
 </head>
 
 The Kubewarden stack uses various webhooks to enforce policies in a Kubernetes cluster. Each `PolicyServer` instance exposes a webhook

--- a/docs/reference/threat-model.md
+++ b/docs/reference/threat-model.md
@@ -135,7 +135,7 @@ and admission controller webhook.
 
 Configure the cluster with mTLS authentication for the Webhooks and enable the mTLS feature in the
 Kubewarden stack. Alternatively, setup mTLS using a CNI that supports Network Policies.
-See [here](./security-hardening/webhook-mtls.md) for more information.
+See [here](./security-hardening/webhooks-hardening.md) for more information.
 
 Use the
 [capabilities-psp](https://artifacthub.io/packages/kubewarden/capabilities-psp/capabilities-psp)
@@ -152,7 +152,7 @@ for the admission controller webhook, by spoofing.
 
 Configure the cluster with mTLS authentication for the Webhooks and enable the mTLS feature in the
 Kubewarden stack. Alternatively, setup mTLS using a CNI that supports Network Policies.
-See [here](./security-hardening/webhook-mtls.md) for more information.
+See [here](./security-hardening/webhooks-hardening.md) for more information.
 
 ### Threat 10 - Abusing a mutation rule to create a privileged container
 


### PR DESCRIPTION
Move to a different link, use a different name.

Fixes https://github.com/kubewarden/docs/issues/559
