### PR TITLE
Bump OTEL versions

### DIFF
--- a/docs/howtos/telemetry/10-opentelemetry-qs.md
+++ b/docs/howtos/telemetry/10-opentelemetry-qs.md
@@ -101,6 +101,10 @@ $ minikube addons enable ingress
 
 ## Install OpenTelemetry {#install-opentelemetry}
 
+:::note
+See [Dependency matrix](reference/dependency-matrix.md) for the latest supported component versions.
+:::
+
 You use the [OpenTelemetry
 Operator](https://github.com/open-telemetry/opentelemetry-operator) to manage
 the automatic injection of the OpenTelemetry Collector sidecar into the
@@ -109,19 +113,6 @@ PolicyServer pod.
 The OpenTelemetry Operator requires installation of
 [cert-manager](https://cert-manager.io/docs/installation/) in the cluster.
 
-At the time of writing (2022-06-21), only specific versions of OpenTelemetry
-are compatible with Cert Manager, [see the compatibility
-chart](https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-operator-vs-kubernetes-vs-cert-manager).
-
-You should install the latest cert-manager Helm chart:
-
-:::note
-
-At time of writing (2024-07-17) the latest cert-manager chart version is
-`v1.15.1`
-
-:::
-
 ```console
 helm repo add jetstack https://charts.jetstack.io
 
@@ -129,18 +120,11 @@ helm install --wait \
     --namespace cert-manager \
     --create-namespace \
     --set crds.enabled=true \
-    --version 1.15.1 \
+    --version 1.18.2 \
     cert-manager jetstack/cert-manager
 ```
 
 Once cert-manager is running, you can install the OpenTelemetry operator Helm chart:
-
-:::note
-
-At the time of writing (2024-11-11) the latest OpenTelemetry operator chart
-version is `0.65.0`
-
-:::
 
 ```console
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
@@ -148,8 +132,8 @@ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm
 helm install --wait \
   --namespace open-telemetry \
   --create-namespace \
-  --version 0.65.0 \
-  --set "manager.collectorImage.repository=otel/opentelemetry-collector-contrib" \
+  --version 0.97.1 \
+  --set "manager.collectorImage.repository=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib" \
   my-opentelemetry-operator open-telemetry/opentelemetry-operator
 ```
 

--- a/docs/howtos/telemetry/40-custom-otel-collector.md
+++ b/docs/howtos/telemetry/40-custom-otel-collector.md
@@ -51,15 +51,15 @@ helm install --wait \
     --namespace cert-manager \
     --create-namespace \
     --set crds.enabled=true \
-    --version 1.15.1 \
+    --version 1.18.2 \
     cert-manager jetstack/cert-manager
 
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 helm install --wait \
   --namespace open-telemetry \
   --create-namespace \
-  --version 0.65.0 \
-  --set "manager.collectorImage.repository=otel/opentelemetry-collector-contrib" \
+  --version 0.97.1 \
+  --set "manager.collectorImage.repository=ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib" \
   my-opentelemetry-operator open-telemetry/opentelemetry-operator
 ```
 
@@ -123,7 +123,7 @@ helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
 helm upgrade -i --wait \
   --namespace jaeger \
   --create-namespace \
-  --version 2.49.0 \
+  --version 2.57.0 \
   jaeger-operator jaegertracing/jaeger-operator \
   --set rbac.clusterRole=true
 
@@ -163,7 +163,7 @@ EOF
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm install --wait --create-namespace \
   --namespace prometheus \
-  --version 51.5.3 \
+  --version 77.13.0 \
   --values kube-prometheus-stack-values.yaml \
   prometheus prometheus-community/kube-prometheus-stack
 ```
@@ -322,8 +322,8 @@ The web UI is reachable at [localhost:16686](localhost:16686).
 
 You can access the Prometheus UI by port forwarding to your local machine:
 
-```console 
-kubectl port-forward -n prometheus --address 0.0.0.0 svc/prometheus-operated 9090 
+```console
+kubectl port-forward -n prometheus --address 0.0.0.0 svc/prometheus-operated 9090
 ```
 
 The web UI is now reachable at [localhost:9090](localhost:9090).

--- a/docs/reference/dependency-matrix.md
+++ b/docs/reference/dependency-matrix.md
@@ -31,8 +31,8 @@ Needed for specific features.
 
 | Chart dependency                                   | Helm chart `appVersion` |             Helm chart `version`             |      Feature      |
 | -------------------------------------------------- | :---------------------: | :------------------------------------------: | :---------------: |
-| `open-telemetry/opentelemetry-operator` chart      |       `>= 0.104`        |              Example: `0.93.0`               |       OTEL        |
-| `prometheus-community/kube-prometheus-stack` chart |       `>= v0.69`        |              Example: `75.17.1`               |      Metrics      |
+| `open-telemetry/opentelemetry-operator` chart      |       `>= 0.104`        |              Example: `0.97.1`               |       OTEL        |
+| `prometheus-community/kube-prometheus-stack` chart |       `>= v0.69`        |              Example: `77.13.0`              |      Metrics      |
 | `jaegertracing/jaeger-operator` chart              |      `>= 1.49 < 2`      |              Example: `2.57.0`               |      Tracing      |
 | `kyverno/policy-reporter` chart                    |       `>= 2 < 4`        | In `kubewarden-controller` chart as subchart | Policy Reports UI |
 


### PR DESCRIPTION
Also updated documentation to point to support matrix instead of hardcoding versions on separate doc pages.

