### PR TITLE
feat: Document new allowed host capability whitelist feature

### DIFF
--- a/docs/explanations/context-aware-policies.md
+++ b/docs/explanations/context-aware-policies.md
@@ -35,6 +35,21 @@ If an unprivileged user deploys a context aware policy as an `AdmissionPolicy`, 
 - Blocks all attempts to access Kubernetes resources.
 - Reports them to the cluster administrator.
 
+:::note
+
+`AdmissionPolicy` and `AdmissionPolicyGroup` resources have no
+`spec.contextAwareResources` field and therefore cannot read Kubernetes
+resources at all. However, they can still exercise other **host capabilities**
+provided by policy-server — such as OCI registry queries, `kubernetes/can_i`
+checks, DNS lookups, and certificate verification.
+
+Cluster operators can restrict which of these host capabilities are available
+to namespaced policies using the `spec.namespacedPoliciesCapabilities` field on
+the `PolicyServer` they run on. For details, see
+[Controlling host capabilities for namespaced policies](../howtos/policy-servers/06-namespaced-policies-capabilities.md).
+
+:::
+
 By default, all the cluster resources are blocked.
 A Kubewarden administrator defines which Kubernetes resources each context aware policy is allowed to read.
 The `ClusterAdmissionPolicy` definition uses the field `contextAwareResources` to do this.

--- a/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
+++ b/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
@@ -48,7 +48,7 @@ see our [Threat model](../../reference/threat-model.md).
 ## Background
 
 `AdmissionPolicy` and `AdmissionPolicyGroup` are namespaced resources.
-Because they are deployable by low-privileged users, they do not have a
+Because they can be made deployable to non privileged users, they do not have a
 `spec.contextAwareResources` field and cannot fetch information from the
 Kubernetes API.
 

--- a/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
+++ b/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
@@ -1,0 +1,327 @@
+---
+sidebar_label: Namespaced policy host capabilities
+sidebar_position: 60
+title: Controlling host capabilities for namespaced policies
+description: How to restrict host capability calls available to namespaced policies and control which PolicyServer they run on.
+keywords:
+  [
+    kubewarden,
+    kubernetes,
+    policyserver,
+    admissionpolicy,
+    admissionpolicygroup,
+    host-capabilities,
+    security,
+    namespaced-policies,
+  ]
+doc-persona: [kubewarden-operator, kubewarden-integrator]
+doc-type: [howto]
+doc-topic:
+  [
+    operator-manual,
+    policy-servers,
+    host-capabilities,
+    namespaced-policies,
+    security,
+  ]
+---
+
+Kubewarden upholds the following security promise:
+
+**"If you can deploy namespaced policies, you can do so without obtaining raised privileges."**
+
+This how-to explains how cluster operators can enforce that promise by:
+
+1. Restricting which host capabilities PolicyServers expose to namespaced policies.
+2. Controlling which PolicyServer a namespaced policy runs on, using the
+   `ns-policyserver-mapper` policy.
+
+
+:::warning
+The per PolicyServer restriction on host capabilities is part of Kubewarden
+`v1.35.0` and higher.
+
+Earlier versions may be vulnerable to reconnaissance or information disclosure,
+see our [Threat model](../../reference/threat-model.md).
+:::
+
+## Background
+
+`AdmissionPolicy` and `AdmissionPolicyGroup` are namespaced resources.
+Because they are deployable by low-privileged users, they do not have a
+`spec.contextAwareResources` field and cannot fetch information from the
+Kubernetes API.
+
+However, namespaced policies can still exercise other **host capabilities**
+provided by policy-server:
+
+- Querying OCI registries (verifying signatures, fetching manifests)
+- Performing Kubernetes `SubjectAccessReview` checks (`can_i`)
+- DNS lookups
+- Certificate trust verification
+
+These capabilities could be abused for reconnaissance or information disclosure
+(see our [Threat Model](../../reference/threat-model.md)). The
+`spec.namespacedPoliciesCapabilities` field on `PolicyServer` lets cluster
+operators gate exactly which of these capabilities are available to namespaced
+policies.
+
+## Host capability call reference
+
+See the full list on our [capabilities call reference](../../reference/spec/host-capabilities/07-host-capabiliy-call-reference.md) documentation page.
+
+## Configuring `spec.namespacedPoliciesCapabilities`
+
+Add the `namespacedPoliciesCapabilities` field to any `PolicyServer` to control
+which host capabilities its namespaced policies may use.
+
+The field accepts an array of strings. Wildcard patterns follow the same
+conventions as Kubernetes Dynamic Admission Controller
+[match rules](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules):
+
+| Value | Meaning |
+|-------|---------|
+| _(unset)_ | Allow all host capabilities (default, backwards-compatible) |
+| `["*"]` | Explicitly allow all host capabilities |
+| `[]` | Deny all host capabilities to namespaced policies |
+| `["oci/*"]` | Allow all OCI capabilities, all versions |
+| `["oci/v2/*"]` | Allow all OCI v2 capabilities only |
+| `["oci/v1/verify", "net/v1/dns_lookup_host"]` | Allow only those two specific calls |
+
+:::info
+Cluster-wide policies (`ClusterAdmissionPolicy` and `ClusterAdmissionPolicyGroup`)
+are always granted all host capabilities regardless of this field. Their access
+to Kubernetes resources is governed separately via `spec.contextAwareResources`.
+:::
+
+### Example: deny all host capabilities
+
+```yaml
+apiVersion: policies.kubewarden.io/v1
+kind: PolicyServer
+metadata:
+  name: for-namespaced-policies
+spec:
+  image: ghcr.io/kubewarden/policy-server:latest
+  replicas: 1
+  namespacedPoliciesCapabilities: []
+```
+
+Any namespaced policy scheduled on this PolicyServer will have all host
+capability calls blocked.
+
+### Example: allow only OCI signature verification
+
+```yaml
+apiVersion: policies.kubewarden.io/v1
+kind: PolicyServer
+metadata:
+  name: for-namespaced-policies
+spec:
+  image: ghcr.io/kubewarden/policy-server:latest
+  replicas: 1
+  namespacedPoliciesCapabilities:
+    - "oci/v1/verify"
+    - "oci/v2/verify"
+```
+
+### Example: allow all capabilities (explicit)
+
+```yaml
+apiVersion: policies.kubewarden.io/v1
+kind: PolicyServer
+metadata:
+  name: for-namespaced-policies
+spec:
+  image: ghcr.io/kubewarden/policy-server:latest
+  replicas: 1
+  namespacedPoliciesCapabilities:
+    - "*"
+```
+
+## Configuring default PolicyServer via Helm
+
+The `kubewarden-defaults` Helm chart exposes
+`.Values.policyServer.namespacedPoliciesCapabilities` to configure the `default`
+PolicyServer. When unset, all host capabilities are allowed (backwards-compatible
+default).
+
+To lock down the default PolicyServer so namespaced policies have no host
+capability access:
+
+```console
+helm upgrade --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults \
+  --set 'policyServer.namespacedPoliciesCapabilities={}'
+```
+
+To allow only OCI and DNS capabilities:
+
+```console
+helm upgrade --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults \
+  --set 'policyServer.namespacedPoliciesCapabilities={oci/*,net/v1/dns_lookup_host}'
+```
+
+## Configuring custom PolicyServers
+
+Cluster operators can configure their custom PolicyServers by setting their
+`spec.namespacedPoliciesCapabilities`. if not provided, PolicyServers by
+default allow all capability calls.
+
+## Controlling on which PolicyServer the namespaced policies run
+
+Even with a well-configured PolicyServer, low-privileged users could explicitly
+set `spec.policyServer` in their `AdmissionPolicy` to a different PolicyServer
+that exposes broader capabilities. The `ns-policyserver-mapper` policy prevents
+this.
+
+### `ns-policyserver-mapper` policy
+
+The `ns-policyserver-mapper` policy is a mutating `ClusterAdmissionPolicy` that
+intercepts `CREATE` and `UPDATE` requests for `AdmissionPolicy` and
+`AdmissionPolicyGroup` resources. It:
+
+1. Reads the `admission.kubewarden.io/policy-server` label from the `Namespace`
+   in which the policy is being deployed.
+2. Mutates the policy's `spec.policyServer` field to the value of that label,
+   overriding whatever the user specified.
+3. **Rejects** the request if the Namespace does not have the label, preventing
+   policies from being silently scheduled on an unintended PolicyServer.
+
+### Labeling Namespaces
+
+Label each Namespace with the name of the PolicyServer that should handle its
+namespaced policies:
+
+```console
+kubectl label namespace my-team-ns admission.kubewarden.io/policy-server=for-namespaced-policies
+```
+
+Or declare it in the Namespace manifest:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-team-ns
+  labels:
+    admission.kubewarden.io/policy-server: for-namespaced-policies
+```
+
+### Deploying `ns-policyserver-mapper`
+
+Deploy the policy as a `ClusterAdmissionPolicy`:
+
+```yaml
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  name: ns-to-policyserver
+spec:
+  module: registry://ghcr.io/kubewarden/policies/ns-policyserver-mapper:v0.1.0
+  mode: protect
+  mutating: true
+  rules:
+    - apiGroups: ["policies.kubewarden.io"]
+      apiVersions: ["v1"]
+      resources: ["admissionpolicies", "admissionpolicygroups"]
+      operations:
+        - CREATE
+        - UPDATE
+  contextAwareResources:
+    - apiVersion: v1
+      kind: Namespace
+```
+
+:::warning
+Deploy `ns-policyserver-mapper` and wait for it to become active **before**
+expecting namespaced policies to be constrained. Any `AdmissionPolicy` or
+`AdmissionPolicyGroup` created while the mapper policy is inactive will not
+be redirected.
+:::
+
+## Complete example: secure self-service namespace setup
+
+The following walkthrough shows how to configure a fully locked-down, self-service
+setup where a team can deploy their own namespaced policies without elevated privileges.
+
+### 1. Create a dedicated PolicyServer with restricted capabilities
+
+```yaml
+apiVersion: policies.kubewarden.io/v1
+kind: PolicyServer
+metadata:
+  name: for-namespaced-policies
+  namespace: kubewarden
+spec:
+  image: ghcr.io/kubewarden/policy-server:v1.35.0
+  namespacedPoliciesCapabilities: []
+```
+
+### 2. Deploy the `ns-policyserver-mapper` policy
+
+```yaml
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  name: ns-to-policyserver
+spec:
+  module: registry://ghcr.io/kubewarden/policies/ns-policyserver-mapper:v0.1.0
+  mode: protect
+  mutating: true
+  rules:
+    - apiGroups: ["policies.kubewarden.io"]
+      apiVersions: ["v1"]
+      resources: ["admissionpolicies", "admissionpolicygroups"]
+      operations:
+        - CREATE
+        - UPDATE
+  contextAwareResources:
+    - apiVersion: v1
+      kind: Namespace
+```
+
+Wait for the policy to become active:
+
+```console
+kubectl wait --for=condition=PolicyActive clusteradmissionpolicy/ns-to-policyserver
+```
+
+### 3. Label team Namespaces
+
+```console
+kubectl label namespace team-alpha admission.kubewarden.io/policy-server=for-namespaced-policies
+kubectl label namespace team-beta  admission.kubewarden.io/policy-server=for-namespaced-policies
+```
+
+### 4. Grant RBAC to deploy namespaced policies
+
+Team members only need RBAC rights to create `AdmissionPolicy` and
+`AdmissionPolicyGroup` resources in their own Namespace. They do not need any
+additional permissions to the PolicyServer.
+
+### 5. Lock down the default PolicyServer (optional)
+
+If the `default` PolicyServer should also prevent namespaced policies from
+exercising host capabilities:
+
+```console
+helm upgrade --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults \
+  --set 'policyServer.namespacedPoliciesCapabilities={}'
+```
+
+## Upgrade considerations
+
+When upgrading from a Kubewarden version that predates this feature (`<= v1.34`):
+
+- Existing namespaced policies continue to work without any change. The
+  default behavior when `spec.namespacedPoliciesCapabilities` is unset is to
+  allow all host capabilities, matching the previous behavior.
+- To begin restricting capabilities, set `spec.namespacedPoliciesCapabilities`
+  on each PolicyServer and deploy `ns-policyserver-mapper`.
+- If you set `spec.namespacedPoliciesCapabilities: []` on an existing
+  PolicyServer, any namespaced policies that rely on host capabilities will have
+  those calls blocked. Review your policies before applying this change.
+- Namespaced policies already deployed retain their scheduling until they are
+  updated. The `ns-policyserver-mapper` policy only applies on `CREATE` and
+  `UPDATE` operations. To migrate existing policies, trigger an update for each
+  one after labeling their Namespace.

--- a/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
+++ b/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
@@ -164,7 +164,7 @@ helm upgrade --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defa
 ## Configuring custom PolicyServers
 
 Cluster operators can configure their custom PolicyServers by setting their
-`spec.namespacedPoliciesCapabilities`. if not provided, Policy Servers by
+`spec.namespacedPoliciesCapabilities`. If not provided, PolicyServers by
 default allow all capability calls.
 
 ## Controlling on which PolicyServer the namespaced policies run

--- a/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
+++ b/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
@@ -325,3 +325,70 @@ When upgrading from a Kubewarden version that predates this feature (`<= v1.34`)
   updated. The `ns-policyserver-mapper` policy only applies on `CREATE` and
   `UPDATE` operations. To migrate existing policies, trigger an update for each
   one after labeling their Namespace.
+
+## Authoring and auditing a policy with host capability calls
+
+### Authoring
+
+Policy authors can self-report a list of host capabilities that a policy uses
+using the policy metadata (see [metadata documentation
+page](../../tutorials/writing-policies/metadata.md)). For example:
+
+```yaml
+[...]
+hostCapabilities:
+  - kubernetes/list_resources_by_namespace
+  - kubernetes/list_resources_all
+  - kubernetes/get_resource
+[...]
+
+In addition, when the policy author annotates the policy Wasm module, `kwctl annotate`
+performs an heuristic scan of the Wasm binary's data for known host-capability
+strings, and compares what it detects against the `hostCapabilities` list
+declared in `metadata.yml`. Any mismatch is reported as warnings on stderr:
+
+- **Used but undeclared**: host capabilities found in the binary but absent
+  from the metadata declaration.
+- **Declared but not detected**: host capabilities listed in the metadata but
+  not found in the binary.
+
+### Auditing
+
+Before deploying an untrusted policy, cluster operators can get a signal about
+which host capabilities it uses by running `kwctl annotate`.
+
+Here is an example output when the metadata declares `oci/v1/verify` but the
+binary actually uses `kubernetes/get_resource` and
+`kubernetes/list_resources_by_namespace`:
+
+```console
+kwctl annotate -m metadata.yml -o annotated-policy.wasm policy.wasm
+
+WARN host capabilities used by the policy but not declared in metadata
+     capabilities={"kubernetes/get_resource", "kubernetes/list_resources_by_namespace"}
+WARN host capabilities declared in metadata but not detected in the policy
+     capabilities={"oci/v1/verify"}
+```
+
+These warnings can inform what to set in a PolicyServer
+`spec.namespacedPoliciesCapabilities` before deploying the policy. For example,
+enabling only the capabilities the scan suggests are actually needed.
+
+:::warning
+Both the self-reporting from the policy author and the `kwctl annotate`
+heuristic scan cannot be used as a security boundary. A policy publisher could
+embed any arbitrary `hostCapabilities` list in the metadata regardless of what
+the binary actually does at runtime.
+
+Use this information as one signal alongside other trust indicators (image
+signing, source code review, policy provenance, etc) not as an authoritative
+proof of what capabilities a policy exercises.
+:::
+
+## Further reading
+
+- [Host capabilities specification](../../reference/spec/host-capabilities/intro-host-capabilities.md)
+- [Security hardening](../security-hardening/security-hardening.md)
+- [Threat model](../../reference/threat-model.md)
+- [Context aware policies](../../explanations/context-aware-policies.md)
+- [`kwctl annotate` reference](../../reference/kwctl-cli.md#kwctl-annotate)

--- a/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
+++ b/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
@@ -146,7 +146,7 @@ The `kubewarden-defaults` Helm chart exposes
 PolicyServer. When unset, all host capabilities are allowed (backwards-compatible
 default).
 
-To lock down the default PolicyServer so namespaced policies have no host
+To lock down the `default` Policy Server so namespaced policies have no host
 capability access:
 
 ```console
@@ -164,7 +164,7 @@ helm upgrade --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defa
 ## Configuring custom PolicyServers
 
 Cluster operators can configure their custom PolicyServers by setting their
-`spec.namespacedPoliciesCapabilities`. if not provided, PolicyServers by
+`spec.namespacedPoliciesCapabilities`. if not provided, Policy Servers by
 default allow all capability calls.
 
 ## Controlling on which PolicyServer the namespaced policies run

--- a/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
+++ b/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
@@ -387,7 +387,7 @@ proof of what capabilities a policy exercises.
 
 ## Further reading
 
-- [Host capabilities specification](../../reference/spec/host-capabilities/intro-host-capabilities.md)
+- [Host capabilities specification](../../reference/spec/host-capabilities/01-intro-host-capabilities.md)
 - [Security hardening](../security-hardening/security-hardening.md)
 - [Threat model](../../reference/threat-model.md)
 - [Context aware policies](../../explanations/context-aware-policies.md)

--- a/docs/howtos/security-hardening/security-hardening.md
+++ b/docs/howtos/security-hardening/security-hardening.md
@@ -93,3 +93,26 @@ Server `.spec.securityContexts` under `.Values.policyServer.securityContexts`.
 
 For Policy Servers managed by operators, you can configure them via their
 [`spec.securityContexts`](https://docs.kubewarden.io/reference/CRDs#policyserversecurity).
+
+### Namespaced policy host capabilities
+
+Namespaced policies (`AdmissionPolicy` and `AdmissionPolicyGroup`) cannot
+access Kubernetes resources via `contextAwareResources`, but they can exercise
+other host capabilities: OCI registry queries, Kubernetes `can_i` checks, DNS
+lookups, and certificate verification. These capabilities could be exploited by
+a low-privileged user for information disclosure or reconnaissance (see our
+[Threat model](../../reference/threat-model.md))
+
+Each `PolicyServer` exposes a `spec.namespacedPoliciesCapabilities` field that
+lists which host capability API call paths are available to its namespaced
+policies. By default, all PolicyServers allow all host capability calls for
+namespaced policies. This includes the PolicyServer `default` (installed with
+the `kubewarden-defaults` Helm chart), and custom PolicyServers.
+
+Cluster operators need to configure each PolicyServer's
+`spec.namespacedPoliciesCapabilities` by setting it to `[]` to deny all, or
+provide an explicit allowlist.
+
+For a full walkthrough, including an example on secure self-service Namespaces
+and policies useful for teams, see [Controlling host capabilities for
+namespaced policies](../policy-servers/06-namespaced-policies-capabilities.md).

--- a/docs/reference/kwctl-cli.md
+++ b/docs/reference/kwctl-cli.md
@@ -124,6 +124,9 @@ A YAML file may contain multiple Custom Resource declarations. In this case, `kw
 ###### **Options:**
 
 * `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Grant access to the Kubernetes resources defined inside of the policy's `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default
+* `--allowed-host-capabilities <ALLOWED-HOST-CAPABILITIES>` — Host capabilities the policy is allowed to use. Use `*` to allow all. Can be repeated multiple times. Examples: `oci/*`, `net/v1/dns_lookup_host`
+
+  Default value: `*`
 * `--cert-email <VALUE>` — Expected email in Fulcio certificate
 * `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
 * `--disable-wasmtime-cache <DISABLE-WASMTIME-CACHE>` — Turn off usage of wasmtime cache
@@ -359,6 +362,9 @@ A YAML file may contain multiple Custom Resource declarations. In this case, `kw
 ###### **Options:**
 
 * `--allow-context-aware <ALLOW-CONTEXT-AWARE>` — Grant access to the Kubernetes resources defined inside of the policy's `contextAwareResources` section. Warning: review the list of resources carefully to avoid abuses. Disabled by default
+* `--allowed-host-capabilities <ALLOWED-HOST-CAPABILITIES>` — Host capabilities the policy is allowed to use. Use `*` to allow all. Can be repeated multiple times. Examples: `oci/*`, `net/v1/dns_lookup_host`
+
+  Default value: `*`
 * `--cert-email <VALUE>` — Expected email in Fulcio certificate
 * `--cert-oidc-issuer <VALUE>` — Expected OIDC issuer in Fulcio certificates
 * `--disable-wasmtime-cache <DISABLE-WASMTIME-CACHE>` — Turn off usage of wasmtime cache

--- a/docs/reference/spec/host-capabilities/07-host-capabiliy-call-reference.md
+++ b/docs/reference/spec/host-capabilities/07-host-capabiliy-call-reference.md
@@ -1,0 +1,47 @@
+---
+sidebar_label: Capabilities call reference
+title: Host capabilities call reference
+description: List of all host capabilities calls
+keywords:
+  [kubewarden, kubernetes, policyserver, host-capabilities,capabilities,namespaced-policies,security]
+doc-persona: [kubewarden-operator, kubewarden-integrator]
+doc-type: [reference]
+doc-topic:
+  [
+    operator-manual,
+    policy-servers,
+    host-capabilities,
+    namespaced-policies,
+    security,
+  ]
+---
+
+<head>
+  
+  <link rel="canonical" href="https://docs.kubewarden.io/reference/spec/host-capabilities/call-reference"/>
+</head>
+
+
+Each host capability is identified by a path string. The following paths can
+be gated in `spec.namespacedPoliciesCapabilities`:
+
+| Category | Path | Description |
+|----------|------|-------------|
+| OCI | `oci/v1/verify` | Verify an OCI artifact signature (v1) |
+| OCI | `oci/v2/verify` | Verify an OCI artifact signature (v2) |
+| OCI | `oci/v1/manifest_digest` | Fetch an OCI manifest digest |
+| OCI | `oci/v1/oci_manifest` | Fetch an OCI manifest |
+| OCI | `oci/v1/oci_manifest_config` | Fetch an OCI manifest config |
+| Kubernetes | `kubernetes/can_i` | Perform a SubjectAccessReview check |
+| Net | `net/v1/dns_lookup_host` | Resolve a hostname via DNS |
+| Crypto | `crypto/v1/is_certificate_trusted` | Verify certificate trust chain |
+
+:::note
+The `kubernetes/list_resources_by_namespace`, `kubernetes/list_resources_all`,
+and `kubernetes/get_resource` calls are not applicable to namespaced policies
+because those policies have no `spec.contextAwareResources` field. They are
+only relevant for `ClusterAdmissionPolicy` resources, which always receive
+full host capability access.
+
+The `tracing/log` call emits a log entry and is always available.
+:::

--- a/docs/reference/threat-model.md
+++ b/docs/reference/threat-model.md
@@ -305,3 +305,72 @@ For example, by:
    Incidentally, this is part of the implementation needed for air-gapped installations.
 2. Use signed Helm charts, and verified digests instead of tags for Kubewarden images in those Helm charts.
    This doesn't secure dependencies though.
+
+### Kubewarden threat 2 - Attacker uses namespaced policy to extract information
+
+#### Scenario
+
+A low-privileged user with RBAC rights to create `AdmissionPolicy` or
+`AdmissionPolicyGroup` resources deploys a policy onto a PolicyServer that
+exposes broad host capabilities. The policy uses those capabilities, such as
+`kubernetes/can_i`, OCI registry queries, or DNS lookups, to perform
+reconnaissance or exfiltrate information from the cluster, without needing
+any additional privileges beyond the ability to deploy a namespaced policy.
+
+#### Mitigation
+
+Cluster operators should apply one or more of the following mitigations:
+
+- If untrusted users must not deploy namespaced policies at all, restrict RBAC
+  rights to `AdmissionPolicy` and `AdmissionPolicyGroup` resources accordingly.
+- Deploy a dedicated PolicyServer for namespaced policies with a restricted
+  `spec.namespacedPoliciesCapabilities` field (for example, set it to `[]` to
+  deny all host capabilities).
+- Deploy the `ns-policyserver-mapper` policy to enforce that namespaced policies
+  always run on the PolicyServer designated for their Namespace, preventing users
+  from redirecting policies to more permissive PolicyServers.
+
+See [Controlling host capabilities for namespaced policies](./security-hardening/webhooks-hardening.md)
+for full configuration details.
+
+### Kubewarden threat 3 - PolicyServer compromise exposes all its mapped namespaces
+
+#### Scenario
+
+A PolicyServer is compromised somehow, for example by privilege escalation on
+the Wasm host and using an unvetted and unsigned policy. The PolicyServer is
+used for policies in several Namespaces, along with cluster-wide policies. All
+Namespaces mapped to it are at risk, especially if the PolicyServer has broad
+host capabilities.
+
+#### Mitigation
+
+- Apply principle of least privilege to `spec.namespacedPoliciesCapabilities`
+  on every PolicyServer. Grant only the host capabilities that the policies
+  running on that instance actually require.
+- Isolate PolicyServers for sensitive Namespaces: do not co-locate high-trust
+  and low-trust namespaced policies on the same PolicyServer instance.
+- Regularly audit PolicyServer configurations and the list of policies scheduled
+  on each instance.
+- Use the `ns-policyserver-mapper` policy to ensure namespaced policies cannot
+  be rescheduled onto a different PolicyServer without a corresponding Namespace
+  label change, which requires cluster-operator-level access.
+
+### Kubewarden threat 4 - Stale or outdated Namespace-to-PolicyServer mapping
+
+#### Scenario
+
+A cluster operator deploys the `ns-policyserver-mapper` policy and labels
+Namespaces to map them to specific PolicyServers. Over time, PolicyServers or
+Namespaces are added, removed, or renamed, but the Namespace mapping labels are
+not updated. As a result, policies may become unschedulable (rejected because
+the target PolicyServer no longer exists) or be silently rescheduled on an
+unintended PolicyServer.
+
+#### Mitigation
+
+- Automate the update of `admission.kubewarden.io/policy-server` Namespace
+  labels as part of the PolicyServer and Namespace lifecycle management
+  processes (for example, in GitOps workflows or cluster provisioning tooling).
+- Wait for the `ns-policyserver-mapper` policy to be in `Active` state before
+  deploying namespaced policies in newly labeled Namespaces.

--- a/docs/reference/threat-model.md
+++ b/docs/reference/threat-model.md
@@ -345,7 +345,7 @@ host capabilities.
 
 #### Mitigation
 
-- Apply principle of least privilege to `spec.namespacedPoliciesCapabilities`
+- Apply the principle of least privilege to `spec.namespacedPoliciesCapabilities`
   on every PolicyServer. Grant only the host capabilities that the policies
   running on that instance actually require.
 - Isolate PolicyServers for sensitive Namespaces: do not co-locate high-trust

--- a/docs/tutorials/writing-policies/metadata.md
+++ b/docs/tutorials/writing-policies/metadata.md
@@ -60,6 +60,11 @@ annotations:
   # Category indicates policy category. See more here at docs.kubewarden.io
   io.kubewarden.policy.severity: medium
   io.kubewarden.policy.category: Resource validation
+  # The next annotation is a list of self-reported host capability calls that
+  # the policy can make. Used when annotating the policy.
+  hostCapabilities:
+    - kubernetes/get_resource
+    - oci/v2/*
   # artifacthub specific: (optional, to release in Artifact Hub)
   io.kubewarden.policy.ociUrl: ghcr.io/myorg/my-policy
   io.artifacthub.displayName: Policy Name
@@ -93,6 +98,44 @@ contextAwareResources:
   - apiVersion: v1 kind: Namespace
 [...]
 ```
+
+## Self-reporting which host capabilities calls the policies use
+
+Within the metadata file, using the `hostCapabilities` field,
+users can define which [host capability
+calls](../../howtos/policy-servers/06-namespaced-policies-capabilities.md) the
+policy intends to use. For example:
+
+
+```yaml
+[...]
+hostCapabilities:
+  - kubernetes/list_resources_by_namespace
+  - kubernetes/list_resources_all
+  - kubernetes/get_resource
+[...]
+```
+
+This metadata is used when annotating the policy Wasm module with `kwctl
+annotate`. In addition, `kwctl annotate` performs an heuristic scan of the Wasm
+binary's data for known host-capability strings, and compares what it detects
+against the `hostCapabilities` list declared in `metadata.yml`. Any mismatch is
+reported as warnings on stderr.
+
+See [host capability
+calls](../../howtos/policy-servers/06-namespaced-policies-capabilities.md)
+documentation page for more info.
+
+:::warning
+Both the self-reporting and the heuristic scan cannot be used as a
+security boundary. A policy publisher could embed any arbitrary
+`hostCapabilities` list in the metadata regardless of what the binary actually
+does at runtime.
+
+Use this information as one signal alongside other trust indicators (image
+signing, source code review, policy provenance, etc) not as an authoritative
+proof of what capabilities a policy exercises.
+:::
 
 ## Specifying policies as mutating or non-mutating
 


### PR DESCRIPTION
## Description

- Expand `explanations/context-aware-policies.md`
- Add new `howtos/policy-servers/06-namespaced-policies-capabilities.md` page. This page is linked from several places, and contains the bulk of the explanation and examples on the new feature.
- Expand `reference/threat_model.md`
- Expand `howtos/security-hardening/security-hardening.md` page for production deployments.
- List host capability API calls in `referece/spec/host-capabilities/07-host-capabiliy-call-reference.md`
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Tested examples locally.
Pre-validated while under embargo.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
