### PR TITLE
docs: update reference docs for the crypto host capability

### DIFF
--- a/docs/reference/spec/host-capabilities/05-crypto.md
+++ b/docs/reference/spec/host-capabilities/05-crypto.md
@@ -52,8 +52,7 @@ performing cryptographic checks exposed by the host:
   "cert_chain": [
       # list of certs, ordered by trust
       # usage (intermediates first, root last)
-      # If empty or missing, certificate is assumed
-      # trusted
+      # If not provided, the Mozilla's CA is used.
       Certificate,
       ...
       Certificate,


### PR DESCRIPTION
Update the documentation of the verify function to reflect the change done with https://github.com/kubewarden/policy-evaluator/pull/744
