### PR TITLE
docs: add default PolicyServer config for airgap environment

### DIFF
--- a/docs/howtos/airgap/02-install.md
+++ b/docs/howtos/airgap/02-install.md
@@ -268,3 +268,63 @@ spec:
 ```
 
 :::
+
+## Configuring the default PolicyServer in an air gap environment
+
+The `kubewarden-defaults` Helm chart creates and manages a default
+PolicyServer resource. In an air gap environment, this PolicyServer
+must be configured to pull policies from your private registry.
+
+### Using a private registry with credentials
+
+If your private registry requires authentication, first create a
+Docker registry Secret in the `kubewarden` namespace:
+
+```bash
+kubectl --namespace kubewarden create secret docker-registry my-registry-secret \
+  --docker-username=<USERNAME> \
+  --docker-password=<PASSWORD> \
+  --docker-server=<REGISTRY.YOURDOMAIN.COM:PORT>
+```
+
+Then pass the Secret name when installing `kubewarden-defaults`:
+
+```bash
+helm install --wait -n kubewarden \
+  kubewarden-defaults kubewarden-defaults.tgz \
+  --set global.cattle.systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \
+  --set policyServer.imagePullSecret=my-registry-secret
+```
+
+### Using a registry with a custom or self-signed CA
+
+If your private registry uses a custom certificate authority,
+configure the `policyServer.sourceAuthorities` value in a
+`values.yaml` file:
+
+```yaml
+policyServer:
+  sourceAuthorities:
+    "<REGISTRY.YOURDOMAIN.COM:PORT>":
+      - |
+        -----BEGIN CERTIFICATE-----
+        <your CA certificate in PEM format>
+        -----END CERTIFICATE-----
+```
+
+Then install with:
+
+```bash
+helm install --wait -n kubewarden \
+  kubewarden-defaults kubewarden-defaults.tgz \
+  --set global.cattle.systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \
+  -f values.yaml
+```
+
+:::note
+For more details on configuring custom CAs and private registry
+credentials on custom (self-deployed) PolicyServers, see
+[Custom Certificate Authorities](../policy-servers/custom-cas) and
+[Private Registries](../policy-servers/private-registry).
+
+:::

--- a/docs/howtos/policy-servers/01-custom-cas.md
+++ b/docs/howtos/policy-servers/01-custom-cas.md
@@ -46,7 +46,6 @@ See the [Custom Certificates Authority](../custom-certificate-authorities.md)
 documentation for more information on how the `policy-server` executable treats
 insecure URIs.
 
-
 ### Custom Certificate Authorities
 
 You can configure the PolicyServer with a custom certificate chain of 1 or more
@@ -78,3 +77,38 @@ spec:
 See the [Custom Certificate Authorities](../custom-certificate-authorities.md)
 documentation for more information on how the `policy-server` executable treats
 them.
+
+## Configuring custom CAs on the default PolicyServer
+
+The instructions above apply to self-deployed (custom) PolicyServer
+resources. If you are using the default PolicyServer managed by the
+`kubewarden-defaults` Helm chart, configure the same setting via
+Helm values instead of editing the resource directly.
+
+Create a `values.yaml` file:
+
+```yaml
+policyServer:
+  sourceAuthorities:
+    "registry.example.com":
+      - |
+        -----BEGIN CERTIFICATE-----
+        <PEM certificate>
+        -----END CERTIFICATE-----
+    "registry2.example.com:5500":
+      - |
+        -----BEGIN CERTIFICATE-----
+        <PEM certificate>
+        -----END CERTIFICATE-----
+```
+
+Apply it during install or upgrade:
+
+```bash
+helm upgrade --install --wait -n kubewarden \
+  kubewarden-defaults kubewarden-defaults.tgz \
+  -f values.yaml
+```
+
+The Helm chart propagates these values to the
+`spec.sourceAuthorities` field of the default PolicyServer resource.

--- a/docs/howtos/policy-servers/02-private-registry.md
+++ b/docs/howtos/policy-servers/02-private-registry.md
@@ -90,3 +90,10 @@ policyServer:
     enabled: False
   imagePullSecret: secret-ghcr-docker
 ```
+
+:::note
+If you are using the default PolicyServer managed by the
+`kubewarden-defaults` Helm chart (for example, in an air gap
+environment), see [Consuming the Secret in Helm charts](#consuming-the-secret-in-helm-charts)
+for the Helm-specific configuration.
+:::


### PR DESCRIPTION
## Description

Fixes #727 

The airgap installation guide did not explain how to configure the
default PolicyServer (managed by the `kubewarden-defaults` Helm chart)
in an air gap environment. Also, the custom CAs and private registry
guides did not include instructions for the default PolicyServer.

This PR adds new sections to the following files:
- `docs/howtos/airgap/install.md` — new section covering private registry credentials and custom CAs for the default PolicyServer
- `docs/howtos/policy-servers/custom-cas.md` — new section for configuring custom CAs via Helm values for the default PolicyServer
- `docs/howtos/policy-servers/private-registry.md` — added note pointing readers to the Helm-specific section

## Test

Documentation only, no code changes.
Open each updated page and verify the new sections render correctly.

## Additional Information

### Tradeoff
None.

### Potential improvement
None at this time.

## Checklist
- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)