### PR TITLE
chore(docs): Reword how to report vulnv

### DIFF
--- a/docs/admission-controller/version-1.38/modules/en/pages/disclosure.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/disclosure.adoc
@@ -25,10 +25,9 @@ On {admc-short-name}'s side, this means:
 * {admc-short-name} always transparently lets the community know about any incident that
   affects them.
 
-If you have found a security vulnerability in {admc-short-name}, the easiest way to
-report a vulnerability is through the
-https://github.com/kubewarden/community/security/advisories[Security tab on
-GitHub]. This mechanism allows maintainers to communicate privately with you,
+If you have found a security vulnerability in Kubewarden, the easiest way to
+report a vulnerability is through the Security tab on GitHub for the specific
+repo. This mechanism allows maintainers to communicate privately with you,
 and you don't need to encrypt your messages.
 
 Alternatively, you can disclose it responsibly by emailing


### PR DESCRIPTION


## Description

The link for "Security Tab" points to the kubewarden/community repo, which shouldn't get the advisory. For tooling automation, it is better to direct reporters to specific repos.
<!-- Please provide the link to the GitHub issue you are addressing -->

Port of https://github.com/kubewarden/community/pull/93

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
