### PR TITLE
docs: update references for adm-controller rename

### DIFF
--- a/docs/explanations/architecture.md
+++ b/docs/explanations/architecture.md
@@ -114,7 +114,7 @@ The Kubewarden consists of these components:
   The `policy-server` is the Webhook endpoint called by the Kubernetes
   API server to validate requests.
 
-- The [Kubewarden controller](https://github.com/kubewarden/kubewarden-controller)
+- The [Kubewarden controller](https://github.com/kubewarden/adm-controller)
   is a Kubernetes controller that reconciles Kubewarden's Custom Resources.
   This controller creates parts of the Kubewarden stack.
   It also translates Kubewarden configuration into Kubernetes directives.

--- a/docs/howtos/airgap/02-install.md
+++ b/docs/howtos/airgap/02-install.md
@@ -93,8 +93,8 @@ images](../../tutorials/verifying-kubewarden.md#container-images)
    ```
 
 1. Download `kubewarden-save-policies.sh` and `kubewarden-load-policies.sh`
-   from the [`kubewarden-controller`
-   repository](https://github.com/kubewarden/kubewarden-controller/blob/main/scripts)
+   from the [`kubewarden/adm-controller`
+   repository](https://github.com/kubewarden/adm-controller/blob/main/scripts)
 1. Save policies into a `.tar.gz` file:
 
    ```shell

--- a/docs/howtos/custom-certificate-authorities.md
+++ b/docs/howtos/custom-certificate-authorities.md
@@ -25,7 +25,7 @@ CA store shipped with its Linux container.
 On the client side, `kwctl` uses your operating system CA store.
 
 If you are using the
-[Kubewarden Controller](https://github.com/kubewarden/kubewarden-controller),
+[Kubewarden Controller](https://github.com/kubewarden/adm-controller),
 you can configure the PolicyServer via its
 [`spec` fields](/howtos/policy-servers/01-custom-cas.md).
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -116,7 +116,7 @@ helm install --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defa
 :::caution
 
 Since
-[`v0.4.0`](https://github.com/kubewarden/kubewarden-controller/releases/tag/v0.4.0),
+[`v0.4.0`](https://github.com/kubewarden/adm-controller/releases/tag/v0.4.0),
 a `PolicyServer` resource named `default` isn't created using the
 `kubewarden-controller` chart. Now a Helm chart called `kubewarden-defaults`,
 installs the default policy server.
@@ -264,9 +264,7 @@ Kubernetes 1.21.0
 :::
 
 The complete documentation of these Custom Resources is
-[here](https://github.com/kubewarden/kubewarden-controller/blob/main/docs/crds/README.md)
-or on
-[docs.crds.dev](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller).
+[here](./reference/CRDs.md)
 
 ## Example: Enforce your first policy
 

--- a/docs/reference/CRDs.md
+++ b/docs/reference/CRDs.md
@@ -13,8 +13,7 @@ doc-topic: [operator-manual, crd]
   <link rel="canonical" href="https://docs.kubewarden.io/reference/CRDs"/>
 </head>
 
-You can find the definitions for the Kubewarden Custom Resources both on this page and
-[here at docs.crds.dev](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller).
+You can find the definitions for the Kubewarden Custom Resources on this page
 
 <!--
 API REFERENCE GOES BELOW.

--- a/docs/reference/policy-evaluation-timeout.md
+++ b/docs/reference/policy-evaluation-timeout.md
@@ -125,7 +125,7 @@ You can tune this behavior using these environment variables:
   The value is in seconds with a default value of `2`.
 
 When using the
-[`PolicyServer`](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller/policies.kubewarden.io/PolicyServer/v1@v1.4.2)
+[`PolicyServer`](./CRDs#policyserver)
 Kubernetes Custom Resource Definition, you can set these environment variables
 as follows:
 

--- a/docs/reference/spec/05-context-aware-policies.md
+++ b/docs/reference/spec/05-context-aware-policies.md
@@ -102,7 +102,7 @@ policy author using the Kubewarden SDKs.
 ## ClusterAdmissionPolicies
 
 ClusterAdmissionPolicies have the field
-[spec.contextAwareResources](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller/policies.kubewarden.io/ClusterAdmissionPolicy/v1#spec-contextAwareResources).
+[spec.contextAwareResources](../CRDs#contextawareresource).
 This field provides a list a `GroupVersionKind` resources that the policy needs
 to access. This permist policy writers to ship the "permissions" that the
 policy needs together with the policy. Moreover, this permits policy operators

--- a/docs/tutorials/verifying-kubewarden.md
+++ b/docs/tutorials/verifying-kubewarden.md
@@ -82,7 +82,7 @@ slsactl verify ghcr.io/kubewarden/policy-server:v1.30.0
 ```
 
 The same applies to all other images produced by the Kubewarden team, such as
-`kubewarden/kubewarden-controller` and `kubewarden/audit-scanner`.
+`kubewarden/controller` and `kubewarden/audit-scanner`.
 
 All container images also have SBOM and provenance files that can be used to
 ensure the secure supply chain of the images. You can find attestation files on


### PR DESCRIPTION
## Description

Update latest documentation to reflect the GitHub repository rename from kubewarden/kubewarden-controller to kubewarden/adm-controller and the container image rename from kubewarden-controller to controller. Versioned docs are left unchanged as historical records. Updated files include quick-start.md, verifying-kubewarden.md, hauler.md, install.md, custom-certificate-authorities.md, architecture.md, CRDs.md, policy-evaluation-timeout.md, and context-aware-policies.md.

Part of https://github.com/kubewarden/adm-controller/issues/1657