### PR TITLE
fix(typo): ghcr.io to versioned docs

### DIFF
--- a/versioned_docs/version-1.10/security/verifying-kubewarden.md
+++ b/versioned_docs/version-1.10/security/verifying-kubewarden.md
@@ -32,7 +32,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.11/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.11/tutorials/verifying-kubewarden.md
@@ -37,7 +37,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.12/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.12/tutorials/verifying-kubewarden.md
@@ -37,7 +37,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.13/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.13/tutorials/verifying-kubewarden.md
@@ -37,7 +37,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.14/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.14/tutorials/verifying-kubewarden.md
@@ -37,7 +37,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.15/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.15/tutorials/verifying-kubewarden.md
@@ -37,7 +37,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.16/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.16/tutorials/verifying-kubewarden.md
@@ -37,7 +37,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.17/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.17/tutorials/verifying-kubewarden.md
@@ -37,7 +37,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.18/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.18/tutorials/verifying-kubewarden.md
@@ -129,7 +129,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.19/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.19/tutorials/verifying-kubewarden.md
@@ -129,7 +129,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.20/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.20/tutorials/verifying-kubewarden.md
@@ -129,7 +129,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.21/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.21/tutorials/verifying-kubewarden.md
@@ -143,7 +143,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.22/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.22/tutorials/verifying-kubewarden.md
@@ -143,7 +143,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.23/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.23/tutorials/verifying-kubewarden.md
@@ -143,7 +143,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.24/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.24/tutorials/verifying-kubewarden.md
@@ -143,7 +143,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.25/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.25/tutorials/verifying-kubewarden.md
@@ -143,7 +143,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.26/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.26/tutorials/verifying-kubewarden.md
@@ -143,7 +143,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.27/tutorials/verifying-kubewarden.md
+++ b/versioned_docs/version-1.27/tutorials/verifying-kubewarden.md
@@ -143,7 +143,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.7/security/verifying-kubewarden.md
+++ b/versioned_docs/version-1.7/security/verifying-kubewarden.md
@@ -29,7 +29,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.8/security/verifying-kubewarden.md
+++ b/versioned_docs/version-1.8/security/verifying-kubewarden.md
@@ -29,7 +29,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 

--- a/versioned_docs/version-1.9/security/verifying-kubewarden.md
+++ b/versioned_docs/version-1.9/security/verifying-kubewarden.md
@@ -29,7 +29,7 @@ To verify a Helm chart, you need `cosign` installed. Then execute the following
 command, for example:
 
 ```
-cosign verify ghrc.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
+cosign verify ghcr.io/kubewarden/charts/kubewarden-defaults:1.5.4 \
   --certificate-identity-regexp 'https://github.com/kubewarden/*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 


### PR DESCRIPTION
## Description

This PR is a follow up of #655 
Fixed a typo in container registry URLs, changing `ghrc.io` to the correct `ghcr.io`. in older versions too.


## Test
CI

## Additional Information

### Tradeoff

This change is a straightforward typo fix.

### Potential improvement

Consider adding tests or a linter to catch common domain typos in future PRs.
