### PR TITLE
Update docs to point to the monorepo

### DIFF
--- a/docs/explanations/architecture.md
+++ b/docs/explanations/architecture.md
@@ -114,26 +114,24 @@ The Kubewarden consists of these components:
   The `policy-server` is the Webhook endpoint called by the Kubernetes
   API server to validate requests.
 
-- The [Kubewarden controller](https://github.com/kubewarden/adm-controller)
+- The [Kubewarden admission controller](https://github.com/kubewarden/adm-controller)
   is a Kubernetes controller that reconciles Kubewarden's Custom Resources.
   This controller creates parts of the Kubewarden stack.
   It also translates Kubewarden configuration into Kubernetes directives.
 
-  The `kubewarden-controller` registers the needed
-  `MutatingWebhookConfiguration` or
-  `ValidatingWebhookConfiguration`
-  objects with the Kubernetes API server.
+  The admission controller registers the needed `MutatingWebhookConfiguration`
+  or `ValidatingWebhookConfiguration` objects with the Kubernetes API server.
 
 - [Kubewarden policies](../tutorials/writing-policies/index.md)
   are WebAssembly modules holding the validation or mutation logic.
   WebAssembly modules have detailed documentation in the
   [writing policies](../tutorials/writing-policies/index.md) sections.
 
-- The [PolicyServer](https://github.com/kubewarden/policy-server)
+- The [PolicyServer](https://github.com/kubewarden/adm-controller)
   receives requests for validation.
   It validates the requests by executing Kubewarden policies.
 
-- The [audit scanner](https://github.com/kubewarden/audit-scanner)
+- The [audit scanner](./audit-scanner/audit-scanner.md)
   inspects the resources already in the cluster.
   It identifies those violating Kubewarden policies.
 
@@ -158,7 +156,7 @@ The Kubewarden consists of these components:
             registry[("OCI registry")]
           end
           subgraph kw["`**Kubewarden**`"]
-            controller("`**KW controller**`")
+            controller("`**KW admission controller**`")
             subgraph policy-server["`**policy-server**`"]
               direction LR
               kw-policy-1{{"Policy 1"}}

--- a/docs/explanations/architecture.md
+++ b/docs/explanations/architecture.md
@@ -127,7 +127,7 @@ The Kubewarden consists of these components:
   WebAssembly modules have detailed documentation in the
   [writing policies](../tutorials/writing-policies/index.md) sections.
 
-- The [PolicyServer](https://github.com/kubewarden/adm-controller)
+- The [PolicyServer](/reference/policy-server-cli)
   receives requests for validation.
   It validates the requests by executing Kubewarden policies.
 

--- a/docs/explanations/comparisons/opa-comparison.md
+++ b/docs/explanations/comparisons/opa-comparison.md
@@ -172,7 +172,7 @@ react to new releases of the policy (using automation tools like
 configuration.
 
 The pipeline tests the policy against different types of requests. You can do
-the testing using the [`kwctl`](https://github.com/kubewarden/adm-controller) CLI tool,
+the testing using the [`kwctl`](/reference/kwctl-cli) CLI tool,
 without requiring a running Kubernetes cluster. kwctl uses the same evaluation
 engine used by the Kubewarden stack deployed in a Kubernetes cluster.
 

--- a/docs/explanations/comparisons/opa-comparison.md
+++ b/docs/explanations/comparisons/opa-comparison.md
@@ -172,7 +172,7 @@ react to new releases of the policy (using automation tools like
 configuration.
 
 The pipeline tests the policy against different types of requests. You can do
-the testing using the [`kwctl`](https://github.com/kubewarden/kwctl) CLI tool,
+the testing using the [`kwctl`](https://github.com/kubewarden/adm-controller) CLI tool,
 without requiring a running Kubernetes cluster. kwctl uses the same evaluation
 engine used by the Kubewarden stack deployed in a Kubernetes cluster.
 

--- a/docs/explanations/distributing-policies.md
+++ b/docs/explanations/distributing-policies.md
@@ -43,7 +43,7 @@ specification permits storing any binary blob inside a regular OCI-compliant con
 
 The target OCI-compliant registry **must support artifacts** to successfully push a Kubewarden Policy to it.
 
-You can use the [`kwctl`](https://github.com/kubewarden/kwctl) CLI to push a Kubewarden Policy to an OCI-compliant registry.
+You can use the [`kwctl`](https://github.com/kubewarden/adm-controller) CLI to push a Kubewarden Policy to an OCI-compliant registry.
 
 ## Annotating the policy
 

--- a/docs/explanations/distributing-policies.md
+++ b/docs/explanations/distributing-policies.md
@@ -43,7 +43,7 @@ specification permits storing any binary blob inside a regular OCI-compliant con
 
 The target OCI-compliant registry **must support artifacts** to successfully push a Kubewarden Policy to it.
 
-You can use the [`kwctl`](https://github.com/kubewarden/adm-controller) CLI to push a Kubewarden Policy to an OCI-compliant registry.
+You can use the [`kwctl`](/reference/kwctl-cli) CLI to push a Kubewarden Policy to an OCI-compliant registry.
 
 ## Annotating the policy
 

--- a/docs/howtos/airgap/01-requirements.md
+++ b/docs/howtos/airgap/01-requirements.md
@@ -15,5 +15,5 @@ doc-topic: [operator-manual, airgap, requirements]
 1. Private registry that supports OCI artifacts. It's needed for storing
    container images and policies. There is a list of supported Open Container
 Initiative (OCI) registries [here](../../reference/oci-registries-support).
-1. [`kwctl`](https://github.com/kubewarden/adm-controller) 1.3.1 or later.
+1. [`kwctl`](/howtos/install-kwctl) 1.3.1 or later.
 1. docker v20.10.6 or later.

--- a/docs/howtos/airgap/01-requirements.md
+++ b/docs/howtos/airgap/01-requirements.md
@@ -15,5 +15,5 @@ doc-topic: [operator-manual, airgap, requirements]
 1. Private registry that supports OCI artifacts. It's needed for storing
    container images and policies. There is a list of supported Open Container
 Initiative (OCI) registries [here](../../reference/oci-registries-support).
-1. [`kwctl`](https://github.com/kubewarden/kwctl) 1.3.1 or later.
+1. [`kwctl`](https://github.com/kubewarden/adm-controller) 1.3.1 or later.
 1. docker v20.10.6 or later.

--- a/docs/howtos/airgap/02-install.md
+++ b/docs/howtos/airgap/02-install.md
@@ -262,7 +262,7 @@ kind: PolicyServer
 metadata:
   name: reserved-instance-for-tenant-a
 spec:
-  image: <REGISTRY.YOURDOMAIN.COM:PORT>/kubewarden/policy-server:v1.3.0
+  image: <REGISTRY.YOURDOMAIN.COM:PORT>/kubewarden/adm-controller/policy-server:v1.3.0
   replicas: 2
   serviceAccountName: sa
 ```

--- a/docs/howtos/airgap/03-hauler.md
+++ b/docs/howtos/airgap/03-hauler.md
@@ -63,10 +63,10 @@ this:
 ```shell
 2025-08-12 18:55:54 WRN specify an export platform to prevent potential platform mismatch on import of index [ghcr.io/kyverno/policy-reporter:3.3.3]
 2025-08-12 18:55:54 WRN specify an export platform to prevent potential platform mismatch on import of index [ghcr.io/kyverno/policy-reporter-ui:2.4.1]
-2025-08-12 18:55:54 WRN specify an export platform to prevent potential platform mismatch on import of index [ghcr.io/kubewarden/policy-server:v1.27.0]
-2025-08-12 18:55:54 WRN specify an export platform to prevent potential platform mismatch on import of index [ghcr.io/kubewarden/audit-scanner:v1.27.0]
-2025-08-12 18:55:54 WRN specify an export platform to prevent potential platform mismatch on import of index [ghcr.io/rancher/kuberlr-kubectl:v5.0.0]
-2025-08-12 18:55:54 WRN specify an export platform to prevent potential platform mismatch on import of index [ghcr.io/kubewarden/kubewarden-controller:v1.27.0]
+2025-08-12 18:55:54 WRN specify an export platform to prevent potential platform mismatch on import of index [ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0]
+2025-08-12 18:55:54 WRN specify an export platform to prevent potential platform mismatch on import of index [ghcr.io/kubewarden/adm-controller/audit-scanner:v1.36.0]
+2025-08-12 18:55:54 WRN specify an export platform to prevent potential platform mismatch on import of index [ghcr.io/rancher/kuberlr-kubectl:v8.0.0]
+2025-08-12 18:55:54 WRN specify an export platform to prevent potential platform mismatch on import of index [ghcr.io/kubewarden/adm-controller/controller:v1.36.0]
 ```
 
 To avoid this warning message, you can set the `--platform` CLI flag to define
@@ -207,7 +207,7 @@ kind: PolicyServer
 metadata:
   name: reserved-instance-for-tenant-a
 spec:
-  image: <REGISTRY.YOURDOMAIN.COM:PORT>/kubewarden/policy-server:v1.3.0
+  image: <REGISTRY.YOURDOMAIN.COM:PORT>/kubewarden/adm-controller/policy-server:v1.36.0
   replicas: 2
   serviceAccountName: sa
 ```

--- a/docs/howtos/custom-certificate-authorities.md
+++ b/docs/howtos/custom-certificate-authorities.md
@@ -25,7 +25,7 @@ CA store shipped with its Linux container.
 On the client side, `kwctl` uses your operating system CA store.
 
 If you are using the
-[Kubewarden Controller](https://github.com/kubewarden/adm-controller),
+[Kubewarden Controller](/explanations/architecture),
 you can configure the PolicyServer via its
 [`spec` fields](/howtos/policy-servers/01-custom-cas.md).
 

--- a/docs/howtos/gatekeeper-migration.md
+++ b/docs/howtos/gatekeeper-migration.md
@@ -25,7 +25,7 @@ uses a basic Gatekeeper demo policy Prerequisites:
 
 - [opa](https://github.com/open-policy-agent/opa/releases): you use this tool
   to build the code into wasm. This guide was written using the `v1.5.1` version.
-- [`kwctl`](https://github.com/kubewarden/kwctl/releases): tool you use to
+- [`kwctl`](https://github.com/kubewarden/adm-controller/releases): tool you use to
   prepare and run Kubewarden web assembly module
 - [`bats`](https://github.com/bats-core/bats-core): tool used to run end-to-end
   tests. If you decided to write such kind of tests

--- a/docs/howtos/gatekeeper-migration.md
+++ b/docs/howtos/gatekeeper-migration.md
@@ -25,7 +25,7 @@ uses a basic Gatekeeper demo policy Prerequisites:
 
 - [opa](https://github.com/open-policy-agent/opa/releases): you use this tool
   to build the code into wasm. This guide was written using the `v1.5.1` version.
-- [`kwctl`](https://github.com/kubewarden/adm-controller/releases): tool you use to
+- [`kwctl`](/howtos/install-kwctl): tool you use to
   prepare and run Kubewarden web assembly module
 - [`bats`](https://github.com/bats-core/bats-core): tool used to run end-to-end
   tests. If you decided to write such kind of tests

--- a/docs/howtos/host-network.md
+++ b/docs/howtos/host-network.md
@@ -95,7 +95,7 @@ kind: PolicyServer
 metadata:
   name: custom-ports
 spec:
-  image: ghcr.io/kubewarden/policy-server:latest
+  image: ghcr.io/kubewarden/adm-controller/policy-server:1.36.0
   replicas: 2
   webhookPort: 9443
   readinessProbePort: 9081
@@ -180,7 +180,7 @@ kind: PolicyServer
 metadata:
   name: secondary
 spec:
-  image: ghcr.io/kubewarden/policy-server:latest
+  image: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
   replicas: 3
   affinity:
     podAntiAffinity:

--- a/docs/howtos/install-kwctl.md
+++ b/docs/howtos/install-kwctl.md
@@ -3,8 +3,7 @@ sidebar_label: Install kwctl
 sidebar_position: 15
 title: Installing kwctl
 description: Installing kwctl
-keywords:
-  [kubewarden, kubernetes, install kwctl, install, kwctl]
+keywords: [kubewarden, kubernetes, install kwctl, install, kwctl]
 doc-persona: [kubewarden-all]
 doc-type: [howto]
 doc-topic: [install-kwctl]
@@ -21,14 +20,13 @@ import TabItem from '@theme/TabItem';
 
 `kwctl` is the command-line interface (CLI) tool for Kubewarden. Below are installation instructions for some operating systems.
 
-
 <Tabs
-  defaultValue="linux"
-  values={[
-    {label: 'Linux', value: 'linux'},
-    {label: 'macOS', value: 'mac'},
-    {label: 'Windows', value: 'windows'},
-  ]}>
+defaultValue="linux"
+values={[
+{label: 'Linux', value: 'linux'},
+{label: 'macOS', value: 'mac'},
+{label: 'Windows', value: 'windows'},
+]}>
 <TabItem value="linux">
 
 ## Install for Linux
@@ -42,6 +40,7 @@ brew install kwctl
 ```
 
 Verify Installation:
+
 ```bash
 kwctl --version
 ```
@@ -57,11 +56,13 @@ zypper install kwctl
 If you're using Arch Linux, or an Arch-based distribution, you can install kwctl from the AUR.
 
 #### Using an AUR Helper (yay)
+
 ```bash
 yay -S kwctl
 ```
 
 #### Using makepkg
+
 ```bash
 # Clone the AUR package
 git clone https://aur.archlinux.org/kwctl.git
@@ -72,6 +73,7 @@ makepkg -si
 ```
 
 #### Verify the installation
+
 ```bash
 kwctl --version
 ```
@@ -79,38 +81,45 @@ kwctl --version
 ### Manual installation
 
 1. Download the latest release of `kwctl` for Linux:
-    ```bash
-    curl -LO https://github.com/kubewarden/kwctl/releases/latest/download/kwctl-linux-x86_64.zip
-    ```
 
-    For ARM64 systems (e.g., Raspberry Pi), use:
-    ```bash
-    curl -LO https://github.com/kubewarden/kwctl/releases/latest/download/kwctl-linux-aarch64.zip
-    ```
+   ```bash
+   curl -LO https://github.com/kubewarden/adm-controller/releases/latest/download/kwctl-linux-x86_64.zip
+   ```
+
+   For ARM64 systems (e.g., Raspberry Pi), use:
+
+   ```bash
+   curl -LO https://github.com/kubewarden/adm-controller/releases/latest/download/kwctl-linux-aarch64.zip
+   ```
+
 1. Extract the files from the downloaded `.zip` file:
-    ```bash
-    unzip kwctl-linux-x86_64.zip
-    ```
 
-    This extracts the following files:
+   ```bash
+   unzip kwctl-linux-x86_64.zip
+   ```
 
-    - `kwctl-linux-x86_64`: The `kwctl` binary
-    - `kwctl-linux-x86_64.sig`: A signature file for verifying the binary
-    - `kwctl-linux-x86_64.pem`: A certificate file for verifying the signature
+   This extracts the following files:
+
+   - `kwctl-linux-x86_64`: The `kwctl` binary
+   - `kwctl-linux-x86_64.bundle.sigstore`: Sigstore bundle to verify the binary
 
 1. Move the binary to a directory in your PATH, rename to `kwctl` and make executable.
 
 1. Verify the installation:
-    ```bash
-    kwctl --version
-    ```
+
+   ```bash
+   kwctl --version
+   ```
+
 </TabItem>
 
 <TabItem value="mac">
 ## Install for Apple
 
 ### Using Homebrew
+
 Install `kwctl`:
+
 ```shell
 brew install kwctl
 ```
@@ -124,28 +133,29 @@ kwctl --version
 ### Manual installation
 
 1. Download the latest release of `kwctl` for macOS:
-    - For **Apple Silicon (ARM64)** systems, use:
-        ```bash
-        curl -LO https://github.com/kubewarden/kwctl/releases/latest/download/kwctl-darwin-aarch64.zip
-        ```
-    - For **Intel (x86_64)** systems, use:
-        ```bash
-        curl -LO https://github.com/kubewarden/kwctl/releases/latest/download/kwctl-darwin-x86_64.zip
-        ```
+   - For **Apple Silicon (ARM64)** systems, use:
+     ```bash
+     curl -LO https://github.com/kubewarden/adm-controller/releases/latest/download/kwctl-darwin-aarch64.zip
+     ```
+   - For **Intel (x86_64)** systems, use:
+     ```bash
+     curl -LO https://github.com/kubewarden/adm-controller/releases/latest/download/kwctl-darwin-x86_64.zip
+     ```
 1. Extract the files from the downloaded `.zip` file:
-    ```bash
-    unzip kwctl-darwin-x86_64.zip
-    ```
-    This extracts the following files:
-    - `kwctl-darwin-x86_64`: The `kwctl` binary
-    - `kwctl-darwin-x86_64.sig`: A signature file for verifying the binary
-    - `kwctl-darwin-x86_64.pem`: A certificate file for verifying the signature
+   ```bash
+   unzip kwctl-darwin-x86_64.zip
+   ```
+   This extracts the following files:
+   - `kwctl-darwin-x86_64`: The `kwctl` binary
+   - `kwctl-darwin-x86_64.bundle.sigstore`: Sigstore bundle to verify the binary
 1. Move the binary to a directory in your PATH, rename to `kwctl` and make executable.
-1. Verify the Installation
-    Check the `kwctl` installation:
-    ```bash
-    kwctl --version
-    ```
+1. Verify the Installation.
+   Check the `kwctl` installation:
+
+   ```bash
+   kwctl --version
+   ```
+
 </TabItem>
 
 <TabItem value="windows">
@@ -153,18 +163,19 @@ kwctl --version
 ## Install for Windows
 
 1. Download `kwctl`
-    1. Open your browser and go to the [Kubewarden releases page](https://github.com/kubewarden/kwctl/releases/latest)
-    1. Download the `kwctl-windows-x86_64.zip` file.
+   1. Open your browser and go to the [Kubewarden releases page](https://github.com/kubewarden/adm-controller/releases/latest)
+   1. Download the `kwctl-windows-x86_64.exe.zip` file.
 1. Extract the files from the downloaded zip file. It will contain:
-    - `kwctl-windows-x86_64.exe`: the `kwctl` binary.
-    - `kwctl-windows-x86_64.sig`: a signature file for verifying the binary.
-    - `kwctl-windows-x86_64.pem`: a certificate file for verifying the signature.
+   - `kwctl-windows-x86_64.exe`: the `kwctl` binary.
+   - `kwctl-windows-x86_64.bundle.sigstore`: Sigstore bundle to verify the binary.
 1. Rename the binary file from `kwctl-windows-x86_64.exe` to `kwctl.exe` for easier use.
 1. Move the binary to a location covered by your `PATH` environment variable.
 1. Verify the installation. Open a new command prompt or PowerShell window and check the `kwctl` installation:
-    ```cmd
-    kwctl --version
-    ```
+
+   ```cmd
+   kwctl --version
+   ```
+
 </TabItem>
 </Tabs>
 

--- a/docs/howtos/policy-servers/02-private-registry.md
+++ b/docs/howtos/policy-servers/02-private-registry.md
@@ -69,7 +69,7 @@ kind: PolicyServer
 metadata:
   name: default
 spec:
-  image: ghcr.io/kubewarden/policy-server:v1.1.1
+  image: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
   serviceAccountName: policy-server
   replicas: 1
   annotations:

--- a/docs/howtos/policy-servers/05-private-sigstore.md
+++ b/docs/howtos/policy-servers/05-private-sigstore.md
@@ -191,7 +191,7 @@ kind: PolicyServer
 metadata:
   name: default
 spec:
-  image: ghcr.io/kubewarden/policy-server:latest
+  image: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
   replicas: 1
   sigstoreTrustConfig: my-sigstore-trust-config
   verificationConfig: my-verification-config

--- a/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
+++ b/docs/howtos/policy-servers/06-namespaced-policies-capabilities.md
@@ -36,7 +36,6 @@ This how-to explains how cluster operators can enforce that promise by:
 2. Controlling which PolicyServer a namespaced policy runs on, using the
    `ns-policyserver-mapper` policy.
 
-
 :::warning
 The per PolicyServer restriction on host capabilities is part of Kubewarden
 `v1.35.0` and higher.
@@ -79,14 +78,14 @@ The field accepts an array of strings. Wildcard patterns follow the same
 conventions as Kubernetes Dynamic Admission Controller
 [match rules](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules):
 
-| Value | Meaning |
-|-------|---------|
-| _(unset)_ | Allow all host capabilities (default, backwards-compatible) |
-| `["*"]` | Explicitly allow all host capabilities |
-| `[]` | Deny all host capabilities to namespaced policies |
-| `["oci/*"]` | Allow all OCI capabilities, all versions |
-| `["oci/v2/*"]` | Allow all OCI v2 capabilities only |
-| `["oci/v1/verify", "net/v1/dns_lookup_host"]` | Allow only those two specific calls |
+| Value                                         | Meaning                                                     |
+| --------------------------------------------- | ----------------------------------------------------------- |
+| _(unset)_                                     | Allow all host capabilities (default, backwards-compatible) |
+| `["*"]`                                       | Explicitly allow all host capabilities                      |
+| `[]`                                          | Deny all host capabilities to namespaced policies           |
+| `["oci/*"]`                                   | Allow all OCI capabilities, all versions                    |
+| `["oci/v2/*"]`                                | Allow all OCI v2 capabilities only                          |
+| `["oci/v1/verify", "net/v1/dns_lookup_host"]` | Allow only those two specific calls                         |
 
 :::info
 Cluster-wide policies (`ClusterAdmissionPolicy` and `ClusterAdmissionPolicyGroup`)
@@ -102,7 +101,7 @@ kind: PolicyServer
 metadata:
   name: for-namespaced-policies
 spec:
-  image: ghcr.io/kubewarden/policy-server:latest
+  image: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
   replicas: 1
   namespacedPoliciesCapabilities: []
 ```
@@ -118,7 +117,7 @@ kind: PolicyServer
 metadata:
   name: for-namespaced-policies
 spec:
-  image: ghcr.io/kubewarden/policy-server:latest
+  image: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
   replicas: 1
   namespacedPoliciesCapabilities:
     - "oci/v1/verify"
@@ -133,7 +132,7 @@ kind: PolicyServer
 metadata:
   name: for-namespaced-policies
 spec:
-  image: ghcr.io/kubewarden/policy-server:latest
+  image: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
   replicas: 1
   namespacedPoliciesCapabilities:
     - "*"
@@ -253,7 +252,7 @@ metadata:
   name: for-namespaced-policies
   namespace: kubewarden
 spec:
-  image: ghcr.io/kubewarden/policy-server:v1.35.0
+  image: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
   namespacedPoliciesCapabilities: []
 ```
 
@@ -381,7 +380,6 @@ Use this information as one signal alongside other trust indicators (image
 signing, source code review, policy provenance, etc) not as an authoritative
 proof of what capabilities a policy exercises.
 :::
-
 
 ## Running a policy with host capability calls
 

--- a/docs/howtos/raw-policies.md
+++ b/docs/howtos/raw-policies.md
@@ -84,7 +84,7 @@ docker run --rm -it \
     -p 3000:3000 \
     -v $(pwd)/policies.yml:/policies.yml \
     -v policy-store:/registry \
-    ghcr.io/kubewarden/policy-server \
+    ghcr.io/kubewarden/adm-controller/policy-server \
     --ignore-kubernetes-connection-failure
 ```
 
@@ -93,6 +93,7 @@ The flag `--ignore-kubernetes-connection-failure` is required to start the polic
 :::
 
 You can also use a bind mount to store the policies modules in a persistent way:
+
 ```bash
 mkdir -p ./registry
 
@@ -101,7 +102,7 @@ docker run --rm -it \
     -p 3000:3000 \
     -v $(pwd)/policies.yml:/policies.yml \
     -v $(pwd)/registry:/registry \
-    ghcr.io/kubewarden/policy-server \
+    ghcr.io/kubewarden/adm-controller/policy-server \
     --ignore-kubernetes-connection-failure
 ```
 
@@ -135,7 +136,7 @@ spec:
     spec:
       containers:
         - name: policy-server
-          image: ghcr.io/kubewarden/policy-server:v1.9.0
+          image: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
           ports:
             - containerPort: 3000
           volumeMounts:

--- a/docs/howtos/security-hardening/secure-supply-chain.md
+++ b/docs/howtos/security-hardening/secure-supply-chain.md
@@ -41,7 +41,7 @@ In the following sections, you need to install a few tools so that users
 can sign and verify Open Container Initiative (OCI) artifact signatures. The
 examples show the use of
 [`cosign`](https://docs.sigstore.dev/quickstart/quickstart-cosign/) and
-[`kwctl`](https://github.com/kubewarden/adm-controller) utilities for signing and
+[`kwctl`](/reference/kwctl-cli) utilities for signing and
 inspecting policies.
 
 To use GitHub to sign policies you need to install [GitHub

--- a/docs/howtos/security-hardening/secure-supply-chain.md
+++ b/docs/howtos/security-hardening/secure-supply-chain.md
@@ -4,7 +4,13 @@ sidebar_position: 40
 title: Secure supply chain
 description: A secure supply chain infrastructure using Kubewarden.
 keywords: [kubewarden, kubernetes, secure supply chain, infrastructure]
-doc-persona: [kubewarden-user, kubewarden-operator, kubewarden-distributor, kubewarden-integrator]
+doc-persona:
+  [
+    kubewarden-user,
+    kubewarden-operator,
+    kubewarden-distributor,
+    kubewarden-integrator,
+  ]
 doc-type: [howto]
 doc-topic: [distributing-policies, secure-supply-chain]
 ---
@@ -35,7 +41,7 @@ In the following sections, you need to install a few tools so that users
 can sign and verify Open Container Initiative (OCI) artifact signatures. The
 examples show the use of
 [`cosign`](https://docs.sigstore.dev/quickstart/quickstart-cosign/) and
-[`kwctl`](https://github.com/kubewarden/kwctl) utilities for signing and
+[`kwctl`](https://github.com/kubewarden/adm-controller) utilities for signing and
 inspecting policies.
 
 To use GitHub to sign policies you need to install [GitHub
@@ -380,8 +386,8 @@ allOf:
     annotations: ~
 anyOf: ~
 ```
-</details>
 
+</details>
 
 You can use this `verification_config.yml` to create the `ConfigMap`.
 
@@ -443,7 +449,7 @@ metadata:
   finalizers:
     - kubewarden
 spec:
-  image: ghcr.io/kubewarden/policy-server:v0.2.7
+  image: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
   serviceAccountName: policy-server
   replicas: 1
   #name of the configmap with the signatures requirements
@@ -456,7 +462,9 @@ spec:
     - name: "KUBEWARDEN_LOG_LEVEL"
       value: "info"
 ```
+
 ➀ `verificationConfig`
+
 <hr/>
 
 If you deploy the default Policy Server using the `kubewarden-defaults` Helm
@@ -483,47 +491,49 @@ apiVersion: v1
 
 allOf: # ➀
   - kind: githubAction
-    owner: kubewarden   # mandatory
+    owner: kubewarden # mandatory
     annotations:
       env: prod
 
 anyOf: # ➁ : at least `anyOf.minimumMatches` are required to match
   minimumMatches: 2 # default is 1
   signatures:
-  - kind: pubKey
-    owner: flavio # optional
-    key: .... # mandatory
-    annotations:  # optional
-      env: prod
-      foo: bar
-  - kind: pubKey
-    owner: victor # optional
-    key: .... # mandatory
-  - kind: genericIssuer
-    issuer: https://github.com/login/oauth
-    subject:
-      equal: alice@example.com
-  - kind: genericIssuer
-    issuer: https://token.actions.githubusercontent.com
-    subject:
-      equal: https://github.com/flavio/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main
-  - kind: genericIssuer
-    issuer: https://token.actions.githubusercontent.com
-    subject:
-      urlPrefix: https://github.com/flavio/
-  - kind: genericIssuer
-    issuer: https://token.actions.githubusercontent.com
-    subject:
-      urlPrefix: https://github.com/kubewarden # <- it will be post-fixed with `/` for security reasons
-  - kind: githubAction
-    owner: flavio   # mandatory
-    repo: policy1 # optional
-  - kind: pubKey
-    owner: alice # optional
-    key: .... # mandatory
+    - kind: pubKey
+      owner: flavio # optional
+      key: .... # mandatory
+      annotations: # optional
+        env: prod
+        foo: bar
+    - kind: pubKey
+      owner: victor # optional
+      key: .... # mandatory
+    - kind: genericIssuer
+      issuer: https://github.com/login/oauth
+      subject:
+        equal: alice@example.com
+    - kind: genericIssuer
+      issuer: https://token.actions.githubusercontent.com
+      subject:
+        equal: https://github.com/flavio/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main
+    - kind: genericIssuer
+      issuer: https://token.actions.githubusercontent.com
+      subject:
+        urlPrefix: https://github.com/flavio/
+    - kind: genericIssuer
+      issuer: https://token.actions.githubusercontent.com
+      subject:
+        urlPrefix: https://github.com/kubewarden # <- it will be post-fixed with `/` for security reasons
+    - kind: githubAction
+      owner: flavio # mandatory
+      repo: policy1 # optional
+    - kind: pubKey
+      owner: alice # optional
+      key: .... # mandatory
 ```
+
 ➀ : `allOf`<br/>
 ➁ : `anyOf`
+
 </details>
 
 ### Signature validation
@@ -547,14 +557,14 @@ data and the owner of the key. In this example, you set `kind` to `pubKey` and
 the `key` has the public key. The owner field is optional, but can be useful to
 clarify who owns the key.
 
-```  yaml
-  - kind: pubKey
-    owner: bob # optional
-    key: |
-      -----BEGIN PUBLIC KEY-----
-      MBFKHFDGHKIJH0CAQYIKoZIzj0DAQcDQgAEX0HFTtCfTtPmkx5p1RbDE6HJSGAVD
-      BVDF6SKFSF87AASUspkQsN3FO4iyWodCy5j3o0CdIJD/KJHDJFHDFIu6sA==
-      -----END PUBLIC KEY-----
+```yaml
+- kind: pubKey
+  owner: bob # optional
+  key: |
+    -----BEGIN PUBLIC KEY-----
+    MBFKHFDGHKIJH0CAQYIKoZIzj0DAQcDQgAEX0HFTtCfTtPmkx5p1RbDE6HJSGAVD
+    BVDF6SKFSF87AASUspkQsN3FO4iyWodCy5j3o0CdIJD/KJHDJFHDFIu6sA==
+    -----END PUBLIC KEY-----
 ```
 
 ### Keyless signature validation

--- a/docs/howtos/tasks.md
+++ b/docs/howtos/tasks.md
@@ -25,7 +25,7 @@ Kubewarden uses two tools to help you find and test policies locally:
 
 - [Artifact Hub](https://artifacthub.io/packages/search?kind=13&sort=relevance&page=1)
   using their package filter for Kubewarden policies.
-- [`kwctl`](https://github.com/kubewarden/kwctl) CLI tool
+- [`kwctl`](https://github.com/kubewarden/adm-controller) CLI tool
 
 ### Artifact hub
 
@@ -86,8 +86,8 @@ _As a cluster administrator_
 #### Installation
 
 `kwctl` binaries for the stable releases are available from the [GitHub
-repository](https://github.com/kubewarden/kwctl/releases). To build `kwctl`
-from the GitHub [repo](https://github.com/kubewarden/kwctl), you need a
+repository](https://github.com/kubewarden/adm-controller/releases). To build `kwctl`
+from the GitHub [repo](https://github.com/kubewarden/adm-controller), you need a
 [Rust](https://www.rust-lang.org/tools/install) development environment.
 
 #### Usage

--- a/docs/howtos/tasks.md
+++ b/docs/howtos/tasks.md
@@ -25,7 +25,7 @@ Kubewarden uses two tools to help you find and test policies locally:
 
 - [Artifact Hub](https://artifacthub.io/packages/search?kind=13&sort=relevance&page=1)
   using their package filter for Kubewarden policies.
-- [`kwctl`](https://github.com/kubewarden/adm-controller) CLI tool
+- [`kwctl`](install-kwctl) CLI tool
 
 ### Artifact hub
 
@@ -85,8 +85,8 @@ _As a cluster administrator_
 
 #### Installation
 
-`kwctl` binaries for the stable releases are available from the [GitHub
-repository](https://github.com/kubewarden/adm-controller/releases). To build `kwctl`
+`kwctl` binaries for the stable releases are available from the [install kwctl
+page](install-kwctl). To build `kwctl`
 from the GitHub [repo](https://github.com/kubewarden/adm-controller), you need a
 [Rust](https://www.rust-lang.org/tools/install) development environment.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -90,7 +90,7 @@ Kubernetes cluster:
   [[< admission-policy >]] and [[< policy-server >]] Custom Resource Definitions. Also,
   the [[< report >]] Custom Resource Definitions used by the audit scanner.
 
-- `kubewarden-controller`, which installs the Kubewarden controller and the
+- `kubewarden-controller`, which installs the Kubewarden admission controller and the
   audit scanner
   :::note
   If you need to disable the audit scanner component check the audit
@@ -161,7 +161,7 @@ kind: PolicyServer
 metadata:
   name: reserved-instance-for-tenant-a
 spec:
-  image: ghcr.io/kubewarden/policy-server:v1.3.0
+  image: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
   replicas: 2
   serviceAccountName: ~
   env:
@@ -170,7 +170,7 @@ spec:
 ```
 
 :::note
-Check the [latest released `PolicyServer` version](https://github.com/kubewarden/policy-server/pkgs/container/policy-server) and change the tag to match.
+Check the [latest released `PolicyServer` version](https://github.com/kubewarden/adm-controller/pkgs/container/adm-controller%2Fpolicy-server) and change the tag to match.
 :::
 
 Overview of the attributes of the `PolicyServer` resource:

--- a/docs/reference/CRDs.md
+++ b/docs/reference/CRDs.md
@@ -17,7 +17,7 @@ You can find the definitions for the Kubewarden Custom Resources on this page
 
 <!--
 API REFERENCE GOES BELOW.
-From a file generated in the kubewarden/kubewarden-controller repo
+From a file generated in the kubewarden/adm-controller repo
 in docs/crds. Make sure to delete the old stuff below this line first!
 And then delete the L1 heading line.
 
@@ -898,7 +898,6 @@ _Appears in:_
 | `scheduled` | PolicyStatusScheduled is a transient state that will continue to<br />pending. This is the default state if a policy server is<br />assigned.<br /> |
 | `pending` | PolicyStatusPending informs that the policy server exists,<br />we are reconciling all resources.<br /> |
 | `active` | PolicyStatusActive informs that the k8s API server should be<br />forwarding admission review objects to the policy.<br /> |
-
 
 
 

--- a/docs/reference/artifacts.md
+++ b/docs/reference/artifacts.md
@@ -23,7 +23,7 @@ demonstrating how to verify Kubewarden artifacts.
 ### Binaries
 
 Kubewarden publishes the `kwctl` CLI tool at
-[GitHub releases](https://github.com/kubewarden/kwctl/releases).
+[GitHub releases](https://github.com/kubewarden/adm-controller/releases).
 
 ### OCI artifacts
 

--- a/docs/reference/artifacts.md
+++ b/docs/reference/artifacts.md
@@ -24,6 +24,7 @@ demonstrating how to verify Kubewarden artifacts.
 
 Kubewarden publishes the `kwctl` CLI tool at
 [GitHub releases](https://github.com/kubewarden/adm-controller/releases).
+Learn how to install it in the [install kwctl](/howtos/install-kwctl) documentation.
 
 ### OCI artifacts
 

--- a/docs/reference/oci-registries-support.md
+++ b/docs/reference/oci-registries-support.md
@@ -50,7 +50,7 @@ correct any registry inaccuracies by using the
 
 The Kubewarden project recommends:
 
-- [`kwctl`](https://github.com/kubewarden/kwctl) (our CLI tool).
+- [`kwctl`](https://github.com/kubewarden/adm-controller) (our CLI tool).
 - [Skopeo](https://github.com/containers/skopeo) ([>= 1.9.0](https://github.com/containers/skopeo/pull/1705)).
 - [Crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md).
 
@@ -66,4 +66,4 @@ Docker Inc. has announced that Docker Hub will support OCI artifacts in the
 
 Although JFrog supports OCI artifacts,
 it's only partially possible to push to it, when following their specification.
-[Read more here](https://github.com/kubewarden/kwctl/issues/59).
+[Read more here](https://github.com/kubewarden/adm-controller/issues/59).

--- a/docs/reference/oci-registries-support.md
+++ b/docs/reference/oci-registries-support.md
@@ -50,7 +50,7 @@ correct any registry inaccuracies by using the
 
 The Kubewarden project recommends:
 
-- [`kwctl`](https://github.com/kubewarden/adm-controller) (our CLI tool).
+- [`kwctl`](/reference/kwctl-cli) (our CLI tool).
 - [Skopeo](https://github.com/containers/skopeo) ([>= 1.9.0](https://github.com/containers/skopeo/pull/1705)).
 - [Crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md).
 

--- a/docs/reference/spec/host-capabilities/03-container-registry.md
+++ b/docs/reference/spec/host-capabilities/03-container-registry.md
@@ -188,9 +188,9 @@ OR
 ```
 
 For example, when requesting the manifest of the
-`ghcr.io/kubewarden/policy-server:v1.10.0` image, the payload would be:
+`ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0` image, the payload would be:
 
-- Input payload: `"ghcr.io/kubewarden/policy-server:v1.10.0"`
+- Input payload: `"ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0"`
 - Output payload: the body of the successful response obtained from the
   registry. It can be an [OCI index
   image](https://github.com/opencontainers/image-spec/blob/main/image-index.md)
@@ -336,9 +336,9 @@ string
 ```
 
 For example, when requesting the image manifest and configuration of the
-`ghcr.io/kubewarden/policy-server:v1.13.0` image, the payload would be:
+`ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0` image, the payload would be:
 
-- Input payload: `"ghcr.io/kubewarden/policy-server:v1.13.0"`
+- Input payload: `"ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0"`
 - Output payload: the body of the successful response obtained from the
   registry. It contains the [OCI image
   manifest](https://github.com/opencontainers/image-spec/blob/main/manifest.md)

--- a/docs/tutorials/testing-policies/02-policy-authors.md
+++ b/docs/tutorials/testing-policies/02-policy-authors.md
@@ -44,7 +44,7 @@ You can also write tests that execute against the Wasm binary containing your po
 To do this without having to deploy a Kubernetes cluster you can use these tools:
 
 - [bats](https://github.com/bats-core/bats-core): is to write tests and automate their execution.
-- [`kwctl`](https://github.com/kubewarden/adm-controller): Kubewarden's default
+- [`kwctl`](/reference/kwctl-cli): Kubewarden's default
   CLI tool that helps you with policy-related operations; pull, inspect,
   annotate, push, and run.
 
@@ -70,8 +70,8 @@ $ curl https://raw.githubusercontent.com/kubewarden/ingress-policy/v0.1.8/test_d
         registry://ghcr.io/kubewarden/policies/ingress:v0.1.8 | jq
 ```
 
-You can download pre-built binaries of `kwctl`
-[here](https://github.com/kubewarden/adm-controller/releases).
+Learn how to install `kwctl` in the
+[install kwctl](/howtos/install-kwctl) documentation.
 
 Using `bats` you can write a test that runs this command and looks for the expected outputs:
 

--- a/docs/tutorials/testing-policies/02-policy-authors.md
+++ b/docs/tutorials/testing-policies/02-policy-authors.md
@@ -2,7 +2,16 @@
 sidebar_label: Policy authors
 title: Testing for policy authors
 description: An introduction to testing Kubewarden policies for policy authors.
-keywords: [kubewarden, policy testing, policy author, rust, go, assemblyscript, development environment]
+keywords:
+  [
+    kubewarden,
+    policy testing,
+    policy author,
+    rust,
+    go,
+    assemblyscript,
+    development environment,
+  ]
 doc-persona: [kubewarden-policy-developer]
 doc-type: [tutorial]
 doc-topic: [testing-policies, policy-authors]
@@ -35,20 +44,19 @@ You can also write tests that execute against the Wasm binary containing your po
 To do this without having to deploy a Kubernetes cluster you can use these tools:
 
 - [bats](https://github.com/bats-core/bats-core): is to write tests and automate their execution.
-- [`kwctl`](https://github.com/kubewarden/kwctl): Kubewarden's default CLI tool that helps you with policy-related operations; pull, inspect, annotate, push, and run.
+- [`kwctl`](https://github.com/kubewarden/adm-controller): Kubewarden's default
+  CLI tool that helps you with policy-related operations; pull, inspect,
+  annotate, push, and run.
 
 To use `kwctl run` you need the following:
 
 1. The Wasm binary file reference of the policy to run.
-The Kubewarden policy can be loaded from:
-    - the local filesystem (`file://`)
-    - a HTTP(s) server (`https://`
-    - an OCI registry (`registry://`).
+   The Kubewarden policy can be loaded from: - the local filesystem (`file://`) - a HTTP(s) server (`https://` - an OCI registry (`registry://`).
 1. The admission request object to test.
-You give it via the `--request-path` argument,
-or on `stdin` by setting `--request-path` to `-`.
+   You give it via the `--request-path` argument,
+   or on `stdin` by setting `--request-path` to `-`.
 1. The policy settings for runtime as an inline JSON via `--settings-json` flag.
-Or a JSON, or a YAML file, loaded from the file system via `--settings-path`.
+   Or a JSON, or a YAML file, loaded from the file system via `--settings-path`.
 
 After the test `kwctl`, prints the `ValidationResponse` object to standard output.
 
@@ -63,7 +71,7 @@ $ curl https://raw.githubusercontent.com/kubewarden/ingress-policy/v0.1.8/test_d
 ```
 
 You can download pre-built binaries of `kwctl`
-[here](https://github.com/kubewarden/kwctl/releases).
+[here](https://github.com/kubewarden/adm-controller/releases).
 
 Using `bats` you can write a test that runs this command and looks for the expected outputs:
 

--- a/docs/tutorials/testing-policies/03-cluster-operators.md
+++ b/docs/tutorials/testing-policies/03-cluster-operators.md
@@ -23,7 +23,7 @@ You'll have questions like:
   - change the configuration parameters of the policy?
   - and so forth?
 
-Kubewarden has a utility, [`kwctl`](https://github.com/kubewarden/kwctl),
+Kubewarden has a utility, [`kwctl`](https://github.com/kubewarden/adm-controller),
 that permits testing of the policies outside of Kubernetes.
 
 To use `kwctl` you invoke it with following inputs:
@@ -42,7 +42,7 @@ Or a JSON, or a YAML file, loaded from the file system via `--settings-path`.
 After the test `kwctl`, prints the `ValidationResponse` object to the standard output.
 
 You can download pre-built binaries of `kwctl`
-[here](https://github.com/kubewarden/kwctl/releases).
+[here](https://github.com/kubewarden/adm-controller/releases).
 
 ## A testing example
 

--- a/docs/tutorials/testing-policies/03-cluster-operators.md
+++ b/docs/tutorials/testing-policies/03-cluster-operators.md
@@ -23,7 +23,7 @@ You'll have questions like:
   - change the configuration parameters of the policy?
   - and so forth?
 
-Kubewarden has a utility, [`kwctl`](https://github.com/kubewarden/adm-controller),
+Kubewarden has a utility, [`kwctl`](/reference/kwctl-cli),
 that permits testing of the policies outside of Kubernetes.
 
 To use `kwctl` you invoke it with following inputs:
@@ -41,8 +41,8 @@ Or a JSON, or a YAML file, loaded from the file system via `--settings-path`.
 
 After the test `kwctl`, prints the `ValidationResponse` object to the standard output.
 
-You can download pre-built binaries of `kwctl`
-[here](https://github.com/kubewarden/adm-controller/releases).
+Learn how to install `kwctl` in the
+[install kwctl](/howtos/install-kwctl) documentation.
 
 ## A testing example
 

--- a/docs/tutorials/writing-policies/go/01-intro-go.md
+++ b/docs/tutorials/writing-policies/go/01-intro-go.md
@@ -100,6 +100,6 @@ During this tutorial you need these tools on your development machine:
 You'll be using the compiler shipped in the official TinyGo container image.
 - [bats](https://github.com/bats-core/bats-core):
 used to write the tests and automate their execution.
-- [`kwctl`](https://github.com/kubewarden/kwctl/releases):
+- [`kwctl`](https://github.com/kubewarden/adm-controller/releases):
 CLI tool provided by Kubewarden to run its policies outside of Kubernetes, among other actions.
 It's covered in [this section](../../testing-policies/index.md) of the documentation.

--- a/docs/tutorials/writing-policies/go/01-intro-go.md
+++ b/docs/tutorials/writing-policies/go/01-intro-go.md
@@ -100,6 +100,6 @@ During this tutorial you need these tools on your development machine:
 You'll be using the compiler shipped in the official TinyGo container image.
 - [bats](https://github.com/bats-core/bats-core):
 used to write the tests and automate their execution.
-- [`kwctl`](https://github.com/kubewarden/adm-controller/releases):
+- [`kwctl`](/howtos/install-kwctl):
 CLI tool provided by Kubewarden to run its policies outside of Kubernetes, among other actions.
 It's covered in [this section](../../testing-policies/index.md) of the documentation.

--- a/docs/tutorials/writing-policies/go/05-e2e-tests.md
+++ b/docs/tutorials/writing-policies/go/05-e2e-tests.md
@@ -24,7 +24,7 @@ Recall, you need these tools on your development machine:
 You'll use the compiler shipped within the official TinyGo container image.
 - [bats](https://github.com/bats-core/bats-core):
 Used to write the tests and automate their execution.
-- [`kwctl`](https://github.com/kubewarden/adm-controller/releases):
+- [`kwctl`](/howtos/install-kwctl):
 CLI tool provided by Kubewarden to run its policies outside of Kubernetes, among other actions.
 It's covered in [this section](../../testing-policies/index.md) of the documentation.
 

--- a/docs/tutorials/writing-policies/go/05-e2e-tests.md
+++ b/docs/tutorials/writing-policies/go/05-e2e-tests.md
@@ -24,7 +24,7 @@ Recall, you need these tools on your development machine:
 You'll use the compiler shipped within the official TinyGo container image.
 - [bats](https://github.com/bats-core/bats-core):
 Used to write the tests and automate their execution.
-- [`kwctl`](https://github.com/kubewarden/kwctl/releases):
+- [`kwctl`](https://github.com/kubewarden/adm-controller/releases):
 CLI tool provided by Kubewarden to run its policies outside of Kubernetes, among other actions.
 It's covered in [this section](../../testing-policies/index.md) of the documentation.
 

--- a/docs/tutorials/writing-policies/index.md
+++ b/docs/tutorials/writing-policies/index.md
@@ -21,7 +21,7 @@ The input data is Kubernetes admission requests.
 The result of the computation is a validation response,
 which tells Kubernetes whether to accept, reject, or mutate the input data, the admission request.
 
-The [policy-server](https://github.com/kubewarden/adm-controller)
+The [policy-server](/reference/policy-server-cli)
 component of Kubewarden performs these operations.
 
 The policy server doesn't include any data processing capability.

--- a/docs/tutorials/writing-policies/index.md
+++ b/docs/tutorials/writing-policies/index.md
@@ -21,7 +21,7 @@ The input data is Kubernetes admission requests.
 The result of the computation is a validation response,
 which tells Kubernetes whether to accept, reject, or mutate the input data, the admission request.
 
-The [policy-server](https://github.com/kubewarden/policy-server)
+The [policy-server](https://github.com/kubewarden/adm-controller)
 component of Kubewarden performs these operations.
 
 The policy server doesn't include any data processing capability.

--- a/docs/tutorials/writing-policies/rego/open-policy-agent/02-create-policy.md
+++ b/docs/tutorials/writing-policies/rego/open-policy-agent/02-create-policy.md
@@ -27,7 +27,7 @@ You need these tools to complete this tutorial:
 - [`opa`](https://github.com/open-policy-agent/opa/releases):
 you'll use the `opa` CLI to build your policy as a `wasm` target.
 
-- [`kwctl`](https://github.com/kubewarden/kwctl/releases):
+- [`kwctl`](https://github.com/kubewarden/adm-controller/releases):
 you'll use `kwctl` to execute your built policy.
 
 ## The policy

--- a/docs/tutorials/writing-policies/rego/open-policy-agent/02-create-policy.md
+++ b/docs/tutorials/writing-policies/rego/open-policy-agent/02-create-policy.md
@@ -27,7 +27,7 @@ You need these tools to complete this tutorial:
 - [`opa`](https://github.com/open-policy-agent/opa/releases):
 you'll use the `opa` CLI to build your policy as a `wasm` target.
 
-- [`kwctl`](https://github.com/kubewarden/adm-controller/releases):
+- [`kwctl`](/howtos/install-kwctl):
 you'll use `kwctl` to execute your built policy.
 
 ## The policy

--- a/docs/tutorials/writing-policies/typescript/01-intro-typescript.md
+++ b/docs/tutorials/writing-policies/typescript/01-intro-typescript.md
@@ -94,5 +94,5 @@ During this tutorial you need these tools on your development machine:
 
 - **Node.js**: Version 18 or higher with npm for dependency management.
 - [**`bats`**](https://github.com/bats-core/bats-core): Used to write the tests and automate their execution.
-- [**`kwctl`** ≥ `v1.30`](https://github.com/kubewarden/adm-controller/releases): CLI tool provided by Kubewarden to run its policies outside of Kubernetes, among other actions. It's covered in [the testing policies section](../../testing-policies/index.md) of the documentation.
+- [**`kwctl`** ≥ `v1.30`](/howtos/install-kwctl): CLI tool provided by Kubewarden to run its policies outside of Kubernetes, among other actions. It's covered in [the testing policies section](../../testing-policies/index.md) of the documentation.
 - [**`javy`** ≥ `6.0.0`](https://github.com/bytecodealliance/javy): CLI tool for compiling JavaScript code to WebAssembly modules.

--- a/docs/tutorials/writing-policies/typescript/01-intro-typescript.md
+++ b/docs/tutorials/writing-policies/typescript/01-intro-typescript.md
@@ -94,5 +94,5 @@ During this tutorial you need these tools on your development machine:
 
 - **Node.js**: Version 18 or higher with npm for dependency management.
 - [**`bats`**](https://github.com/bats-core/bats-core): Used to write the tests and automate their execution.
-- [**`kwctl`** ≥ `v1.30`](https://github.com/kubewarden/kwctl/releases): CLI tool provided by Kubewarden to run its policies outside of Kubernetes, among other actions. It's covered in [the testing policies section](../../testing-policies/index.md) of the documentation.
+- [**`kwctl`** ≥ `v1.30`](https://github.com/kubewarden/adm-controller/releases): CLI tool provided by Kubewarden to run its policies outside of Kubernetes, among other actions. It's covered in [the testing policies section](../../testing-policies/index.md) of the documentation.
 - [**`javy`** ≥ `6.0.0`](https://github.com/bytecodealliance/javy): CLI tool for compiling JavaScript code to WebAssembly modules.


### PR DESCRIPTION
## Description

Update all the references to the old Kubewarden admission components to the new monorepo and after renaming

Part of https://github.com/kubewarden/adm-controller/issues/1657 and https://github.com/kubewarden/adm-controller/issues/1269
