### PR TITLE
refactor(quickstart): extract quickstart text to partials

### DIFF
--- a/docs/admission-controller/version-1.37/modules/en/pages/quick-start.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/quick-start.adoc
@@ -28,7 +28,7 @@ The {admc-name} stack comprises:
   `PolicyServer`. The {admc-short-name} `PolicyServer` loads and evaluates your
   administrator's policies.
 * One or more {admission-policy} resources: policies for a defined namespace.
-* A deployment of a `{admcontroller-name}`: this controller monitors the
+* A deployment of a `{admc-release}`: this controller monitors the
   {cluster-admission-policy} resources and interacts with the {admc-short-name}
   {policy-server} components.
 
@@ -81,7 +81,7 @@ The {admc-short-name} has three main components which you interact with:
 
 === `PolicyServer`
 
-The `{admcontroller-name}` manages a {admc-short-name} `PolicyServer`. You can
+The `{admc-release}` manages a {admc-short-name} `PolicyServer`. You can
 deploy multiple {policy-server}s in the same Kubernetes cluster.
 
 A `PolicyServer` validates incoming requests by executing {admc-short-name}
@@ -123,7 +123,7 @@ Overview of the attributes of the `PolicyServer` resource:
 | N
 | `serviceAccountName`
 | The name of the `ServiceAccount` to use for the `PolicyServer` deployment. If
-  there is no provided value, the default `ServiceAccount` from the installation namespace, of `{admcontroller-name}`, gets used.
+  there is no provided value, the default `ServiceAccount` from the installation namespace, of `{admc-release}`, gets used.
 
 | N
 | `env`
@@ -446,7 +446,7 @@ kubectl delete crd admissionpolicygroups.policies.kubewarden.io
 == Wrapping up
 
 {cluster-admission-policy} is the core resource that a cluster operator has to
-manage. The `{admcontroller-name}` module automatically takes care of the
+manage. The `{admc-release}` module automatically takes care of the
 configuration for the rest of the resources needed to run the policies.
 
 == What's next?

--- a/docs/admission-controller/version-1.37/modules/en/pages/quick-start.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/quick-start.adoc
@@ -28,7 +28,7 @@ The {admc-name} stack comprises:
   `PolicyServer`. The {admc-short-name} `PolicyServer` loads and evaluates your
   administrator's policies.
 * One or more {admission-policy} resources: policies for a defined namespace.
-* A deployment of a `kubewarden-controller`: this controller monitors the
+* A deployment of a `{admcontroller-name}`: this controller monitors the
   {cluster-admission-policy} resources and interacts with the {admc-short-name}
   {policy-server} components.
 
@@ -69,66 +69,7 @@ names for the CRDs:
 [#_installation]
 == Installation
 
-[IMPORTANT]
-.Authentication
-====
-
-:gh-pat-url: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
-
-You can retrieve {admc-short-name} policies from the GitHub container registry at
-https://ghcr.io. You need authentication to use the repository with the
-{admc-short-name} CLI, a {gh-pat-url}[GitHub personal access token] (PAT). Their
-documentation guides you through creating one if you haven't already done so.
-Then you authenticate with a command like:
-
-[subs="+attributes",console]
-----
-echo $PAT | docker login ghcr.io --username <my-gh-username> --password-stdin
-----
-
-====
-
-
-Deploy the {admc-short-name} stack using `helm` charts as follows:
-
-[subs="+attributes",console]
-----
-helm repo add kubewarden https://charts.kubewarden.io
-----
-
-[subs="+attributes",console]
-----
-helm repo update kubewarden
-----
-
-Install the `admission-controller` Helm chart in the `kubewarden` namespace in your
-Kubernetes cluster. This will:
-
-* Register the {cluster-admission-policy},
-  {admission-policy} and {policy-server} Custom Resource Definitions. Also, the
-  {policy-report} Custom Resource Definitions used by the audit scanner.
-* Deploy the {admc-short-name} and the audit scanner
-+
-[NOTE]
-====
-
-If you need to disable the audit scanner component check the audit scanner
-installation xref:howtos/audit-scanner.adoc[documentation page].
-
-====
-+
-* Create a `PolicyServer` resource named
-  `default`. You can also install a set of recommended policies to secure your
-  cluster by enforcing well known best practices.
-
-[subs="+attributes",console]
-----
-helm install --wait -n kubewarden --create-namespace admission-controller kubewarden/admission-controller
-----
-
-The default configuration values are sufficient for most deployments. The
-https://charts.kubewarden.io/#configuration[documentation] describes all the
-options.
+include::partial${build-type}-specific/quick-start-installation.adoc[]
 
 == Main components
 
@@ -140,7 +81,7 @@ The {admc-short-name} has three main components which you interact with:
 
 === `PolicyServer`
 
-The `kubewarden-controller` manages a {admc-short-name} `PolicyServer`. You can
+The `{admcontroller-name}` manages a {admc-short-name} `PolicyServer`. You can
 deploy multiple {policy-server}s in the same Kubernetes cluster.
 
 A `PolicyServer` validates incoming requests by executing {admc-short-name}
@@ -155,7 +96,7 @@ kind: PolicyServer
 metadata:
   name: reserved-instance-for-tenant-a
 spec:
-  image: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
+  image: {default-policy-server-image-tag}
   replicas: 2
   serviceAccountName: ~
   env:
@@ -163,14 +104,7 @@ spec:
       value: debug
 ----
 
-[NOTE]
-====
-
-Check the
-https://github.com/kubewarden/adm-controller/policy-server/pkgs/container/adm-controller%2Fpolicy-server[latest
-released `PolicyServer` version] and change the tag to match.
-
-====
+include::partial${build-type}-specific/quick-start-policyserver-note.adoc[]
 
 Overview of the attributes of the `PolicyServer` resource:
 
@@ -189,7 +123,7 @@ Overview of the attributes of the `PolicyServer` resource:
 | N
 | `serviceAccountName`
 | The name of the `ServiceAccount` to use for the `PolicyServer` deployment. If
-  there is no provided value, the default `ServiceAccount` from the installation namespace, of `kubewarden-controller`, gets used.
+  there is no provided value, the default `ServiceAccount` from the installation namespace, of `{admcontroller-name}`, gets used.
 
 | N
 | `env`
@@ -481,7 +415,7 @@ Uninstall the Helm chart as follows:
 
 [subs="+attributes",console]
 ----
-helm uninstall --namespace kubewarden admission-controller
+helm uninstall --namespace {admc-namespace} {admc-release}
 ----
 
 Uninstalling the Helm chart removes:
@@ -512,7 +446,7 @@ kubectl delete crd admissionpolicygroups.policies.kubewarden.io
 == Wrapping up
 
 {cluster-admission-policy} is the core resource that a cluster operator has to
-manage. The `kubewarden-controller` module automatically takes care of the
+manage. The `{admcontroller-name}` module automatically takes care of the
 configuration for the rest of the resources needed to run the policies.
 
 == What's next?

--- a/docs/admission-controller/version-1.37/modules/en/partials/community-specific/quick-start-installation.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/partials/community-specific/quick-start-installation.adoc
@@ -1,0 +1,60 @@
+[IMPORTANT]
+.Authentication
+====
+
+:gh-pat-url: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+
+You can retrieve {admc-short-name} policies from the GitHub container registry at
+https://ghcr.io. You need authentication to use the repository with the
+{admc-short-name} CLI, a {gh-pat-url}[GitHub personal access token] (PAT). Their
+documentation guides you through creating one if you haven't already done so.
+Then you authenticate with a command like:
+
+[subs="+attributes",console]
+----
+echo $PAT | docker login ghcr.io --username <my-gh-username> --password-stdin
+----
+
+====
+
+
+Deploy the {admc-short-name} stack using `helm` charts as follows:
+
+[subs="+attributes",console]
+----
+helm repo add kubewarden https://charts.kubewarden.io
+----
+
+[subs="+attributes",console]
+----
+helm repo update kubewarden
+----
+
+Install the `admission-controller` Helm chart in the `{admc-namespace}` namespace in your
+Kubernetes cluster. This will:
+
+* Register the {cluster-admission-policy},
+  {admission-policy} and {policy-server} Custom Resource Definitions. Also, the
+  {policy-report} Custom Resource Definitions used by the audit scanner.
+* Deploy the {admc-short-name} and the audit scanner
++
+[NOTE]
+====
+
+If you need to disable the audit scanner component check the audit scanner
+installation xref:howtos/audit-scanner.adoc[documentation page].
+
+====
++
+* Create a `PolicyServer` resource named
+  `default`. You can also install a set of recommended policies to secure your
+  cluster by enforcing well known best practices.
+
+[subs="+attributes",console]
+----
+helm install --wait -n {admc-namespace} --create-namespace {admc-release} {admc-chart-location}
+----
+
+The default configuration values are sufficient for most deployments. The
+https://charts.kubewarden.io/#configuration[documentation] describes all the
+options.

--- a/docs/admission-controller/version-1.37/modules/en/partials/community-specific/quick-start-policyserver-note.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/partials/community-specific/quick-start-policyserver-note.adoc
@@ -1,0 +1,8 @@
+[NOTE]
+====
+
+Check the
+https://github.com/kubewarden/adm-controller/policy-server/pkgs/container/adm-controller%2Fpolicy-server[latest
+released `PolicyServer` version] and change the tag to match.
+
+====

--- a/docs/admission-controller/version-1.37/modules/en/partials/variables.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/partials/variables.adoc
@@ -1,4 +1,7 @@
 // Include shared project global variables
 include::latest@shared:en:partial$kubewarden-variables-1.36-forward.adoc[]
 
-// global variables for this version below:
+:default-container-image-tag: v1.37.0
+// Fully-qualified policy server image reference. {default-policy-server-image}
+// comes from the shared file; {default-container-image-tag} is set above.
+:default-policy-server-image-tag: {default-policy-server-image}:{default-container-image-tag}

--- a/shared/modules/en/partials/kubewarden-variables-1.36-forward.adoc
+++ b/shared/modules/en/partials/kubewarden-variables-1.36-forward.adoc
@@ -42,6 +42,11 @@ ifeval::["{build-type}" == "community"]
 :admc-abbrev: {admc-community-abbrev}
 :intro-paragraph: {admc-name} is a xref:#_vendor_neutrality[vendor neutral], https://cncf.io[CNCF] Sandbox project, originally created by https://www.rancher.com/[SUSE Rancher].
 :project-security-team: {kw-community-project-name} team
+:admcontroller-name: admission-controller
+:default-policy-server-image: ghcr.io/kubewarden/adm-controller/policy-server
+:admc-chart-location: kubewarden/admission-controller
+:admc-namespace: kubewarden
+:admc-release: admission-controller
 endif::[]
 
 ifeval::["{build-type}" == "product"]
@@ -53,6 +58,11 @@ ifeval::["{build-type}" == "product"]
 :community-project-name: {kw-community-project-name}
 :intro-paragraph: {admc-name} is derived from a vendor neutral, https://cncf.io[CNCF] Sandbox project, called link:https://kubewarden.io[{community-project-name}], originally created by https://www.rancher.com/[SUSE Rancher]. The name {admc-name} may be shortened to {admc-short-name} or abbreviated as {admc-abbrev}. The name {community-project-name} refers to the open-source community project. The name {community-project-name} may also be used throughout this documentation in place of {admc-name}, {admc-short-name}, or {admc-abbrev}. This will be in references in source code or configuration examples.
 :project-security-team: {product-project-name} Team
+:admcontroller-name: suse-sec-adm-controller
+:default-policy-server-image: dp.apps.rancher.io/containers/kubewarden-policy-server
+:admc-chart-location: oci://dp.apps.rancher.io/charts/suse-security-admission-controller
+:admc-namespace: suse-sec-adm-controller
+:admc-release: suse-sec-adm-controller
 endif::[]
 
 // Glossary terms start
@@ -82,3 +92,5 @@ endif::[]
 :Wasmtime: xref:glossary.adoc#_wasmtime[Wasmtime]
 
 // Glossary terms end
+
+

--- a/shared/modules/en/partials/kubewarden-variables-1.36-forward.adoc
+++ b/shared/modules/en/partials/kubewarden-variables-1.36-forward.adoc
@@ -33,6 +33,8 @@ ifndef::admc-product-abbrev[]
 :admc-product-abbrev: SSAC
 endif::[]
 
+
+
 ifeval::["{build-type}" == "community"]
 :project-name: {kw-community-project-name}
 :product-project-name: SUSE Security
@@ -42,10 +44,12 @@ ifeval::["{build-type}" == "community"]
 :admc-abbrev: {admc-community-abbrev}
 :intro-paragraph: {admc-name} is a xref:#_vendor_neutrality[vendor neutral], https://cncf.io[CNCF] Sandbox project, originally created by https://www.rancher.com/[SUSE Rancher].
 :project-security-team: {kw-community-project-name} team
-:admcontroller-name: admission-controller
-:default-policy-server-image: ghcr.io/kubewarden/adm-controller/policy-server
+:default-oci-registry: ghcr.io
+:default-oci-admcontroller-container-namespace: kubewarden/adm-controller
+:default-policy-server-image: {default-oci-registry}/{default-oci-admcontroller-container-namespace}/policy-server
 :admc-chart-location: kubewarden/admission-controller
 :admc-namespace: kubewarden
+// Default name used when installing the admission-controller component. (e.g. helm install)
 :admc-release: admission-controller
 endif::[]
 
@@ -59,7 +63,9 @@ ifeval::["{build-type}" == "product"]
 :intro-paragraph: {admc-name} is derived from a vendor neutral, https://cncf.io[CNCF] Sandbox project, called link:https://kubewarden.io[{community-project-name}], originally created by https://www.rancher.com/[SUSE Rancher]. The name {admc-name} may be shortened to {admc-short-name} or abbreviated as {admc-abbrev}. The name {community-project-name} refers to the open-source community project. The name {community-project-name} may also be used throughout this documentation in place of {admc-name}, {admc-short-name}, or {admc-abbrev}. This will be in references in source code or configuration examples.
 :project-security-team: {product-project-name} Team
 :admcontroller-name: suse-sec-adm-controller
-:default-policy-server-image: dp.apps.rancher.io/containers/kubewarden-policy-server
+:default-oci-registry: dp.apps.rancher.io
+:default-oci-admcontroller-container-namespace: containers/
+:default-policy-server-image: {default-oci-registry}/{default-oci-admcontroller-container-namespace}/kubewarden-policy-server
 :admc-chart-location: oci://dp.apps.rancher.io/charts/suse-security-admission-controller
 :admc-namespace: suse-sec-adm-controller
 :admc-release: suse-sec-adm-controller


### PR DESCRIPTION
## Description

Updates the quick-start documentation extracting some text to partials. This allows the product documentation to override the sections that do not match community docs. Furthermore, add some variable that customize the fields that change if it's community or product version.