### PR TITLE
Shift the baseline of the mono SUSE font to better align with the pro…

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -103,3 +103,10 @@ html[data-theme='light'] .tooltip:hover .tooltiptext {
 html[data-theme='dark'] .tooltip:hover .tooltiptext {
   visibility: visible;
 }
+
+/* Align SUSE Mono baseline with SUSE proportional font */
+code, kbd, samp {
+  font-family: 'SUSE Mono', monospace;
+  position: relative;
+  top: -0.07em; /* Adjust this value as needed */
+}


### PR DESCRIPTION
…portional for in line mono text.

Looks better! For reference, side-by-side, before and after.

<img width="2587" height="751" alt="image" src="https://github.com/user-attachments/assets/db9c09fe-dda5-4d88-ba84-c085ba287220" />
