### PR TITLE
fix(updatecli): missing version bump in headers pipeline.

### DIFF
--- a/updatecli/updatecli.d/update-cli-docs-version.yaml
+++ b/updatecli/updatecli.d/update-cli-docs-version.yaml
@@ -76,6 +76,26 @@ targets:
       key: "$.files[0].dst"
       value: 'docs/admission-controller/version-{{ source "devVersion" }}/modules/en/pages/reference/policy-server-cli.adoc'
 
+  updateHeadersKwctlPath:
+    name: "Update kwctl CLI docs header target version"
+    kind: yaml
+    sourceid: devVersion
+    scmid: default
+    spec:
+      file: "updatecli/values.d/headers.yaml"
+      key: "$.files[0].path"
+      value: 'docs/admission-controller/version-{{ source "devVersion" }}/modules/en/pages/reference/kwctl-cli.adoc'
+
+  updateHeadersPolicyServerPath:
+    name: "Update policy-server CLI docs header target version"
+    kind: yaml
+    sourceid: devVersion
+    scmid: default
+    spec:
+      file: "updatecli/values.d/headers.yaml"
+      key: "$.files[1].path"
+      value: 'docs/admission-controller/version-{{ source "devVersion" }}/modules/en/pages/reference/policy-server-cli.adoc'
+
 actions:
   default:
     kind: "github/pullrequest"

--- a/updatecli/values.d/headers.yaml
+++ b/updatecli/values.d/headers.yaml
@@ -1,6 +1,6 @@
 ---
 files:
-  - path: "docs/admission-controller/version-1.36/modules/en/pages/reference/kwctl-cli.adoc"
+  - path: "docs/admission-controller/version-1.37/modules/en/pages/reference/kwctl-cli.adoc"
     sidebar_label: kwctl CLI Reference
     sidebar_position: 120
     title: kwctl CLI
@@ -9,7 +9,7 @@ files:
     doc_persona: "kubewarden-operator"
     doc_type: "reference"
     doc_topic: "operator-manual"
-  - path: "docs/admission-controller/version-1.36/modules/en/pages/reference/policy-server-cli.adoc"
+  - path: "docs/admission-controller/version-1.37/modules/en/pages/reference/policy-server-cli.adoc"
     sidebar_label: Policy Server CLI Reference
     sidebar_position: 121
     title: Policy Server CLI


### PR DESCRIPTION
## Description

The updatecli pipeline used to bump the documentation version is missing an update in the headers.yaml values file to ensure that the pipeline used to add the headers update the correct file.
