### PR TITLE
fix(kwctl-cli): update kwctl reference CLI docs.

### DIFF
--- a/versioned_docs/version-1.31/reference/kwctl-cli.md
+++ b/versioned_docs/version-1.31/reference/kwctl-cli.md
@@ -151,6 +151,7 @@ A YAML file may contain multiple Custom Resource declarations. In this case, `kw
 * `-r`, `--request-path <PATH>` — File containing the Kubernetes admission request object in JSON format
 * `--settings-json <VALUE>` — JSON string containing the settings for this policy
 * `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sigstore-trust-config <PATH>` — JSON-formatted file conforming to the ClientTrustConfig message in the Sigstore protobuf specs. This file configures the entire Sigstore instance state, including the URIs used to access the CA and artifact transparency services as well as the cryptographic root of trust itself
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 * `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
 * `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
@@ -271,6 +272,7 @@ Pulls a Kubewarden policy from a given URI
 * `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
 * `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
 * `-o`, `--output-path <PATH>` — Output file. If not provided will be downloaded to the Kubewarden store
+* `--sigstore-trust-config <PATH>` — JSON-formatted file conforming to the ClientTrustConfig message in the Sigstore protobuf specs. This file configures the entire Sigstore instance state, including the URIs used to access the CA and artifact transparency services as well as the cryptographic root of trust itself
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 * `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
 * `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
@@ -380,6 +382,7 @@ A YAML file may contain multiple Custom Resource declarations. In this case, `kw
 * `-r`, `--request-path <PATH>` — File containing the Kubernetes admission request object in JSON format
 * `--settings-json <VALUE>` — JSON string containing the settings for this policy
 * `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sigstore-trust-config <PATH>` — JSON-formatted file conforming to the ClientTrustConfig message in the Sigstore protobuf specs. This file configures the entire Sigstore instance state, including the URIs used to access the CA and artifact transparency services as well as the cryptographic root of trust itself
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 * `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
 * `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)
@@ -471,6 +474,7 @@ Output a Kubernetes resource manifest
 * `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
 * `--settings-json <VALUE>` — JSON string containing the settings for this policy
 * `-s`, `--settings-path <PATH>` — File containing the settings for this policy
+* `--sigstore-trust-config <PATH>` — JSON-formatted file conforming to the ClientTrustConfig message in the Sigstore protobuf specs. This file configures the entire Sigstore instance state, including the URIs used to access the CA and artifact transparency services as well as the cryptographic root of trust itself
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 * `--title <VALUE>` — Policy title
 * `-t`, `--type <VALUE>` — Kubewarden Custom Resource type
@@ -524,6 +528,7 @@ Verify a Kubewarden policy from a given URI using Sigstore
 * `--docker-config-json-path <PATH>` — Path to a directory containing the Docker 'config.json' file. Can be used to indicate registry authentication details
 * `--github-owner <VALUE>` — GitHub owner expected in the certificates generated in CD pipelines
 * `--github-repo <VALUE>` — GitHub repository expected in the certificates generated in CD pipelines
+* `--sigstore-trust-config <PATH>` — JSON-formatted file conforming to the ClientTrustConfig message in the Sigstore protobuf specs. This file configures the entire Sigstore instance state, including the URIs used to access the CA and artifact transparency services as well as the cryptographic root of trust itself
 * `--sources-path <PATH>` — YAML file holding source information (https, registry insecure hosts, custom CA's...)
 * `-a`, `--verification-annotation <KEY=VALUE>` — Annotation in key=value format. Can be repeated multiple times
 * `--verification-config-path <PATH>` — YAML file holding verification config information (signatures, public keys...)


### PR DESCRIPTION
## Description

Updates the kwctl references documentation to ensure that the new `--sigstore-trust-config` CLI flag is listed there.

Fix https://github.com/kubewarden/docs/pull/704#issuecomment-3626625501
