### PR TITLE
policy evaluation timeout language review for active voice as part of the CNCF recommendations.

### DIFF
--- a/docs/reference/policy-evaluation-timeout.md
+++ b/docs/reference/policy-evaluation-timeout.md
@@ -21,60 +21,58 @@ This feature is available starting from Kubewarden v1.5.0.
 Policy evaluation timeout protection is a security feature of Policy Server.
 It's purpose is to limit the amount of time a request evaluation can take.
 
-This feature is enabled by default from Kubewarden v1.5.0.
+Kubewarden enables this feature from version v1.5.0.
 
 ## Purpose
 
-Kubewarden policies can be written using both traditional programming languages
+You can write Kubewarden policies using both traditional programming languages
 (like [Go](../tutorials/writing-policies/go/01-intro-go.md),
 [Rust](../tutorials/writing-policies/rust/01-intro-rust.md) and
-[others](../tutorials/writing-policies/index.md)
-) or using the special query language [Rego](../tutorials/writing-policies/rego/01-intro-rego.md).
-While both approaches have their pros and cons, the goal of Kubewarden is to allow the policy
-authors to pick the best tool to do their job.
+[others](../tutorials/writing-policies/index.md)) or using the special query
+language [Rego](../tutorials/writing-policies/rego/01-intro-rego.md). Both
+approaches have merits so a goal of Kubewarden is to let the policy authors
+choose the best tool for their needs.
 
-When using a traditional programming language (or, to be
-more correct, a [Turing-complete](https://en.wikipedia.org/wiki/Turing_completeness)
-language), it is possible to introduce mistakes like
-[infinite loops](https://en.wikipedia.org/wiki/Infinite_loop),
-[deadlocks](https://en.wikipedia.org/wiki/Deadlock) or code that runs slowly
-because it lacks optimizations or simply because it performs computationally
-intense operations.
+When using a traditional, [Turing-complete](https://en.wikipedia.org/wiki/Turing_completeness) programming language, it's possible to have issues like:
 
-The policy evaluation timeout protection feature terminates the evaluation of
-a request after a certain time. This ensures Policy Server always has compute
-resources available to process incoming requests.
+* [infinite loops](https://en.wikipedia.org/wiki/Infinite_loop)
+* [deadlocks](https://en.wikipedia.org/wiki/Deadlock).
+* slow running code lacking optimizations
+* computationally intense operations.
+
+The policy evaluation timeout protection feature terminates the evaluation of a
+request after a defined period of time. This ensures Policy Server always has
+compute resources available to process incoming requests.
 
 ## Limitations
 
-Currently, policy evaluation timeout protection is capable of interrupting
-the majority of long running evaluations.
-There are however certain edge cases that are not yet handled. This includes
-invoking a `sleep` instruction from within a policy and deadlocks.
+Currently, policy evaluation timeout protection is capable of interrupting most
+long running evaluations. There are certain edge cases not yet handled.
+This includes invoking a `sleep` instruction from within a policy, and
+deadlocks.
 
-These scenarios are going to be handled by a future release of Policy Server.
+A future release of Policy Server will address these scenarios.
 
 Finally, the policy evaluation timeout affects all the policies hosted by a
-Policy Server instance. Currently, there's no way to tune policy evaluation timeout
-on a per-policy basis.
+Policy Server instance. Currently, there's no way to tune policy evaluation
+timeout on a per-policy basis.
 
 ## Configuration
 
-Policy evaluation timeout is a configuration option of Policy Server which is
-enabled by default.
-By default, a request evaluation is interrupted after 2 seconds.
+Policy evaluation timeout is a configuration option of Policy Server enabled by
+default. Interruption of a request evaluation takes place after 2 seconds.
 
-This behavior can be tuned by using these environment variables:
+You can tune this behavior using these environment variables:
 
-* `KUBEWARDEN_DISABLE_TIMEOUT_PROTECTION`: this disables policy evaluation entirely.
-  The value of the environment variable is not relevant, any value will lead to the
-  feature being turned off.
-* `KUBEWARDEN_POLICY_TIMEOUT`: this allows to set a different timeout value. The
-  value is expressed in seconds and has a default value of `2`.
+* `KUBEWARDEN_DISABLE_TIMEOUT_PROTECTION`: this disables policy evaluation
+  entirely. Any assigned value turns off the feature.
+* `KUBEWARDEN_POLICY_TIMEOUT`: this sets a different timeout value.
+  The value is in seconds with a default value of `2`.
 
-When using the [`PolicyServer`](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller/policies.kubewarden.io/PolicyServer/v1@v1.4.2)
-Kubernetes Custom Resource Definition, these environment variables can be set in
-this way:
+When using the
+[`PolicyServer`](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller/policies.kubewarden.io/PolicyServer/v1@v1.4.2)
+Kubernetes Custom Resource Definition, you can set these environment variables
+as follows:
 
 ```yaml
 # A Policy Server that has policy evaluation timeout disabled
@@ -101,85 +99,96 @@ spec:
 
 ## Comparison with Kubernetes Dynamic Admission Controller timeout
 
-Kubewarden is a [webhook](https://en.wikipedia.org/wiki/Webhook) implementation of  the[ Kubernetes Dynamic Admission Controller](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/).
+Kubewarden is a [webhook](https://en.wikipedia.org/wiki/Webhook) implementation
+of the[ Kubernetes Dynamic Admission
+Controller](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/).
 
-Under the hood, the Kubernetes API server makes an HTTP request against  Kubewarden's Policy Server
-describing an event that is about to happen. After the HTTP request is made,
-Kubernetes API Server waits for an answer to be provided. However, Kubernetes
-API server will not wait forever, after a certain amount of time it will
-consider the request to be "timed-out".
+Internally, the Kubernetes API server makes an HTTP request to  Kubewarden's
+Policy Server describing an event that's about to happen. After the HTTP
+request, the Kubernetes API Server waits for an answer. However, the Kubernetes
+API server doesn't wait forever. After a certain amount of time it considers
+the request to have timed out.
 
-Quoting the [official Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts):
+Quoting the [Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts):
 
-> Default timeout for a webhook call is 10 seconds, You can set the timeout and
-> it is encouraged to use a short timeout for webhooks.
-> If the webhook call times out, the request is handled according to the
-> webhook's failure policy.
+> Because webhooks add to API request latency, they should evaluate as quickly
+> as > possible. `timeoutSeconds` allows configuring how long the API server
+> should wait for a webhook to respond before treating the call as a
+> failure.
+>
+> If the timeout expires before the webhook responds, the webhook call
+> will be ignored or the API call will be rejected based on the [failure policy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy).
+>
+> The timeout value must be between 1 and 30 seconds.
+>
+> The timeout for an admission webhook defaults to 10 seconds.
+
 That means that, regardless of the policy evaluation timeout feature, each
 Kubernetes admission request is subject to a timeout.
 
 Every Kubewarden Policy can set its own timeout value via the `timeoutSeconds`
 attribute of the `ClusterAdmissionPolicy` and `AdmissionPolicy` custom resources.
-By default the timeout value is 10 seconds.
+By default, the timeout value is 10 seconds.
 
 :::info
 
-All the Kubernetes admission requests made against a Policy Server are subject
+All the Kubernetes admission requests made to a Policy Server are subject
 to two different timeouts:
 
-* The Kubernetes API server timeout value. Set to 10 seconds by default, tunable
-  on a per-policy basis via a dedicated attribute on the Kubewarden Custom Resources.
+* The Kubernetes API server timeout value. Set to 10 seconds by default,
+  tunable on a per-policy basis via a dedicated attribute on the Kubewarden
+  Custom Resources.
 * The Policy Server policy evaluation timeout
 
 :::
 
-Let's go through the following scenarios to better understand the differences
-between Kubernetes' Webhook timeout and Kubewarden's policy evaluation timeout.
+Now you can examine the following scenarios to better understand the
+differences between Kubernetes' Webhook timeout and Kubewarden's policy
+evaluation timeout.
 
 ### Kubewarden policy evaluation timeout is disabled
 
-Let's assume we have a Policy Server that has the policy evaluation timeout
-feature disabled. This server is hosting a policy that is affected by a bug
-which causes it to enter an infinite loop during evaluation.
+Assume you have a Policy Server that has the policy evaluation timeout feature
+turned off. This Policy Server is hosting a policy affected by a bug which
+causes it to enter an infinite loop during evaluation.
 
-Kubernetes API server sends an admission request to be evaluated by this
-bugged policy. As a result, the policy evaluation will enter an infinite loop.
-In the meantime the Kubernetes API server will be waiting for a response.
+The Kubernetes API server sends an admission request for evaluation by this
+buggy policy. As a result, the policy evaluation enters an infinite loop.
+Meanwhile, the Kubernetes API server is waiting for a response.
 
-After 10 seconds Kubernetes' webhook timeout will take place, the request
-will be handled according to the webhook's failure policy.
+After 10 seconds Kubernetes' webhook timeout takes place, and the request is
+handled according to the webhook's failure policy.
 
-Unfortunately, the Policy Server will be left with some computation resources stuck
-inside of this infinite loop. Over time, with more admission requests
-triggering the bugged policy, the Policy Server will run out of computation resources
-and will be unable to respond to the Kubernetes API server. This is actually a
-Denial Of Service (DOS) attack against the Policy Server.
+Now the Policy Server has computational resources stuck in this infinite loop.
+Over time, with more admission requests triggering the bugged policy, the
+Policy Server runs out of computational resources. It's unable to respond
+to the Kubernetes API server. This is equal to a Denial Of Service (DOS)
+attack on the Policy Server.
 
 ### Kubewarden policy evaluation timeout is enabled
 
-Let's assume a scenario where the same Policy Server now has the policy evaluation timeout
-feature enabled, and the policy evaluation timeout is set to be 2 seconds.
-Kubernetes API server sends an admission request to be evaluated by this
-bugged policy. As a result, the policy evaluation will enter an infinite loop.
-In the meantime the Kubernetes API server will be waiting for a response.
+Assume a scenario where the same Policy Server now has the policy evaluation
+timeout feature enabled, and the policy evaluation timeout is 2 seconds. The
+Kubernetes API server sends an admission request for evaluation by this buggy
+policy. As a result, policy evaluation enters an infinite loop. Meanwhile, the
+Kubernetes API server is waiting for a response.
 
-After two seconds, Kubewarden's policy evaluation timeout feature will interrupt
-the policy evaluation and will produce a rejection response.
-The response will contain a message explaining that the rejection
-happened because the policy evaluation didn't complete in a timely manner.
+After two seconds, Kubewarden's policy evaluation timeout feature interrupts
+the policy evaluation and produces a rejection response. The response contains
+a message explaining that rejection happened because the policy evaluation
+didn't complete in time.
 
 :::note
 
 Setting Kubewarden's policy evaluation timeout to a value higher than the
-Kubernetes' webhook timeout is not a good choice.
+Kubernetes' webhook timeout isn't a good choice.
 
-While the policy evaluation will still be interrupted, reducing the chances
-of a DOS attack, the final rejection response will not be produced by the Policy
-Server. As a matter of fact, the rejection will be produced by the Kubernetes
-API server by the webhook timeout.
+While the policy evaluation is still interrupted, reducing the chances of a DOS
+attack, the final rejection response isn't produced by the Policy Server. The
+rejection comes from the Kubernetes API server with the webhook timeout.
 
-As a result, it will be harder for end users, and Kubernetes operators, to
-detect these slow/bugged policies. The only proof of the policy evaluation
-interruption will be inside of the Policy Server logs and trace events.
+As a result, it's harder for users, and Kubernetes operators, to detect these
+slow/buggy policies. The only proof of the policy evaluation interruption is in
+Policy Server logs and trace events.
 
 :::

--- a/docs/reference/policy-evaluation-timeout.md
+++ b/docs/reference/policy-evaluation-timeout.md
@@ -18,8 +18,8 @@ doc-topic: [operator-manual, policy-evaluation-timeout]
 This feature is available starting from Kubewarden v1.5.0.
 :::
 
-Policy evaluation timeout protection is a security feature of Policy Server.
-It's purpose is to limit the amount of time a request evaluation can take.
+Policy evaluation timeout protection is a security feature of the Policy Server.
+Its purpose is to limit the amount of time a request evaluation can take.
 
 Kubewarden enables this feature from version v1.5.0.
 
@@ -38,7 +38,7 @@ When using a traditional, [Turing-complete](https://en.wikipedia.org/wiki/Turing
 * [infinite loops](https://en.wikipedia.org/wiki/Infinite_loop)
 * [deadlocks](https://en.wikipedia.org/wiki/Deadlock).
 * slow running code lacking optimizations
-* computationally intense operations.
+* computationally intense operations
 
 The policy evaluation timeout protection feature terminates the evaluation of a
 request after a defined period of time. This ensures Policy Server always has
@@ -100,13 +100,13 @@ spec:
 ## Comparison with Kubernetes Dynamic Admission Controller timeout
 
 Kubewarden is a [webhook](https://en.wikipedia.org/wiki/Webhook) implementation
-of the[ Kubernetes Dynamic Admission
+of the [Kubernetes Dynamic Admission
 Controller](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/).
 
 Internally, the Kubernetes API server makes an HTTP request to  Kubewarden's
 Policy Server describing an event that's about to happen. After the HTTP
 request, the Kubernetes API Server waits for an answer. However, the Kubernetes
-API server doesn't wait forever. After a certain amount of time it considers
+API server doesn't wait forever. After a certain amount of time, it considers
 the request to have timed out.
 
 Quoting the [Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts):
@@ -156,7 +156,7 @@ The Kubernetes API server sends an admission request for evaluation by this
 buggy policy. As a result, the policy evaluation enters an infinite loop.
 Meanwhile, the Kubernetes API server is waiting for a response.
 
-After 10 seconds Kubernetes' webhook timeout takes place, and the request is
+After 10 seconds, Kubernetes' webhook timeout takes place, and the request is
 handled according to the webhook's failure policy.
 
 Now the Policy Server has computational resources stuck in this infinite loop.


### PR DESCRIPTION
As part of the work on #477.