### PR TITLE
Update TypeScript policy SDK package name

### DIFF
--- a/docs/tutorials/writing-policies/typescript/01-intro-typescript.md
+++ b/docs/tutorials/writing-policies/typescript/01-intro-typescript.md
@@ -79,13 +79,13 @@ The Kubewarden project provides a [template JavaScript/TypeScript policy project
 The easiest way to get the toolchain is by using the Kubewarden JavaScript SDK, which includes the Javy compilation plug-in:
 
 ```bash
-npm install kubewarden-policy-sdk
+npm install @kubewarden/policy-sdk
 ```
 
 The Javy plug-in binary is automatically included and you can find it at:
 
 ```
-node_modules/kubewarden-policy-sdk/plugin/javy-plugin-kubewarden.wasm
+node_modules/@kubewarden/policy-sdk/plugin/javy-plugin-kubewarden.wasm
 ```
 
 ## Tutorial prerequisites

--- a/docs/tutorials/writing-policies/typescript/02-scaffold.md
+++ b/docs/tutorials/writing-policies/typescript/02-scaffold.md
@@ -88,7 +88,7 @@ asset bundled.js 5.52 KiB [compared for emit] [minimized] (name: main)
 asset types.d.ts 430 bytes [compared for emit]
 asset index.d.ts 11 bytes [compared for emit]
 ./src/index.ts 3.84 KiB [built] [code generated]
-./node_modules/kubewarden-policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
+./node_modules/@kubewarden/policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
 webpack 5.101.3 compiled successfully in 2280 ms
 npm install
 
@@ -107,7 +107,7 @@ asset bundled.js 5.52 KiB [compared for emit] [minimized] (name: main)
 asset types.d.ts 430 bytes [compared for emit]
 asset index.d.ts 11 bytes [compared for emit]
 ./src/index.ts 3.84 KiB [built] [code generated]
-./node_modules/kubewarden-policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
+./node_modules/@kubewarden/policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
 webpack 5.101.3 compiled successfully in 1909 ms
 bats e2e.bats
 e2e.bats

--- a/versioned_docs/version-1.30/tutorials/writing-policies/typescript/01-intro-typescript.md
+++ b/versioned_docs/version-1.30/tutorials/writing-policies/typescript/01-intro-typescript.md
@@ -79,13 +79,13 @@ The Kubewarden project provides a [template JavaScript/TypeScript policy project
 The easiest way to get the toolchain is by using the Kubewarden JavaScript SDK, which includes the Javy compilation plug-in:
 
 ```bash
-npm install kubewarden-policy-sdk
+npm install @kubewarden/policy-sdk
 ```
 
 The Javy plug-in binary is automatically included and you can find it at:
 
 ```
-node_modules/kubewarden-policy-sdk/plugin/javy-plugin-kubewarden.wasm
+node_modules/@kubewarden/policy-sdk/plugin/javy-plugin-kubewarden.wasm
 ```
 
 ## Tutorial prerequisites

--- a/versioned_docs/version-1.30/tutorials/writing-policies/typescript/02-scaffold.md
+++ b/versioned_docs/version-1.30/tutorials/writing-policies/typescript/02-scaffold.md
@@ -88,7 +88,7 @@ asset bundled.js 5.52 KiB [compared for emit] [minimized] (name: main)
 asset types.d.ts 430 bytes [compared for emit]
 asset index.d.ts 11 bytes [compared for emit]
 ./src/index.ts 3.84 KiB [built] [code generated]
-./node_modules/kubewarden-policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
+./node_modules/@kubewarden/policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
 webpack 5.101.3 compiled successfully in 2280 ms
 npm install
 
@@ -107,7 +107,7 @@ asset bundled.js 5.52 KiB [compared for emit] [minimized] (name: main)
 asset types.d.ts 430 bytes [compared for emit]
 asset index.d.ts 11 bytes [compared for emit]
 ./src/index.ts 3.84 KiB [built] [code generated]
-./node_modules/kubewarden-policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
+./node_modules/@kubewarden/policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
 webpack 5.101.3 compiled successfully in 1909 ms
 bats e2e.bats
 e2e.bats

--- a/versioned_docs/version-1.31/tutorials/writing-policies/typescript/01-intro-typescript.md
+++ b/versioned_docs/version-1.31/tutorials/writing-policies/typescript/01-intro-typescript.md
@@ -79,13 +79,13 @@ The Kubewarden project provides a [template JavaScript/TypeScript policy project
 The easiest way to get the toolchain is by using the Kubewarden JavaScript SDK, which includes the Javy compilation plug-in:
 
 ```bash
-npm install kubewarden-policy-sdk
+npm install @kubewarden/policy-sdk
 ```
 
 The Javy plug-in binary is automatically included and you can find it at:
 
 ```
-node_modules/kubewarden-policy-sdk/plugin/javy-plugin-kubewarden.wasm
+node_modules/@kubewarden/policy-sdk/plugin/javy-plugin-kubewarden.wasm
 ```
 
 ## Tutorial prerequisites

--- a/versioned_docs/version-1.31/tutorials/writing-policies/typescript/02-scaffold.md
+++ b/versioned_docs/version-1.31/tutorials/writing-policies/typescript/02-scaffold.md
@@ -88,7 +88,7 @@ asset bundled.js 5.52 KiB [compared for emit] [minimized] (name: main)
 asset types.d.ts 430 bytes [compared for emit]
 asset index.d.ts 11 bytes [compared for emit]
 ./src/index.ts 3.84 KiB [built] [code generated]
-./node_modules/kubewarden-policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
+./node_modules/@kubewarden/policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
 webpack 5.101.3 compiled successfully in 2280 ms
 npm install
 
@@ -107,7 +107,7 @@ asset bundled.js 5.52 KiB [compared for emit] [minimized] (name: main)
 asset types.d.ts 430 bytes [compared for emit]
 asset index.d.ts 11 bytes [compared for emit]
 ./src/index.ts 3.84 KiB [built] [code generated]
-./node_modules/kubewarden-policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
+./node_modules/@kubewarden/policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
 webpack 5.101.3 compiled successfully in 1909 ms
 bats e2e.bats
 e2e.bats

--- a/versioned_docs/version-1.32/tutorials/writing-policies/typescript/01-intro-typescript.md
+++ b/versioned_docs/version-1.32/tutorials/writing-policies/typescript/01-intro-typescript.md
@@ -79,13 +79,13 @@ The Kubewarden project provides a [template JavaScript/TypeScript policy project
 The easiest way to get the toolchain is by using the Kubewarden JavaScript SDK, which includes the Javy compilation plug-in:
 
 ```bash
-npm install kubewarden-policy-sdk
+npm install @kubewarden/policy-sdk
 ```
 
 The Javy plug-in binary is automatically included and you can find it at:
 
 ```
-node_modules/kubewarden-policy-sdk/plugin/javy-plugin-kubewarden.wasm
+node_modules/@kubewarden/policy-sdk/plugin/javy-plugin-kubewarden.wasm
 ```
 
 ## Tutorial prerequisites

--- a/versioned_docs/version-1.32/tutorials/writing-policies/typescript/02-scaffold.md
+++ b/versioned_docs/version-1.32/tutorials/writing-policies/typescript/02-scaffold.md
@@ -88,7 +88,7 @@ asset bundled.js 5.52 KiB [compared for emit] [minimized] (name: main)
 asset types.d.ts 430 bytes [compared for emit]
 asset index.d.ts 11 bytes [compared for emit]
 ./src/index.ts 3.84 KiB [built] [code generated]
-./node_modules/kubewarden-policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
+./node_modules/@kubewarden/policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
 webpack 5.101.3 compiled successfully in 2280 ms
 npm install
 
@@ -107,7 +107,7 @@ asset bundled.js 5.52 KiB [compared for emit] [minimized] (name: main)
 asset types.d.ts 430 bytes [compared for emit]
 asset index.d.ts 11 bytes [compared for emit]
 ./src/index.ts 3.84 KiB [built] [code generated]
-./node_modules/kubewarden-policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
+./node_modules/@kubewarden/policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
 webpack 5.101.3 compiled successfully in 1909 ms
 bats e2e.bats
 e2e.bats

--- a/versioned_docs/version-1.33/tutorials/writing-policies/typescript/01-intro-typescript.md
+++ b/versioned_docs/version-1.33/tutorials/writing-policies/typescript/01-intro-typescript.md
@@ -79,13 +79,13 @@ The Kubewarden project provides a [template JavaScript/TypeScript policy project
 The easiest way to get the toolchain is by using the Kubewarden JavaScript SDK, which includes the Javy compilation plug-in:
 
 ```bash
-npm install kubewarden-policy-sdk
+npm install @kubewarden/policy-sdk
 ```
 
 The Javy plug-in binary is automatically included and you can find it at:
 
 ```
-node_modules/kubewarden-policy-sdk/plugin/javy-plugin-kubewarden.wasm
+node_modules/@kubewarden/policy-sdk/plugin/javy-plugin-kubewarden.wasm
 ```
 
 ## Tutorial prerequisites

--- a/versioned_docs/version-1.33/tutorials/writing-policies/typescript/02-scaffold.md
+++ b/versioned_docs/version-1.33/tutorials/writing-policies/typescript/02-scaffold.md
@@ -88,7 +88,7 @@ asset bundled.js 5.52 KiB [compared for emit] [minimized] (name: main)
 asset types.d.ts 430 bytes [compared for emit]
 asset index.d.ts 11 bytes [compared for emit]
 ./src/index.ts 3.84 KiB [built] [code generated]
-./node_modules/kubewarden-policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
+./node_modules/@kubewarden/policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
 webpack 5.101.3 compiled successfully in 2280 ms
 npm install
 
@@ -107,7 +107,7 @@ asset bundled.js 5.52 KiB [compared for emit] [minimized] (name: main)
 asset types.d.ts 430 bytes [compared for emit]
 asset index.d.ts 11 bytes [compared for emit]
 ./src/index.ts 3.84 KiB [built] [code generated]
-./node_modules/kubewarden-policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
+./node_modules/@kubewarden/policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
 webpack 5.101.3 compiled successfully in 1909 ms
 bats e2e.bats
 e2e.bats

--- a/versioned_docs/version-1.34/tutorials/writing-policies/typescript/01-intro-typescript.md
+++ b/versioned_docs/version-1.34/tutorials/writing-policies/typescript/01-intro-typescript.md
@@ -79,13 +79,13 @@ The Kubewarden project provides a [template JavaScript/TypeScript policy project
 The easiest way to get the toolchain is by using the Kubewarden JavaScript SDK, which includes the Javy compilation plug-in:
 
 ```bash
-npm install kubewarden-policy-sdk
+npm install @kubewarden/policy-sdk
 ```
 
 The Javy plug-in binary is automatically included and you can find it at:
 
 ```
-node_modules/kubewarden-policy-sdk/plugin/javy-plugin-kubewarden.wasm
+node_modules/@kubewarden/policy-sdk/plugin/javy-plugin-kubewarden.wasm
 ```
 
 ## Tutorial prerequisites

--- a/versioned_docs/version-1.34/tutorials/writing-policies/typescript/02-scaffold.md
+++ b/versioned_docs/version-1.34/tutorials/writing-policies/typescript/02-scaffold.md
@@ -88,7 +88,7 @@ asset bundled.js 5.52 KiB [compared for emit] [minimized] (name: main)
 asset types.d.ts 430 bytes [compared for emit]
 asset index.d.ts 11 bytes [compared for emit]
 ./src/index.ts 3.84 KiB [built] [code generated]
-./node_modules/kubewarden-policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
+./node_modules/@kubewarden/policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
 webpack 5.101.3 compiled successfully in 2280 ms
 npm install
 
@@ -107,7 +107,7 @@ asset bundled.js 5.52 KiB [compared for emit] [minimized] (name: main)
 asset types.d.ts 430 bytes [compared for emit]
 asset index.d.ts 11 bytes [compared for emit]
 ./src/index.ts 3.84 KiB [built] [code generated]
-./node_modules/kubewarden-policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
+./node_modules/@kubewarden/policy-sdk/dist/bundle.js 3.85 KiB [built] [code generated]
 webpack 5.101.3 compiled successfully in 1909 ms
 bats e2e.bats
 e2e.bats


### PR DESCRIPTION
## Summary

- update the TypeScript tutorial to install `@kubewarden/policy-sdk`
- update documented `node_modules` paths for the scoped package
- apply the same correction to versioned TypeScript docs from 1.30 through 1.34

Fixes #729

## Validation

- `git diff --check`
- `corepack yarn install --frozen-lockfile`
- `corepack yarn build`
- `npm view @kubewarden/policy-sdk name version`
- `npm pack --dry-run @kubewarden/policy-sdk`