### PR TITLE
Add matchConditions policy example

### DIFF
--- a/docs/howtos/policies.md
+++ b/docs/howtos/policies.md
@@ -86,6 +86,47 @@ spec:
       enforce: "restricted"
 ```
 
+## Filtering admission requests with matchConditions
+
+Use `spec.matchConditions` when `rules`, `namespaceSelector`, and
+`objectSelector` are not precise enough. Match conditions are
+[Kubernetes CEL expressions](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchconditions)
+that Kubernetes evaluates before calling the policy webhook. If any condition
+evaluates to `false`, the policy is skipped. If all conditions evaluate to
+`true`, Kubewarden evaluates the policy.
+
+The following policy rejects privileged containers in Deployments, but it skips
+updates that only change fields outside the Pod template. This avoids evaluating
+the policy for scale-only updates while still checking new Deployments and
+changes that can affect the Pods created by the Deployment:
+
+```yaml
+---
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  name: pod-privileged-template-changes
+spec:
+  module: registry://ghcr.io/kubewarden/policies/pod-privileged:v1.0.10
+  policyServer: default
+  mode: protect
+  rules:
+    - apiGroups: ["apps"]
+      apiVersions: ["v1"]
+      resources: ["deployments"]
+      operations: ["CREATE", "UPDATE"]
+  matchConditions:
+    - name: pod-template-changed
+      expression: 'request.operation == "CREATE" || object.spec.template != oldObject.spec.template'
+  mutating: false
+  settings: {}
+```
+
+Match conditions can use AdmissionReview data such as `object`, `oldObject`,
+and `request`. In this example, `oldObject` is only needed for `UPDATE`
+requests, and the `CREATE` check keeps the expression valid when there is no
+previous object.
+
 ## Custom rejection message
 
 When a policy rejects a resource, the message shown to the user is

--- a/versioned_docs/version-1.34/howtos/policies.md
+++ b/versioned_docs/version-1.34/howtos/policies.md
@@ -86,6 +86,47 @@ spec:
       enforce: "restricted"
 ```
 
+## Filtering admission requests with matchConditions
+
+Use `spec.matchConditions` when `rules`, `namespaceSelector`, and
+`objectSelector` are not precise enough. Match conditions are
+[Kubernetes CEL expressions](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchconditions)
+that Kubernetes evaluates before calling the policy webhook. If any condition
+evaluates to `false`, the policy is skipped. If all conditions evaluate to
+`true`, Kubewarden evaluates the policy.
+
+The following policy rejects privileged containers in Deployments, but it skips
+updates that only change fields outside the Pod template. This avoids evaluating
+the policy for scale-only updates while still checking new Deployments and
+changes that can affect the Pods created by the Deployment:
+
+```yaml
+---
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  name: pod-privileged-template-changes
+spec:
+  module: registry://ghcr.io/kubewarden/policies/pod-privileged:v1.0.10
+  policyServer: default
+  mode: protect
+  rules:
+    - apiGroups: ["apps"]
+      apiVersions: ["v1"]
+      resources: ["deployments"]
+      operations: ["CREATE", "UPDATE"]
+  matchConditions:
+    - name: pod-template-changed
+      expression: 'request.operation == "CREATE" || object.spec.template != oldObject.spec.template'
+  mutating: false
+  settings: {}
+```
+
+Match conditions can use AdmissionReview data such as `object`, `oldObject`,
+and `request`. In this example, `oldObject` is only needed for `UPDATE`
+requests, and the `CREATE` check keeps the expression valid when there is no
+previous object.
+
 ## Custom rejection message
 
 When a policy rejects a resource, the message shown to the user is


### PR DESCRIPTION
## Description

Add a `spec.matchConditions` example to the policies how-to. The new section briefly explains that match conditions are Kubernetes CEL expressions evaluated before the policy webhook is called, links to the Kubernetes documentation, and shows a Deployment example that evaluates `pod-privileged` only for CREATE requests or Pod template changes.

The same content is added to the current docs and the latest 1.34 versioned docs.

Fixes #645

## Checklist

- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md).

## AI usage

OpenAI Codex assisted with this contribution. I reviewed the generated changes and am responsible for them.

## Test

- `sed -n '104,122p' docs/howtos/policies.md | yq e . >/dev/null`
- `sed -n '104,122p' versioned_docs/version-1.34/howtos/policies.md | yq e . >/dev/null`
- `git diff --check`
- `corepack yarn build`

The docs build succeeds with existing broken-anchor, deprecated Docusaurus config, and stale Browserslist warnings.
