### PR TITLE
Standardize use of "how-to". And a typo and a little active voice.

### DIFF
--- a/docs/howtos/vap-migration.md
+++ b/docs/howtos/vap-migration.md
@@ -24,7 +24,7 @@ You can read more about the CEL policy in [this section](../tutorials/writing-po
 [This paragraph](../tutorials/writing-policies/CEL/intro-cel#benefits-of-kubewardens-cel-policy-in-comparison-with-validatingadmissionpolicies)
 explains the benefits of running VAP policies using Kubewarden.
 
-This howto explains how the `kwctl` tool can be used to migrate a VAP policy to Kubewarden.
+This guide explains how to use the `kwctl` tool to migrate a VAP policy to Kubewarden.
 
 ## Migration steps
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -53,7 +53,7 @@ If new to the Kubewarden project start with the
 and the [architecture](./explanations/architecture.md) page.
 Then it depends where your interests take you.
 For policy developers there are language specific sections in the tutorials.
-For integrators and administrators there is a 'howtos' section.
+For integrators and administrators there is a 'how-tos' section.
 The explanations section contains useful background material.
 There is also a [glossary](./glossary.md).
 

--- a/docs/organization.md
+++ b/docs/organization.md
@@ -19,7 +19,7 @@ Kubewarden organizes project documentation as follows:
 - [Quick start](./quick-start.md)
 - _Tutorials_ — learning through examples.
 - _Explanations_ — underlying concepts.
-- _Howtos_ — getting Kubewarden tasks done.
+- _How-tos_ — getting Kubewarden tasks done.
 - _Reference_
 - Organization — this page
 - [Personas](./personas.md) — who is Kubewarden for?
@@ -27,7 +27,7 @@ Kubewarden organizes project documentation as follows:
 - [Glossary](./glossary.md)
 
 Most of the material is in the four sections,
-_Tutorials_, _Explanations_, _Howtos_, and _Reference_.
+_Tutorials_, _Explanations_, _How-tos_, and _Reference_.
 There may be overlap as the sections aren't mutually exclusive.
 The Kubewarden project tries to follow the [Diátaxis](https://diataxis.fr/) documentation framework
 

--- a/docs/reference/security-hardening/webhooks-hardening.md
+++ b/docs/reference/security-hardening/webhooks-hardening.md
@@ -170,7 +170,7 @@ matchExpressions:
 
 :::tip
 
-Refere to [this how-to](../../howtos/security-hardening/webhook-mtls/) for a
+Refer to [this how-to](../../howtos/security-hardening/webhook-mtls/) for a
 step-by-step guide on configuring the Kubernetes API server of K3s to
 authenticate to the webhook.
 

--- a/docs/tutorials/writing-policies/CEL/02-reusing-vap.md
+++ b/docs/tutorials/writing-policies/CEL/02-reusing-vap.md
@@ -116,9 +116,12 @@ Notice the commented numbers on both the YAML manifests. Let's expand on them:
 |     | `---`               | Kubewarden-only features              | For other features, see the rest of tutorial CEL examples.                                                                                                                                                               |
 
 :::tip
-The `kwctl` tool can be used to migrate a VAP policy to Kubewarden.
 
-This is described inside of [this howto](../../../howtos/vap-migration).
+You can use the `kwctl` tool to migrate a VAP policy to Kubewarden.
+
+This [VAP migration how-to](../../../howtos/vap-migration) describes how to do
+so.
+
 :::
 
 ### Yet to be implemented equivalences


### PR DESCRIPTION
See TermWeb for howto vs. how-to.

https://suse.termweb.eu/search/terms/609743

