### PR TITLE
fix(migrations): rename migration documentation

### DIFF
--- a/docs/admission-controller/version-1.37/modules/en/nav.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/nav.adoc
@@ -79,7 +79,7 @@ include::partial$variables.adoc[]
 *** xref:howtos/Rancher-Fleet.adoc[Rancher Fleet]
 *** xref:howtos/kubestellar-console.adoc[KubeStellar Console guided installation]
 ** Migrations
-*** xref:{build-type}-specific/howtos/chart-migration.adoc[]
+*** xref:{build-type}-specific/howtos/app136-to-app137-migration.adoc[]
 ifeval::["{build-type}" == "product"]
 *** xref:{build-type}-specific/howtos/appco-chart-migration.adoc[]
 *** xref:{build-type}-specific/howtos/community-chart-migration.adoc[]

--- a/docs/admission-controller/version-1.37/modules/en/pages/community-specific/howtos/app136-to-app137-migration.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/community-specific/howtos/app136-to-app137-migration.adoc
@@ -1,6 +1,5 @@
 include::partial$variables.adoc[]
 
-= Migration from three-chart setup
 :page-languages: [en, de, es, fr, ja, pt, zh]
 :revdate: 2026-06-26
 :page-revdate: {revdate}
@@ -12,6 +11,8 @@ include::partial$variables.adoc[]
 :sidebar_label: Migration from three-chart setup
 :sidebar_position: 10
 :current-version: {page-origin-branch}
+
+= {admc-community-name} 1.36 to 1.37
 
 Starting from Kubewarden 1.37, a single helm chart is used to manage
 the stack.


### PR DESCRIPTION
## Description

Renames the 1.36 to 1.37 migration documentation to have a better title in the sidebar.