### PR TITLE
struct.Pod ref broken link fix.

### DIFF
--- a/docs/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/docs/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In the line marked ➀. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In the line marked ➁. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In the line marked ➂. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In the line marked ➃. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.10/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.10/writing-policies/rust/04-write-validation-logic.md
@@ -65,7 +65,7 @@ Walking through the code listing:
 - In line 2. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In line 10. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In line 13. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In line 36. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.11/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.11/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In line 2. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In line 10. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In line 13. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In line 36. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.12/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.12/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In line 2. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In line 10. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In line 13. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In line 36. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.13/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.13/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In line 2. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In line 10. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In line 13. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In line 36. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.14/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.14/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In line 2. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In line 10. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In line 13. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In line 36. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.15/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.15/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In line 2. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In line 10. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In line 13. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In line 36. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.16/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.16/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In line 2. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In line 10. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In line 13. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In line 36. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.17/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.17/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In line 2. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In line 10. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In line 13. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In line 36. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.18/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.18/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In line 2. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In line 10. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In line 13. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In line 36. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.19/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.19/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In line 2. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In line 10. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In line 13. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In line 36. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.20/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.20/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In the line marked ➀. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In the line marked ➁. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In the line marked ➂. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In the line marked ➃. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.21/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.21/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In the line marked ➀. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In the line marked ➁. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In the line marked ➂. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In the line marked ➃. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.22/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.22/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In the line marked ➀. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In the line marked ➁. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In the line marked ➂. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In the line marked ➃. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.23/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.23/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In the line marked ➀. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In the line marked ➁. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In the line marked ➂. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In the line marked ➃. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.24/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.24/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In the line marked ➀. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In the line marked ➁. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In the line marked ➂. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In the line marked ➃. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.25/tutorials/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.25/tutorials/writing-policies/rust/04-write-validation-logic.md
@@ -69,7 +69,7 @@ Walking through the code listing:
 - In the line marked ➀. Parse the incoming `payload` into a `ValidationRequest<Setting>` object.
 This automatically populates the `Settings` instance inside the `ValidationRequest` with the parameters provided by the user.
 - In the line marked ➁. Convert the Kubernetes raw JSON object embedded into the request into an instance of the
-[Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+[Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
 - In the line marked ➂. The request has a Pod object, the code approves only the requests that don't have `metadata.name` equal to the hard-coded value `invalid-pod-name`
 - In the line marked ➃. The request doesn't contain a Pod object, hence the policy accepts the request.
 

--- a/versioned_docs/version-1.7/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.7/writing-policies/rust/04-write-validation-logic.md
@@ -45,7 +45,7 @@ This is a walk-through the code described above:
     automatically populates the `Settings` instance inside of `ValidationRequest` with
     the params provided by the user.
   2. Convert the Kubernetes raw JSON object embedded into the request
-    into an instance of the [Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+    into an instance of the [Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
   3. The request contains a Pod object, the code approves only the requests
     that do not have `metadata.name` equal to the hard-coded value `invalid-pod-name`
   4. The request doesn't contain a Pod object, hence the policy accepts the request

--- a/versioned_docs/version-1.8/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.8/writing-policies/rust/04-write-validation-logic.md
@@ -45,7 +45,7 @@ This is a walk-through the code described above:
     automatically populates the `Settings` instance inside of `ValidationRequest` with
     the params provided by the user.
   2. Convert the Kubernetes raw JSON object embedded into the request
-    into an instance of the [Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+    into an instance of the [Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
   3. The request contains a Pod object, the code approves only the requests
     that do not have `metadata.name` equal to the hard-coded value `invalid-pod-name`
   4. The request doesn't contain a Pod object, hence the policy accepts the request

--- a/versioned_docs/version-1.9/writing-policies/rust/04-write-validation-logic.md
+++ b/versioned_docs/version-1.9/writing-policies/rust/04-write-validation-logic.md
@@ -45,7 +45,7 @@ This is a walk-through the code described above:
     automatically populates the `Settings` instance inside of `ValidationRequest` with
     the params provided by the user.
   2. Convert the Kubernetes raw JSON object embedded into the request
-    into an instance of the [Pod struct](https://arnavion.github.io/k8s-openapi/v0.11.x/k8s_openapi/api/core/v1/struct.Pod.html)
+    into an instance of the [Pod struct](https://arnavion.github.io/k8s-openapi/v0.25.x/k8s_openapi/api/core/v1/struct.Pod.html)
   3. The request contains a Pod object, the code approves only the requests
     that do not have `metadata.name` equal to the hard-coded value `invalid-pod-name`
   4. The request doesn't contain a Pod object, hence the policy accepts the request


### PR DESCRIPTION
The original link is to v0.11.x which is now 404. I've updated it to v0.25.x. Is that OK? Lots of versions in between. I don't know if it makes difference or not.