### PR TITLE
Change branch name from dev antora to live main.

### DIFF
--- a/kw-remote-community-playbook.yml
+++ b/kw-remote-community-playbook.yml
@@ -13,8 +13,7 @@ site:
 content:
   sources:
     - url: https://github.com/kubewarden/docs.git
-      branches: [antora]
-      # branches: [main]
+      branches: [main]
       start_paths: [shared, docs/kw/version-*, docs/admc/version-*, docs/sboms/v*]
 
 ui:


### PR DESCRIPTION
Missed this at go live, adding now.