### PR TITLE
fix(ci): use official updatecli policy.

### DIFF
--- a/.github/workflows/update-ref-docs.yml
+++ b/.github/workflows/update-ref-docs.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   schedule:
     # Run this job every Monday and Wednesday at 00:00
-    - cron: '0 0 * * 1,3'
+    - cron: "0 0 * * 1,3"
 
 permissions:
   contents: write
@@ -21,9 +21,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Updatecli Binary
-        uses: updatecli/updatecli-action@cf942226b953240efac9ff60bf42df2b908c2fa0 # v2.83.0
+        uses: updatecli/updatecli-action@719e3592d124cbf826da704cbe557e1221dd4bba # v2.94.0
 
       - name: Run Updatecli to update CLI Reference Docs
         run: "updatecli compose apply --file updatecli/update-cli-ref-docs.yaml"
         env:
-          GITHUB_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/updatecli/update-cli-ref-docs.yaml
+++ b/updatecli/update-cli-ref-docs.yaml
@@ -1,10 +1,10 @@
 policies:
   - name: Copy kwctl CLI reference documentation files
-    policy: ghcr.io/jvanz/updatecli/policies/copy:0.1.0
+    policy: ghcr.io/updatecli/policies/file:0.2.1
     values:
       - values.d/update-kwctl-cli-ref-docs.yaml
   - name: Copy policy server CLI reference documentation files
-    policy: ghcr.io/jvanz/updatecli/policies/copy:0.1.0
+    policy: ghcr.io/updatecli/policies/file:0.2.1
     values:
       - values.d/update-policy-server-cli-ref-docs.yaml
   - name: Add header to the CLI reference documentation

--- a/updatecli/values.d/update-kwctl-cli-ref-docs.yaml
+++ b/updatecli/values.d/update-kwctl-cli-ref-docs.yaml
@@ -1,5 +1,8 @@
 ---
 # Values.yaml contains settings that be used from Updatecli manifest.
+scm:
+  enabled: false
+
 files:
   - src: "cli-docs.md"
     dst: "docs/reference/kwctl-cli.md"

--- a/updatecli/values.d/update-policy-server-cli-ref-docs.yaml
+++ b/updatecli/values.d/update-policy-server-cli-ref-docs.yaml
@@ -1,5 +1,8 @@
 ---
 # Values.yaml contains settings that be used from Updatecli manifest.
+scm:
+  enabled: false
+
 files:
   - src: "cli-docs.md"
     dst: "docs/reference/policy-server-cli.md"


### PR DESCRIPTION
## Description

The original policy written to copy file between repositories is an official updatecli policy. Therefore, we should use the official version instead of the first version of the policy.

