### PR TITLE
Update OTEL operator in version matrix

### DIFF
--- a/docs/reference/dependency-matrix.md
+++ b/docs/reference/dependency-matrix.md
@@ -31,9 +31,9 @@ Needed for specific features.
 
 | Chart dependency                                   | Helm chart `appVersion` |             Helm chart `version`             |      Feature      |
 | -------------------------------------------------- | :---------------------: | :------------------------------------------: | :---------------: |
-| `open-telemetry/opentelemetry-operator` chart      |       `>= 0.104`        |              Example: `0.65.0`               |       OTLM        |
-| `prometheus-community/kube-prometheus-stack` chart |       `>= v0.69`        |              Example: `51.5.3`               |      Metrics      |
-| `jaegertracing/jaeger-operator` chart              |      `>= 1.49 < 2`      |              Example: `2.49.0`               |      Tracing      |
+| `open-telemetry/opentelemetry-operator` chart      |       `>= 0.104`        |              Example: `0.92.3`               |       OTEL        |
+| `prometheus-community/kube-prometheus-stack` chart |       `>= v0.69`        |              Example: `75.17.1`               |      Metrics      |
+| `jaegertracing/jaeger-operator` chart              |      `>= 1.49 < 2`      |              Example: `2.57.0`               |      Tracing      |
 | `kyverno/policy-reporter` chart                    |       `>= 2 < 4`        | In `kubewarden-controller` chart as subchart | Policy Reports UI |
 
 | CRD dependency                      |  Version   |                 Helm chart `version`                 |    Feature    |


### PR DESCRIPTION
## Description

Last tested version of OTEL operator is 0.92.3, we can use it in our dependency metrics.