### PR TITLE
fix(updatecli): missing revdate and page-revdate fields

### DIFF
--- a/updatecli/updatecli.d/headers.yaml
+++ b/updatecli/updatecli.d/headers.yaml
@@ -31,6 +31,8 @@ sources:
           include::partial$variables.adoc[]
           = {{ $file.title }}
           :page-languages: [en, de, es, fr, ja, pt, zh]
+          :revdate: {{ now | date "2006-01-02" }}
+          :page-revdate: {revdate}
           :title: {{ $file.title }}
           :description: {{ $file.description }}
           :keywords: {{ $file.keywords }}


### PR DESCRIPTION
## Description

Updates the headers.yaml pipeline to add the missing revdate and page-revdate fields in the headers added to the CLI reference documentation.
