### PR TITLE
docs: update name for the wasm32-wasi target

### DIFF
--- a/docs/tutorials/writing-policies/rust/01-intro-rust.md
+++ b/docs/tutorials/writing-policies/rust/01-intro-rust.md
@@ -31,7 +31,7 @@ Refer to the rustup [install documentation](https://rust-lang.github.io/rustup/i
 Once you have installed `rustup` add the WebAssembly System Interface (WASI) target:
 
 ```console
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 ## OSX dependencies

--- a/versioned_docs/version-1.28/tutorials/writing-policies/rust/01-intro-rust.md
+++ b/versioned_docs/version-1.28/tutorials/writing-policies/rust/01-intro-rust.md
@@ -31,7 +31,7 @@ Refer to the rustup [install documentation](https://rust-lang.github.io/rustup/i
 Once you have installed `rustup` add the WebAssembly System Interface (WASI) target:
 
 ```console
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 ## OSX dependencies


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Update documentation to align with Rust `wasm32-wasi` to `wasm32-wasip1` [renaming](https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets/#renaming-wasm32-wasi-to-wasm32-wasip1)

## Test

CI
