### PR TITLE
fix(ci): update asciidoc CLI reference documentation

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -19,18 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup Node
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.4.4
-        with:
-          node-version: 20.x
-
-      #  https://github.com/actions/setup-node/issues/490
-      - name: Repair NPM # Update to latest npm and yarn
-        run: "npm install -g npm yarn"
-
-      - name: Install Dependencies
-        run: "yarn install --frozen-lockfile"
-
       - name: Install Updatecli Binary
         uses: updatecli/updatecli-action@cf942226b953240efac9ff60bf42df2b908c2fa0 # v2.83.0
 

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,10 +1,9 @@
 ---
-name: "Updatecli: Dependency Management"
+name: Bump documentation version on new release
 
 on:
   workflow_dispatch:
   schedule:
-    # * is a special character in YAML so you have to quote this string
     - cron: "0 * * * *"
 
 permissions:
@@ -19,11 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install Updatecli Binary
+      - name: Install Updatecli
         uses: updatecli/updatecli-action@cf942226b953240efac9ff60bf42df2b908c2fa0 # v2.83.0
 
-      - name: Run Updatecli in enforce mode
-        run: "updatecli compose apply --experimental --file updatecli/updatecli-compose.yaml"
+      - name: Promote docs version and update CLI reference paths
+        run: "updatecli compose apply --experimental --file updatecli/bump-documentation-version.yaml"
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/updatecli/bump-documentation-version.yaml
+++ b/updatecli/bump-documentation-version.yaml
@@ -1,0 +1,24 @@
+policies:
+  # The following pipelines are designed to work from GitHub action workflows.
+  # This means that before running any Updatecli command, we need the two following environment variables set:
+  #
+  #   GITHUB_TOKEN: Set to a personal access token
+  #   GITHUB_ACTOR: Set to the username associated with the GITHUB_TOKEN
+  #
+  # Instruction to retrieve your PAT is documented on https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+
+  # Promote the dev Antora version directory to stable and create the next dev
+  # version when a new adm-controller release is detected.
+  - name: Promote admission-controller docs on new release
+    config:
+      - updatecli.d/antora.yaml
+    values:
+      - values.d/adm-controller.yaml
+
+  # Update the destination paths in CLI reference docs values files so they
+  # point to the latest dev version directory.
+  - name: Update CLI reference docs target version
+    config:
+      - updatecli.d/update-cli-docs-version.yaml
+    values:
+      - values.d/adm-controller.yaml

--- a/updatecli/updatecli-compose.yaml
+++ b/updatecli/updatecli-compose.yaml
@@ -1,9 +1,0 @@
-policies:
-  # The following policy is designed to work from GitHub action workflows.
-  # This means that before running any Updatecli command, we need the two following environment variables set:
-  # 
-  #   GITHUB_TOKEN: Set to a personal access token
-  #   GITHUB_ACTOR: Set to the username associated with the GITHUB_TOKEN
-  # 
-  # Instruction to retrieve your PAT is documented on https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
-  - policy: ghcr.io/olblak/policies/rancher/docusaurus/kubewarden:0.1.1@sha256:3bf24b340ae1ba8b4ef39295ca7c77882fcff5ef1d448b56c80d7f4df359d7a8

--- a/updatecli/updatecli.d/antora.yaml
+++ b/updatecli/updatecli.d/antora.yaml
@@ -1,0 +1,176 @@
+# {{ $GitHubUser := env ""}}
+# {{ $GitHubRepositoryList := env "GITHUB_REPOSITORY" | split "/"}}
+# {{ $GitHubPAT := env "GITHUB_TOKEN"}}
+# {{ $GitHubUsername := env "GITHUB_ACTOR"}}
+
+name: 'Bump {{ .component }} version in documentation'
+pipelineid: "{{ .pipelineid }}"
+
+scms:
+  default:
+    kind: "github"
+    spec:
+      user: "{{ default $GitHubUser .scm.user}}"
+      email: "{{ .scm.email }}"
+      owner: "{{ default $GitHubRepositoryList._0 .scm.owner }}"
+      repository: "{{ default $GitHubRepositoryList._1 .scm.repository}}"
+      token: "{{ default $GitHubPAT .scm.token }}"
+      username: "{{ default $GitHubUsername .scm.username }}"
+      branch: "{{ .scm.branch }}"
+      commitmessage:
+        hidecredit: true
+        footers: "Signed-off-by: Kubewarden bot <cncf-kubewarden-maintainers@lists.cncf.io>"
+
+sources:
+  releaseVersion:
+    name: "Get latest {{ .component }} release version"
+    kind: githubrelease
+    spec:
+      # {{ $AppGitHubRepositoryList := .sourceRepository | split "/"}}
+      owner: "{{ $AppGitHubRepositoryList._0 }}"
+      repository: "{{ $AppGitHubRepositoryList._1 }}"
+      token: "{{ default .scm.token $GitHubPAT }}"
+      username: "{{ default .scm.username $GitHubUsername }}"
+      versionfilter:
+        kind: "semver"
+        pattern: ">0.1"
+    transformers:
+      - trimprefix: "v"
+      - findsubmatch:
+          pattern: '^(\d*).(\d*)'
+          captureindex: 0
+
+conditions:
+  versionReadyForPromotion:
+    name: "Check if {{ .component }} version needs promotion"
+    kind: "shell"
+    scmid: "default"
+    disablesourceinput: true
+    spec:
+      environments:
+        - name: "PATH"
+      changedif:
+        kind: "exitcode"
+        spec:
+          failure: 1
+          success: 0
+          warning: 1
+      command: |+
+        #!/bin/sh
+        VERSION='{{ source "releaseVersion" }}'
+        COMPONENT_DIR="docs/{{ .component }}"
+        ANTORA_FILE="${COMPONENT_DIR}/version-${VERSION}/antora.yml"
+
+        if [ -f "$ANTORA_FILE" ]; then
+          if ! grep -q "prerelease:" "$ANTORA_FILE"; then
+            echo "Version ${VERSION} is already promoted to stable"
+            exit 1
+          fi
+        fi
+
+        DEV_COUNT=0
+        for dir in ${COMPONENT_DIR}/version-*/; do
+          if [ -f "${dir}antora.yml" ] && grep -q "prerelease:" "${dir}antora.yml"; then
+            DEV_COUNT=$((DEV_COUNT + 1))
+          fi
+        done
+
+        if [ "$DEV_COUNT" -ne 1 ]; then
+          echo "Expected exactly 1 dev version directory, found ${DEV_COUNT}"
+          exit 1
+        fi
+
+        LATEST_COUNT=0
+        for dir in ${COMPONENT_DIR}/version-*/; do
+          if [ -f "${dir}antora.yml" ] && grep -q "display:.*-latest" "${dir}antora.yml"; then
+            LATEST_COUNT=$((LATEST_COUNT + 1))
+          fi
+        done
+
+        if [ "$LATEST_COUNT" -ne 1 ]; then
+          echo "Expected exactly 1 version with -latest display marker, found ${LATEST_COUNT}"
+          exit 1
+        fi
+
+        exit 0
+
+targets:
+  antora:
+    kind: "shell"
+    name: "Promote {{ .component }} version and create next dev"
+    scmid: "default"
+    disablesourceinput: true
+    spec:
+      environments:
+        - name: "PATH"
+      command: |+
+        #!/bin/sh
+        set -e
+
+        VERSION='{{ source "releaseVersion" }}'
+        COMPONENT='{{ .component }}'
+        COMPONENT_DIR="docs/${COMPONENT}"
+        TARGET_DIR="${COMPONENT_DIR}/version-${VERSION}"
+
+        MAJOR=$(echo "$VERSION" | cut -d. -f1)
+        MINOR=$(echo "$VERSION" | cut -d. -f2)
+        NEXT_MINOR=$((MINOR + 1))
+        NEXT_VERSION="${MAJOR}.${NEXT_MINOR}"
+
+        # If the version directory does not exist, find the current dev
+        # version and rename it. The dev version content is preserved
+        # and released under the new version number.
+        if [ ! -d "$TARGET_DIR" ]; then
+          DEV_DIR=""
+          for dir in ${COMPONENT_DIR}/version-*/; do
+            if [ -f "${dir}antora.yml" ] && grep -q "prerelease:" "${dir}antora.yml"; then
+              DEV_DIR="$dir"
+              break
+            fi
+          done
+
+          if [ -z "$DEV_DIR" ]; then
+            echo "No dev version directory found to promote"
+            exit 1
+          fi
+
+          echo "Renaming $(basename "$DEV_DIR") to version-${VERSION}"
+          mv "$DEV_DIR" "$TARGET_DIR"
+          sed -i "s/^version:.*$/version: '${VERSION}'/" "${TARGET_DIR}/antora.yml"
+        fi
+
+        # Find current latest version (the one with display: *-latest)
+        CURRENT_LATEST=""
+        for dir in ${COMPONENT_DIR}/version-*/; do
+          if [ -f "${dir}antora.yml" ] && grep -q "display:.*-latest" "${dir}antora.yml"; then
+            CURRENT_LATEST=$(basename "$dir" | sed 's/^version-//')
+            break
+          fi
+        done
+
+        if [ -z "$CURRENT_LATEST" ]; then
+          echo "No version with -latest display marker found"
+          exit 1
+        fi
+
+        echo "Promoting: current_latest=${CURRENT_LATEST}, release=${VERSION}, next_dev=${NEXT_VERSION}"
+        scripts/make-new-release.sh "${COMPONENT}" "${CURRENT_LATEST}" "${VERSION}" "${NEXT_VERSION}" -n
+
+actions:
+  default:
+    kind: "github/pullrequest"
+    scmid: "default"
+    spec:
+      automerge: false
+# {{ if .pr.title }}
+      title: "{{ .pr.title }}"
+# {{ end }}
+# {{ if .pr.description }}
+      description: "{{ .pr.description }}"
+# {{ end }}
+# {{ if .pr.labels }}
+      labels:
+# {{ range .pr.labels }}
+        - "{{ . }}"
+# {{ end }}
+# {{ end }}

--- a/updatecli/updatecli.d/headers.yaml
+++ b/updatecli/updatecli.d/headers.yaml
@@ -11,12 +11,12 @@ scms:
     kind: "github"
     spec:
       # Priority set to the environment variable
-      user: '{{ default $GitHubUser .scm.user}}'
-      owner: '{{ default $GitHubRepositoryList._0 .scm.owner }}'
-      repository: '{{ default $GitHubRepositoryList._1 .scm.repository}}'
-      token: '{{ default $GitHubPAT .scm.token }}'
-      username: '{{ default $GitHubUsername .scm.username }}'
-      branch: '{{ .scm.branch }}'
+      user: "{{ default $GitHubUser .scm.user}}"
+      owner: "{{ default $GitHubRepositoryList._0 .scm.owner }}"
+      repository: "{{ default $GitHubRepositoryList._1 .scm.repository}}"
+      token: "{{ default $GitHubPAT .scm.token }}"
+      username: "{{ default $GitHubUsername .scm.username }}"
+      branch: "{{ .scm.branch }}"
       commitusingapi: true
       commitmessage:
         hidecredit: true
@@ -28,19 +28,18 @@ sources:
     kind: file
     transformers:
       - addprefix: |
-          ---
-          sidebar_label: {{ $file.sidebar_label }}
-          sidebar_position: {{ $file.sidebar_position }}
-          title: {{ $file.title }}
-          description: {{ $file.description }}
-          keywords: {{ $file.keywords }}
-          doc-persona: {{ $file.doc_persona }}
-          doc-type: {{ $file.doc_type }}
-          doc-topic: {{ $file.doc_topic }}
-          ---
+          include::partial$variables.adoc[]
+          = {{ $file.title }}
+          :page-languages: [en, de, es, fr, ja, pt, zh]
+          :title: {{ $file.title }}
+          :description: {{ $file.description }}
+          :keywords: {{ $file.keywords }}
+          :doc-persona: {{ $file.doc_persona }}
+          :doc-type: {{ $file.doc_type }}
+          :doc-topic: {{ $file.doc_topic }}
       - replacer:
-          from: "↴"
-          to: ""
+          from: "Kubewarden"
+          to: "{admc-short-name}"
     spec:
       file: {{ $file.path }}
 # {{ end }}
@@ -72,7 +71,6 @@ actions:
 # {{ if .pr.labels }}
       labels:
 # {{ range .pr.labels }}
-        - '{{ . }}'
+        - "{{ . }}"
 # {{ end }}
 # {{ end }}
-

--- a/updatecli/updatecli.d/headers.yaml
+++ b/updatecli/updatecli.d/headers.yaml
@@ -37,9 +37,6 @@ sources:
           :doc-persona: {{ $file.doc_persona }}
           :doc-type: {{ $file.doc_type }}
           :doc-topic: {{ $file.doc_topic }}
-      - replacer:
-          from: "Kubewarden"
-          to: "{admc-short-name}"
     spec:
       file: {{ $file.path }}
 # {{ end }}

--- a/updatecli/updatecli.d/update-cli-docs-version.yaml
+++ b/updatecli/updatecli.d/update-cli-docs-version.yaml
@@ -1,0 +1,96 @@
+# {{ $GitHubUser := env ""}}
+# {{ $GitHubRepositoryList := env "GITHUB_REPOSITORY" | split "/"}}
+# {{ $GitHubPAT := env "GITHUB_TOKEN"}}
+# {{ $GitHubUsername := env "GITHUB_ACTOR"}}
+
+name: Update Kubewarden admission controller CLI documentation target version
+pipelineid: "{{ .pipelineid }}"
+
+scms:
+  default:
+    kind: "github"
+    spec:
+      user: "{{ default $GitHubUser .scm.user}}"
+      email: "{{ .scm.email }}"
+      owner: "{{ default $GitHubRepositoryList._0 .scm.owner }}"
+      repository: "{{ default $GitHubRepositoryList._1 .scm.repository}}"
+      token: "{{ default $GitHubPAT .scm.token }}"
+      username: "{{ default $GitHubUsername .scm.username }}"
+      branch: "{{ .scm.branch }}"
+      commitusingapi: true
+      commitmessage:
+        hidecredit: true
+        footers: "Signed-off-by: Kubewarden bot <cncf-kubewarden-maintainers@lists.cncf.io>"
+
+sources:
+  releaseVersion:
+    name: "Get latest release version"
+    kind: githubrelease
+    spec:
+      # {{ $AppGitHubRepositoryList := .sourceRepository | split "/"}}
+      owner: "{{ $AppGitHubRepositoryList._0 }}"
+      repository: "{{ $AppGitHubRepositoryList._1 }}"
+      token: "{{ default .scm.token $GitHubPAT }}"
+      username: "{{ default .scm.username $GitHubUsername }}"
+      versionfilter:
+        kind: "semver"
+        pattern: ">0.1"
+    transformers:
+      - trimprefix: "v"
+      - findsubmatch:
+          pattern: '^(\d*).(\d*)'
+          captureindex: 0
+
+  devVersion:
+    name: "Compute next dev version (release + 1)"
+    kind: shell
+    dependson:
+      - "source#releaseVersion"
+    spec:
+      command: |
+        #!/bin/sh
+        VERSION='{{ source "releaseVersion" }}'
+        MAJOR=$(echo "$VERSION" | cut -d. -f1)
+        MINOR=$(echo "$VERSION" | cut -d. -f2)
+        NEXT_MINOR=$((MINOR + 1))
+        echo "${MAJOR}.${NEXT_MINOR}"
+
+targets:
+  updateKwctlValuesFile:
+    name: "Update kwctl CLI docs target version"
+    kind: yaml
+    sourceid: devVersion
+    scmid: default
+    spec:
+      file: "updatecli/values.d/update-kwctl-cli-ref-docs.yaml"
+      key: "$.files[0].dst"
+      value: 'docs/admission-controller/version-{{ source "devVersion" }}/modules/en/pages/reference/kwctl-cli.adoc'
+
+  updatePolicyServerValuesFile:
+    name: "Update policy-server CLI docs target version"
+    kind: yaml
+    sourceid: devVersion
+    scmid: default
+    spec:
+      file: "updatecli/values.d/update-policy-server-cli-ref-docs.yaml"
+      key: "$.files[0].dst"
+      value: 'docs/admission-controller/version-{{ source "devVersion" }}/modules/en/pages/reference/policy-server-cli.adoc'
+
+actions:
+  default:
+    kind: "github/pullrequest"
+    scmid: "default"
+    spec:
+      automerge: false
+# {{ if .pr.title }}
+      title: "{{ .pr.title }}"
+# {{ end }}
+# {{ if .pr.description }}
+      description: "{{ .pr.description }}"
+# {{ end }}
+# {{ if .pr.labels }}
+      labels:
+# {{ range .pr.labels }}
+        - "{{ . }}"
+# {{ end }}
+# {{ end }}

--- a/updatecli/values.d/adm-controller.yaml
+++ b/updatecli/values.d/adm-controller.yaml
@@ -1,0 +1,32 @@
+---
+pipelineid: "docs-update"
+# Source repository to watch for new releases (format: owner/repo)
+sourceRepository: "kubewarden/adm-controller"
+component: "admission-controller"
+scm:
+  # GitHub user associated to the commit message
+  user: "updatecli-bot"
+  # GitHub email associated to the commit message
+  email: ""
+  # GitHub repository owner where the pull request will be created
+  # If a variable "GITHUB_REPOSITORY" is set, it will be used instead
+  owner: "kubewarden"
+  # GitHub repository where the pull request will be created
+  # If a variable "GITHUB_REPOSITORY" is set, it will be used instead
+  repository: "docs"
+  # GitHub token used to create the pull request
+  # If a variable "GITHUB_TOKEN" is set, it will be used instead
+  token: ""
+  # GitHub username used to create the pull request
+  # If a variable "GITHUB_ACTOR" is set, it will be used instead
+  username: ""
+  # GitHub branch where the pull request will be created
+  # If a variable "GITHUB_REF_NAME" is set, it will be used instead
+  branch: "main"
+
+pr:
+  title: "Update Kubewarden admission controller documentation version"
+  description: "Automatically update Kubewarden admission controller version and the values files to proper update CLI reference documentation in future updates"
+  labels:
+    - "kind/chore"
+    - "area/documentation"

--- a/updatecli/values.d/headers.yaml
+++ b/updatecli/values.d/headers.yaml
@@ -1,23 +1,23 @@
 ---
 files:
-  - path: "docs/reference/kwctl-cli.md"
+  - path: "docs/admission-controller/version-1.36/modules/en/pages/reference/kwctl-cli.adoc"
     sidebar_label: kwctl CLI Reference
     sidebar_position: 120
     title: kwctl CLI
-    description: kwctl CLI reference documentation
-    keywords: "[cli, reference, kwctl]"
-    doc_persona: "[kubewarden-operator]"
-    doc_type: "[reference]"
-    doc_topic: "[operator-manual]"
-  - path: "docs/reference/policy-server-cli.md"
+    description: "Explore the `kwctl` command-line tool to manage {admc-name} policies and perform tasks like loading policies"
+    keywords: "cli, reference, kwctl"
+    doc_persona: "kubewarden-operator"
+    doc_type: "reference"
+    doc_topic: "operator-manual"
+  - path: "docs/admission-controller/version-1.36/modules/en/pages/reference/policy-server-cli.adoc"
     sidebar_label: Policy Server CLI Reference
     sidebar_position: 121
     title: Policy Server CLI
-    description: Policy Server CLI reference documentation
-    keywords: "[cli, reference, policy-server]"
-    doc_persona: "[kubewarden-operator]"
-    doc_type: "[reference]"
-    doc_topic: "[operator-manual]"
+    description: "Explore the policy-server command-line help and options to customize and run the `policy-server` program."
+    keywords: "cli, reference, policy-server"
+    doc_persona: "kubewarden-operator"
+    doc_type: "reference"
+    doc_topic: "operator-manual"
 scm:
   branch: "main"
 pr:

--- a/updatecli/values.d/update-kwctl-cli-ref-docs.yaml
+++ b/updatecli/values.d/update-kwctl-cli-ref-docs.yaml
@@ -4,8 +4,8 @@ scm:
   enabled: false
 
 files:
-  - src: "cli-docs.md"
-    dst: "docs/reference/kwctl-cli.md"
+  - src: "crates/kwctl/cli-docs.adoc"
+    dst: "docs/admission-controller/version-1.36/modules/en/pages/reference/kwctl-cli.adoc"
 src:
   branch: "main"
-  url: "https://github.com/kubewarden/kwctl.git"
+  url: "https://github.com/kubewarden/adm-controller.git"

--- a/updatecli/values.d/update-policy-server-cli-ref-docs.yaml
+++ b/updatecli/values.d/update-policy-server-cli-ref-docs.yaml
@@ -4,8 +4,8 @@ scm:
   enabled: false
 
 files:
-  - src: "cli-docs.md"
-    dst: "docs/reference/policy-server-cli.md"
+  - src: "crates/policy-server/cli-docs.adoc"
+    dst: "docs/admission-controller/version-1.36/modules/en/pages/reference/policy-server-cli.adoc"
 src:
   branch: "main"
-  url: "https://github.com/kubewarden/policy-server.git"
+  url: "https://github.com/kubewarden/adm-controller.git"


### PR DESCRIPTION

## Description

Updates the updatecli script to copy the kwctl and policy-server CLI reference documentation generate now in asciidoc.

This PR requires the adm-controller change to be merged https://github.com/kubewarden/adm-controller/pull/1778

Fix https://github.com/kubewarden/adm-controller/issues/1751

# Test

https://github.com/jvanz/docs/pull/64/changes