### PR TITLE
feat: generate static HTML redirect files for old Docusaurus URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,10 @@ community-local: tmpdir environment
 	npx antora --stacktrace --log-format=pretty --log-level=info \
 		kw-local-community-playbook.yml \
 		2>&1 | tee -a tmp/build.log
-	cd build/site && ln -s kubewarden/latest latest
+	cd build/site && ln -sf kubewarden/latest latest
+	./scripts/generate-redirects.sh \
+		build/site \
+		admission-controller/1.35/en
 	@echo ""
 	@echo "If your build was successful, you can preview the site with"
 	@echo "'make preview'."
@@ -28,7 +31,10 @@ community-remote: tmpdir environment
 	npx antora --stacktrace --log-format=pretty --log-level=info \
 		kw-remote-community-playbook.yml \
 		2>&1 | tee -a tmp/build.log
-	cd build/site && ln -s kubewarden/latest latest
+	cd build/site && ln -sf kubewarden/latest latest
+	./scripts/generate-redirects.sh \
+		build/site \
+		admission-controller/1.35/en
 
 .PHONY: community-netlify-preview
 community-netlify-preview: tmpdir environment
@@ -36,7 +42,10 @@ community-netlify-preview: tmpdir environment
 	npx antora --attribute build-environment=netlify --stacktrace --log-format=pretty --log-level=info \
 		kw-local-community-playbook.yml \
 		2>&1 | tee -a tmp/build.log
-	cd build/site && ln -s kubewarden/latest latest
+	cd build/site && ln -sf kubewarden/latest latest
+	./scripts/generate-redirects.sh \
+		build/site \
+		admission-controller/1.35/en
 
 
 .PHONY: clean

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,14 +5,3 @@ command = "make community-netlify-preview"
 
 #[build.environment]
 #  NODE_OPTIONS = "--max_old_space_size=4096"
-
-# Redirect old Docusaurus-style URLs (/<path>) to the new Antora URLs
-# (/admission-controller/1.35/en/<path>).
-# Netlify serves existing files directly, so this only fires for paths that
-# don't have a real file in the build output (the old doc URLs).
-# Netlify pretty URL feature automatically adds the .html on the new Antora
-# URLs.
-[[redirects]]
-from = "/*"
-to = "/admission-controller/1.35/en/:splat"
-status = 301

--- a/scripts/generate-redirects.sh
+++ b/scripts/generate-redirects.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# generate-redirects.sh
+#
+# Generates static HTML meta-refresh redirect files for old flat Docusaurus-
+# style URLs, pointing them at the equivalent pages in the new Antora structure.
+#
+# Instead of reading source .adoc files, this script derives redirect targets
+# from the HTML files that Antora actually produced under ANTORA_PREFIX in the
+# built site. This guarantees the redirect list matches the real build output,
+# regardless of which branch or remote Antora pulled content from.
+#
+# Usage: ./scripts/generate-redirects.sh <site-output-dir> <antora-prefix>
+#   site-output-dir  path to the built site root (e.g. build/site)
+#   antora-prefix    path under site-output-dir where Antora pages live
+#                    (e.g. admc/1.35/en)
+#
+# Example:
+#   ./scripts/generate-redirects.sh \
+#     build/site \
+#     admission-controller/1.35/en
+
+set -euo pipefail
+
+SITE_DIR="${1:?site-output-dir argument required}"
+ANTORA_PREFIX="${2:?antora-prefix argument required}"
+
+if [ ! -d "$SITE_DIR" ]; then
+  echo "ERROR: site output directory not found: $SITE_DIR" >&2
+  exit 1
+fi
+
+ANTORA_DIR="${SITE_DIR}/${ANTORA_PREFIX}"
+
+if [ ! -d "$ANTORA_DIR" ]; then
+  echo "ERROR: antora prefix directory not found: $ANTORA_DIR" >&2
+  exit 1
+fi
+
+count=0
+
+while IFS= read -r -d '' html; do
+  # Derive the page path relative to the antora prefix dir, without .html
+  rel="${html#"$ANTORA_DIR"/}"
+  rel="${rel%.html}"
+
+  # Derive the resulting html page
+  antora_html_file="${SITE_DIR}/${rel}.html"
+  antora_index_file="${SITE_DIR}/${rel}/index.html"
+
+  # The old flat URL path (what users had bookmarked under Docusaurus)
+  flat_dir="${SITE_DIR}/${rel}"
+  out_file="${flat_dir}/index.html"
+  new_url="/${ANTORA_PREFIX}/${rel}.html"
+
+  # Skip only if Antora already produced a real page at this path.
+  # Otherwise, overwrite the redirect deterministically on each run.
+  if [ -e "$antora_html_file" ] || { [ -e "$antora_index_file" ] && [ "$antora_index_file" != "$out_file" ]; }; then
+    continue
+  fi
+
+  # Overwrite unconditionally so version bumps to ANTORA_PREFIX always take effect
+  mkdir -p "$flat_dir"
+  cat >"$out_file" <<HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=${new_url}">
+  <link rel="canonical" href="${new_url}">
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>This page has moved. <a href="${new_url}">Click here if you are not redirected.</a></p>
+</body>
+</html>
+HTML
+
+  count=$((count + 1))
+done < <(find "$ANTORA_DIR" -name "*.html" -not -name "index.html" -print0)
+
+echo "Generated ${count} redirect file(s) under ${SITE_DIR}."


### PR DESCRIPTION
## Description

This PR removes the Netlify redirect configuration and moves to have static files that redirect.
This allows us to keep serving the page with gh-pages.

<!-- Please provide the link to the GitHub issue you are addressing -->

Add scripts/generate-redirects.sh, which creates meta-refresh HTML files at old
flat paths (e.g. /reference/threat-model/index.html) pointing to the new
Antora URL structure (/admc/1.35/en/...).

Wire into both `make community-remote` and `make community-local`
targets so GitHub Pages serves the redirects without needing server-side
configuration.

Remove unneeded Netlify configuration for redirects.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

- `<netlify-preview>/admc/1.35/en/reference/threat-model.html` , file exists, served directly
- `<netlify-preview>/reference/threat-model` , no file, redirected to <netlify-preview>/admc/1.35/en/reference/threat-model` , Netlify then serves `<netlify-preview>/admc/1.35/en/reference/threat-model.html`
- `<netlify-preview>/admc/ `, file/directory exists, served directly 

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

On build, it creates the folder and file structure with html files, so one can hit the redirects:

```
$ ls -la build-local-community/site
total 2228
drwxrwxr-x 18 vic vic    4096 May 19 16:14 ./
drwxrwxr-x  3 vic vic    4096 May 19 16:14 ../
drwxrwxr-x  7 vic vic    4096 May 19 16:14 _/
-rw-rw-r--  1 vic vic    6837 May 19 16:14 404.html
drwxrwxr-x 13 vic vic    4096 May 19 16:14 admc/
drwxrwxr-x  2 vic vic    4096 May 19 16:14 disclosure/
drwxrwxr-x  2 vic vic    4096 May 19 16:14 enterprise/
drwxrwxr-x 10 vic vic    4096 May 19 16:14 explanations/
drwxrwxr-x  2 vic vic    4096 May 19 16:14 glossary/
drwxrwxr-x 30 vic vic    4096 May 19 16:14 howtos/
-rw-rw-r--  1 vic vic     553 May 19 16:14 index.html
-rw-rw-r--  1 vic vic     538 May 19 16:14 index.html.bkp
drwxrwxr-x  2 vic vic    4096 May 19 16:14 introduction/
drwxrwxr-x  4 vic vic    4096 May 19 16:14 kubewarden/
lrwxrwxrwx  1 vic vic      17 May 19 16:14 latest -> kubewarden/latest/
drwxrwxr-x  2 vic vic    4096 May 19 16:14 organization/
drwxrwxr-x  2 vic vic    4096 May 19 16:14 personas/
drwxrwxr-x  2 vic vic    4096 May 19 16:14 quick-start/
drwxrwxr-x 17 vic vic    4096 May 19 16:14 reference/
drwxrwxr-x  4 vic vic    4096 May 19 16:14 sboms/
-rw-rw-r--  1 vic vic 1995489 May 19 16:14 search-index.js
-rw-rw-r--  1 vic vic  180158 May 19 16:14 sitemap-admc.xml
-rw-rw-r--  1 vic vic     241 May 19 16:14 sitemap-kubewarden.xml
-rw-rw-r--  1 vic vic    1494 May 19 16:14 sitemap-sboms.xml
-rw-rw-r--  1 vic vic     357 May 19 16:14 sitemap.xml
drwxrwxr-x  6 vic vic    4096 May 19 16:14 tutorials/
drwxrwxr-x  2 vic vic    4096 May 19 16:14 use-cases/

```

This means that we cannot re-use a path like `build-local-community/site/howtos` or `build-local-community/site/introduction`, but that's always the case with redirects.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
