### PR TITLE
feat: Redirect old docusaurus paths to antora for admc

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,14 @@ command = "make community-remote"
 
 #[build.environment]
 #  NODE_OPTIONS = "--max_old_space_size=4096"
+
+# Redirect old Docusaurus-style URLs (/<path>) to the new Antora URLs
+# (/admc/1.35/en/<path>).
+# Netlify serves existing files directly, so this only fires for paths that
+# don't have a real file in the build output (the old doc URLs).
+# Netlify pretty URL feature automatically adds the .html on the new Antora
+# URLs.
+[[redirects]]
+from = "/*"
+to = "/admc/1.35/en/:splat"
+status = 301


### PR DESCRIPTION
## Description

Redirect old Docusaurus-style URLs (`/<path>`) to the new Antora URLs (`/admc/1.35/en/<path>`).

Netlify's redirect resolution order:
1. If a file exists at the requested path in `build/site/`, it's served directly (no redirect).
2. If no file exists, Netlify checks redirect rules. The /* rule fires and sends a `301` to `/admc/1.35/en/<path>`.

So:
- https://docs.kubewarden.io/admc/1.35/en/reference/threat-model.html , file exists, served directly
- https://docs.kubewarden.io/reference/threat-model , no file, redirected to /admc/1.35/en/reference/threat-model , Netlify then serves /admc/1.35/en/reference/threat-model.html
- https://docs.kubewarden.io/admc/ , file/directory exists, served directly 


Netlify "pretty URL" feature takes care of adding the `.html` when landing on the Antora side.

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
