### PR TITLE
feat(variables): variables for specific docs type

### DIFF
--- a/docs/admission-controller/version-1.37/modules/en/partials/community-specific/variables.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/partials/community-specific/variables.adoc
@@ -1,0 +1,6 @@
+// This partial file contains variables that are relevant only for community 
+// version only
+
+// Default container image tag used in the documentation version. All the admission
+// controller container image has synced container tag
+:default-container-image-tag: v1.37.0

--- a/docs/admission-controller/version-1.37/modules/en/partials/variables.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/partials/variables.adoc
@@ -1,7 +1,7 @@
 // Include shared project global variables
 include::latest@shared:en:partial$kubewarden-variables-1.36-forward.adoc[]
-
-:default-container-image-tag: v1.37.0
+// Include variables that have values that change under specific docs types
+include::partial${build-type}-specific/variables.adoc[]
 // Fully-qualified policy server image reference. {default-policy-server-image}
 // comes from the shared file; {default-container-image-tag} is set above.
 :default-policy-server-image-tag: {default-policy-server-image}:{default-container-image-tag}


### PR DESCRIPTION
## Description

Adds a partials file with variables that have values that are attached to the doc type and version. For now, the variable used is the container image tag that can change from community and product documentation.