### PR TITLE
refactor: s#peaceiris/actions-gh-pages#actions/deploy-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+  id-token: write
+  pages: write
 
 jobs:
   deploy:
+    environment:
+      name: github-pages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main docs repo
@@ -20,8 +26,11 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           yarn build
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact for deployment
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+          path: ./build
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use actions/upload-pages-artifact for the publish dir to consume from actions/deploy-pages.

## Description

Part of https://github.com/kubewarden/kubewarden-controller/issues/1097.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Workflow run:
https://github.com/viccuad/docs/actions/runs/14836710802

Visible at:
https://viccuad.github.io/docs/

I didn't change the base URL config of docusaurus, and I believe that's why it isn't showing correctly. But I think it is fine.
<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
