### PR TITLE
chore: fix repository to copy documentation

### DIFF
--- a/updatecli/values.d/update-kwctl-cli-ref-docs.yaml
+++ b/updatecli/values.d/update-kwctl-cli-ref-docs.yaml
@@ -4,8 +4,8 @@ scm:
   enabled: false
 
 files:
-  - src: "cli-docs.md"
-    dst: "crates/kwctl/cli-docs.md"
+  - src: "crates/kwctl/cli-docs.md"
+    dst: "docs/reference/kwctl-cli.md"
 src:
   branch: "main"
   url: "https://github.com/kubewarden/kubewarden-controller.git"

--- a/updatecli/values.d/update-kwctl-cli-ref-docs.yaml
+++ b/updatecli/values.d/update-kwctl-cli-ref-docs.yaml
@@ -5,7 +5,7 @@ scm:
 
 files:
   - src: "cli-docs.md"
-    dst: "docs/reference/kwctl-cli.md"
+    dst: "crates/kwctl/cli-docs.md"
 src:
   branch: "main"
-  url: "https://github.com/kubewarden/kwctl.git"
+  url: "https://github.com/kubewarden/kubewarden-controller.git"

--- a/updatecli/values.d/update-policy-server-cli-ref-docs.yaml
+++ b/updatecli/values.d/update-policy-server-cli-ref-docs.yaml
@@ -4,8 +4,8 @@ scm:
   enabled: false
 
 files:
-  - src: "cli-docs.md"
+  - src: "crates/policy-server/cli-docs.md"
     dst: "docs/reference/policy-server-cli.md"
 src:
   branch: "main"
-  url: "https://github.com/kubewarden/policy-server.git"
+  url: "https://github.com/kubewarden/kubewarden-controller.git"


### PR DESCRIPTION
## Description

The updatecli script to copy kwctl cli reference documentation is pointing to the old repository. Now, the script should copy the files from the kubewarden-controller monorepo.

This is the fix of the issue detected on https://github.com/kubewarden/docs/pull/741
