### PR TITLE
fix(typo): ghcr.io

### DIFF
--- a/docs/tutorials/verifying-kubewarden.md
+++ b/docs/tutorials/verifying-kubewarden.md
@@ -143,7 +143,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 


### PR DESCRIPTION
## Description

Fixed a typo in container registry URLs, changing `ghrc.io` to the correct `ghcr.io`.

## Test
CI

## Additional Information

### Tradeoff

This change is a straightforward typo fix.

### Potential improvement

Consider adding tests or a linter to catch common domain typos in future PRs.
