### PR TITLE
docs: fix quickstart

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -204,8 +204,8 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: psp-capabilities
 spec:
-  policyServer: reserved-instance-for-tenant-a
-  module: registry://ghcr.io/kubewarden/policies/psp-capabilities:v0.1.9
+  policyServer: default
+  module: registry://ghcr.io/kubewarden/policies/capabilities-psp:v1.0.10
   rules:
     - apiGroups: [""]
       apiVersions: ["v1"]


### PR DESCRIPTION
The policy being referenced could not be downloaded.

Plus, use `default` as policy server for the demo policy, otherwise someone doing copy & paste will find the policy in pending state and will be confused by that.
