### PR TITLE
fix: remove arrows from CLI reference documentation.

### DIFF
--- a/updatecli/updatecli.d/headers.yaml
+++ b/updatecli/updatecli.d/headers.yaml
@@ -38,6 +38,9 @@ sources:
           doc-type: {{ $file.doc_type }}
           doc-topic: {{ $file.doc_topic }}
           ---
+      - replacer:
+          from: "↴"
+          to: ""
     spec:
       file: {{ $file.path }}
 # {{ end }}


### PR DESCRIPTION
## Description

Updates the updatecli policy used to add the headers in the CLI reference documentation to remove the arrows added in the markdown files.

Related to #493 

