### PR TITLE
techdebt: fix silently-broken links, anchors and dates

### DIFF
--- a/docs/admission-controller/version-1.28/modules/en/pages/disclosure.adoc
+++ b/docs/admission-controller/version-1.28/modules/en/pages/disclosure.adoc
@@ -13,8 +13,7 @@ include::partial$variables.adoc[]
 
 The {project-name} team appreciates investigative work on security vulnerabilities
 carried out by well-intentioned, ethical security researchers. {short-project-name}
-follows the practice of [responsible
-disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) to best
+follows the practice of https://en.wikipedia.org/wiki/Responsible_disclosure[responsible disclosure] to best
 protect {short-project-name}'s user base from the impact of security issues. On
 {short-project-name}'s side, this means:
 
@@ -30,7 +29,7 @@ GitHub]. This mechanism allows maintainers to communicate privately with you,
 and you don't need to encrypt your messages.
 
 Alternatively, you can disclose it responsibly by emailing
-xref:mailto:cncf-kubewarden-maintainers@lists.cncf.io.adoc[cncf-kubewarden-maintainers@lists.cncf.io]
+mailto:cncf-kubewarden-maintainers@lists.cncf.io[cncf-kubewarden-maintainers@lists.cncf.io]
 in an *unencrypted* message. Please don't discuss potential vulnerabilities in
 public without validating with us first.
 

--- a/docs/admission-controller/version-1.28/modules/en/pages/explanations/comparisons/opa-comparison.adoc
+++ b/docs/admission-controller/version-1.28/modules/en/pages/explanations/comparisons/opa-comparison.adoc
@@ -78,6 +78,7 @@ Both OPA Gatekeeper and Kubernetes can write validation and mutation policies.
 These policies can target any kind of Kubernetes resource, including Custom
 Resources.
 
+[#_writing_policies]
 == Writing policies
 
 You write OPA Gatekeeper policies using
@@ -116,6 +117,7 @@ xref:/tutorials/writing-policies/rego/01-intro-rego.adoc[here].
 ====
 
 
+[#_context_aware]
 == Context aware
 
 Sometimes a policy needs data about the current state of the cluster to make a
@@ -140,6 +142,7 @@ Each policy has access only to the resources that the Kubernetes administrator
 specifies. Attempting to read unauthorized data is immediately blocked and
 reported to the cluster administrators.
 
+[#_kubernetes_integration]
 == Kubernetes integration
 
 OPA Gatekeeper has a cluster wide Custom Resource, permitting policy
@@ -156,6 +159,7 @@ manage `AdmissionPolicy` resources, in the namespaces they can access.
 
 This allows Kubernetes administrators to delegate policy-related work.
 
+[#_policy_distribution]
 == Policy distribution
 
 OPA Gatekeeper and Kubewarden policies have policy source code (Rego for OPA
@@ -173,6 +177,7 @@ You can distribute Kubewarden policies among geographically distributed
 container registries using the traditional tools and processes adopted for
 container images.
 
+[#_cicd_integration]
 == CI/CD integration
 
 Both OPA Gatekeeper and Kubewarden are managed using GitOps methodologies.
@@ -219,6 +224,7 @@ operation modes:
 * `deny`: violation of a policy rejects the request
 * `warn`: violation of a policy doesn't cause rejection and is logged
 
+[#_deployment_mode]
 == Deployment mode
 
 The same server evaluates all the OPA Gatekeeper policies. Conversely,
@@ -243,6 +249,7 @@ This allows interesting scenarios like the following ones:
 * Deploy critical policies to a dedicated Policy Server pool.
 * Deploy the policies of a noisy tenant to a dedicated Policy Server pool.
 
+[#_background_checks]
 == Background checks
 
 As policies are added, removed, and reconfigured the resources already in the

--- a/docs/admission-controller/version-1.28/modules/en/pages/glossary.adoc
+++ b/docs/admission-controller/version-1.28/modules/en/pages/glossary.adoc
@@ -13,6 +13,7 @@ include::partial$variables.adoc[]
 
 == A
 
+[#_admissionpolicy]
 === AdmissionPolicy
 
 A namespace-wide resource. The policy processes only those requests targeting
@@ -20,23 +21,27 @@ the namespace in which the AdmissionPolicy is defined.
 
 == C
 
+[#_clusteradmissionpolicy]
 === ClusterAdmissionPolicy
 
 An <<_admissionpolicy,AdmissionPolicy>> which targets cluster-wide resources.
 
+[#_clusterreport]
 === ClusterPolicyReport
 
-A <<_policyreport,PolicyReport>> and a ClusterPolicyReport store results of
+A <<_report,PolicyReport>> and a ClusterPolicyReport store results of
 policy scans. Which one is used, depends on the scope of the resource.
 
 == K
 
+[#_kwctl]
 === kwctl
 
 A CLI tool to generate and test Kubernetes YAML files for policy deployment.
 
 == M
 
+[#_mutatingwebhookconfiguration]
 === MutatingWebhookConfiguration
 
 A
@@ -47,18 +52,20 @@ this is how a {short-project-name} controller informs Kubernetes where to find a
 
 == P
 
+[#_report]
 === PolicyReport
 
-A PolicyReport and a <<_clusterpolicyreport,ClusterPolicyReport>> store results of
+A PolicyReport and a <<_clusterreport,ClusterPolicyReport>> store results of
 policy scans. Which one is used depends on the scope of the resource.
 
-[#_policy_server]
+[#_policyserver]
 === PolicyServer
 
 A PolicyServer validates incoming requests by executing {short-project-name} policies against requests.
 
 == V
 
+[#_validatingwebhookconfiguration]
 === ValidatingWebhookConfiguration
 
 A
@@ -68,19 +75,23 @@ In other words, this is how {short-project-name} informs Kubernetes where to fin
 
 == W
 
+[#_wapc]
 === waPC
 
 WebAssembly Procedure Calls. https://wapc.io.
 
+[#_wasi]
 === WASI
 
 WebAssembly System Interface. https://wasi.dev.
 
+[#_wasm]
 === Wasm
 
 A binary instruction format for a stack-based virtual machine. Designed for web
 deployment. https://webassembly.org.
 
+[#_wasmtime]
 === Wasmtime
 
 A runtime for WebAssembly. https://wasmtime.dev.

--- a/docs/admission-controller/version-1.28/modules/en/pages/howtos/application-collection/01-verify-images.adoc
+++ b/docs/admission-controller/version-1.28/modules/en/pages/howtos/application-collection/01-verify-images.adoc
@@ -155,7 +155,7 @@ EOF
 
 To test it, deploy a Pod with a signed image from Application Collection:
 
- $ kubectl run nginx --image [dp.apps.rancher.io/containers/nginx:1.24.0](http://dp.apps.rancher.io/containers/nginx:1.24.0) --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
+ $ kubectl run nginx --image dp.apps.rancher.io/containers/nginx:1.24.0 --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
  pod/nginx created
 
 You can inspect the logs of your policy-server Pod to see that the verification

--- a/docs/admission-controller/version-1.28/modules/en/pages/howtos/gatekeeper-migration.adoc
+++ b/docs/admission-controller/version-1.28/modules/en/pages/howtos/gatekeeper-migration.adoc
@@ -193,6 +193,7 @@ touch policy.wasm # opa creates the bundle with unix epoch timestamp, fix it
 There is more information on how to build Gatekeeper policies in our
 xref:/tutorials/writing-policies/rego/gatekeeper/03-build-and-run.adoc[tutorial].
 
+[#_rego_policy_code_and_opa_v1_0_0_compatibility]
 === Rego Policy code and OPA v1.0.0 compatibility
 
 With the release of OPA (Open Policy Agent)

--- a/docs/admission-controller/version-1.28/modules/en/pages/howtos/psp-migration.adoc
+++ b/docs/admission-controller/version-1.28/modules/en/pages/howtos/psp-migration.adoc
@@ -488,6 +488,7 @@ Error from server: error when creating "STDIN": admission webhook "clusterwide-p
 
 ======
 
+[#_mapping_kubewarden_policies_to_psp_fields]
 == Mapping Kubewarden policies to PSP fields
 
 This table maps PSP configuration fields to corresponding Kubewarden policies.

--- a/docs/admission-controller/version-1.28/modules/en/pages/introduction.adoc
+++ b/docs/admission-controller/version-1.28/modules/en/pages/introduction.adoc
@@ -91,6 +91,7 @@ https://github.com/opencontainers/artifacts[OCI artifacts].
 
 ifeval::["{build-type}" == "community"]
 
+[#_vendor_neutrality]
 == Vendor neutrality
 
 {short-project-name} is a

--- a/docs/admission-controller/version-1.28/modules/en/pages/reference/metrics-reference.adoc
+++ b/docs/admission-controller/version-1.28/modules/en/pages/reference/metrics-reference.adoc
@@ -37,6 +37,7 @@ key-value attributes are added to the metric to provide additional information.
 | <<_kubewarden_policy_evaluations_total,Baggage>>
 |===
 
+[#_kubewarden_policy_evaluations_total]
 ==== `kubewarden_policy_evaluations_total`
 
 ===== Baggage

--- a/docs/admission-controller/version-1.28/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
+++ b/docs/admission-controller/version-1.28/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
@@ -61,12 +61,11 @@ spec:
 ----
 
 Now, we need to write the CEL code that will fetch the existing Ingresses in
-the cluster. For that, we use the [Kubewarden CEL extension
-library](https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities).
+the cluster. For that, we use the https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities[Kubewarden CEL extension library].
 Particularly, the `kw.k8s` host capabilities, which allows us to query the
 cluster for GroupVersionKinds. You can see the available docs for the CEL
 functions
-[here](https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library).
+https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library[here].
 
 The library uses a builder pattern just as the upstream Kubernetes CEL
 extensions; calling a CEL function method returns a CEL object which on its own

--- a/docs/admission-controller/version-1.29/modules/en/pages/disclosure.adoc
+++ b/docs/admission-controller/version-1.29/modules/en/pages/disclosure.adoc
@@ -13,8 +13,7 @@ include::partial$variables.adoc[]
 
 The {project-name} team appreciates investigative work on security vulnerabilities
 carried out by well-intentioned, ethical security researchers. {short-project-name}
-follows the practice of [responsible
-disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) to best
+follows the practice of https://en.wikipedia.org/wiki/Responsible_disclosure[responsible disclosure] to best
 protect {short-project-name}'s user base from the impact of security issues. On
 {short-project-name}'s side, this means:
 
@@ -30,7 +29,7 @@ GitHub]. This mechanism allows maintainers to communicate privately with you,
 and you don't need to encrypt your messages.
 
 Alternatively, you can disclose it responsibly by emailing
-xref:mailto:cncf-kubewarden-maintainers@lists.cncf.io.adoc[cncf-kubewarden-maintainers@lists.cncf.io]
+mailto:cncf-kubewarden-maintainers@lists.cncf.io[cncf-kubewarden-maintainers@lists.cncf.io]
 in an *unencrypted* message. Please don't discuss potential vulnerabilities in
 public without validating with us first.
 

--- a/docs/admission-controller/version-1.29/modules/en/pages/explanations/comparisons/opa-comparison.adoc
+++ b/docs/admission-controller/version-1.29/modules/en/pages/explanations/comparisons/opa-comparison.adoc
@@ -79,6 +79,7 @@ Both OPA Gatekeeper and Kubernetes can write validation and mutation policies.
 These policies can target any kind of Kubernetes resource, including Custom
 Resources.
 
+[#_writing_policies]
 == Writing policies
 
 You write OPA Gatekeeper policies using
@@ -117,6 +118,7 @@ xref:/tutorials/writing-policies/rego/01-intro-rego.adoc[here].
 ====
 
 
+[#_context_aware]
 == Context aware
 
 Sometimes a policy needs data about the current state of the cluster to make a
@@ -141,6 +143,7 @@ Each policy has access only to the resources that the Kubernetes administrator
 specifies. Attempting to read unauthorized data is immediately blocked and
 reported to the cluster administrators.
 
+[#_kubernetes_integration]
 == Kubernetes integration
 
 OPA Gatekeeper has a cluster wide Custom Resource, permitting policy
@@ -157,6 +160,7 @@ manage `AdmissionPolicy` resources, in the namespaces they can access.
 
 This allows Kubernetes administrators to delegate policy-related work.
 
+[#_policy_distribution]
 == Policy distribution
 
 OPA Gatekeeper and Kubewarden policies have policy source code (Rego for OPA
@@ -174,6 +178,7 @@ You can distribute Kubewarden policies among geographically distributed
 container registries using the traditional tools and processes adopted for
 container images.
 
+[#_cicd_integration]
 == CI/CD integration
 
 Both OPA Gatekeeper and Kubewarden are managed using GitOps methodologies.
@@ -220,6 +225,7 @@ operation modes:
 * `deny`: violation of a policy rejects the request
 * `warn`: violation of a policy doesn't cause rejection and is logged
 
+[#_deployment_mode]
 == Deployment mode
 
 The same server evaluates all the OPA Gatekeeper policies. Conversely,
@@ -244,6 +250,7 @@ This allows interesting scenarios like the following ones:
 * Deploy critical policies to a dedicated Policy Server pool.
 * Deploy the policies of a noisy tenant to a dedicated Policy Server pool.
 
+[#_background_checks]
 == Background checks
 
 As policies are added, removed, and reconfigured the resources already in the

--- a/docs/admission-controller/version-1.29/modules/en/pages/glossary.adoc
+++ b/docs/admission-controller/version-1.29/modules/en/pages/glossary.adoc
@@ -13,6 +13,7 @@ include::partial$variables.adoc[]
 
 == A
 
+[#_admissionpolicy]
 === AdmissionPolicy
 
 A namespace-wide resource. The policy processes only those requests targeting
@@ -20,23 +21,27 @@ the namespace in which the AdmissionPolicy is defined.
 
 == C
 
+[#_clusteradmissionpolicy]
 === ClusterAdmissionPolicy
 
 An <<_admissionpolicy,AdmissionPolicy>> which targets cluster-wide resources.
 
+[#_clusterreport]
 === ClusterPolicyReport
 
-A <<_policyreport,PolicyReport>> and a ClusterPolicyReport store results of
+A <<_report,PolicyReport>> and a ClusterPolicyReport store results of
 policy scans. Which one is used, depends on the scope of the resource.
 
 == K
 
+[#_kwctl]
 === kwctl
 
 A CLI tool to generate and test Kubernetes YAML files for policy deployment.
 
 == M
 
+[#_mutatingwebhookconfiguration]
 === MutatingWebhookConfiguration
 
 A
@@ -47,18 +52,20 @@ this is how a {short-project-name} controller informs Kubernetes where to find a
 
 == P
 
+[#_report]
 === PolicyReport
 
-A PolicyReport and a <<_clusterpolicyreport,ClusterPolicyReport>> store results of
+A PolicyReport and a <<_clusterreport,ClusterPolicyReport>> store results of
 policy scans. Which one is used depends on the scope of the resource.
 
-[#_policy_server]
+[#_policyserver]
 === PolicyServer
 
 A PolicyServer validates incoming requests by executing {short-project-name} policies against requests.
 
 == V
 
+[#_validatingwebhookconfiguration]
 === ValidatingWebhookConfiguration
 
 A
@@ -68,19 +75,23 @@ In other words, this is how {short-project-name} informs Kubernetes where to fin
 
 == W
 
+[#_wapc]
 === waPC
 
 WebAssembly Procedure Calls. https://wapc.io.
 
+[#_wasi]
 === WASI
 
 WebAssembly System Interface. https://wasi.dev.
 
+[#_wasm]
 === Wasm
 
 A binary instruction format for a stack-based virtual machine. Designed for web
 deployment. https://webassembly.org.
 
+[#_wasmtime]
 === Wasmtime
 
 A runtime for WebAssembly. https://wasmtime.dev.

--- a/docs/admission-controller/version-1.29/modules/en/pages/howtos/application-collection/01-verify-images.adoc
+++ b/docs/admission-controller/version-1.29/modules/en/pages/howtos/application-collection/01-verify-images.adoc
@@ -160,7 +160,7 @@ To test it, deploy a Pod with a signed image from Application Collection:
 
 [subs="+attributes",console]
 ----
-$ kubectl run nginx --image [dp.apps.rancher.io/containers/nginx:1.24.0](http://dp.apps.rancher.io/containers/nginx:1.24.0) --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
+$ kubectl run nginx --image dp.apps.rancher.io/containers/nginx:1.24.0 --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
  pod/nginx created
 ----
 

--- a/docs/admission-controller/version-1.29/modules/en/pages/howtos/gatekeeper-migration.adoc
+++ b/docs/admission-controller/version-1.29/modules/en/pages/howtos/gatekeeper-migration.adoc
@@ -194,6 +194,7 @@ touch policy.wasm # opa creates the bundle with unix epoch timestamp, fix it
 There is more information on how to build Gatekeeper policies in our
 xref:/tutorials/writing-policies/rego/gatekeeper/03-build-and-run.adoc[tutorial].
 
+[#_rego_policy_code_and_opa_v1_0_0_compatibility]
 === Rego Policy code and OPA v1.0.0 compatibility
 
 With the release of OPA (Open Policy Agent)

--- a/docs/admission-controller/version-1.29/modules/en/pages/howtos/psp-migration.adoc
+++ b/docs/admission-controller/version-1.29/modules/en/pages/howtos/psp-migration.adoc
@@ -488,6 +488,7 @@ Error from server: error when creating "STDIN": admission webhook "clusterwide-p
 
 ======
 
+[#_mapping_kubewarden_policies_to_psp_fields]
 == Mapping Kubewarden policies to PSP fields
 
 This table maps PSP configuration fields to corresponding Kubewarden policies.

--- a/docs/admission-controller/version-1.29/modules/en/pages/introduction.adoc
+++ b/docs/admission-controller/version-1.29/modules/en/pages/introduction.adoc
@@ -92,6 +92,7 @@ https://github.com/opencontainers/artifacts[OCI artifacts].
 
 ifeval::["{build-type}" == "community"]
 
+[#_vendor_neutrality]
 == Vendor neutrality
 
 {short-project-name} is a

--- a/docs/admission-controller/version-1.29/modules/en/pages/reference/metrics-reference.adoc
+++ b/docs/admission-controller/version-1.29/modules/en/pages/reference/metrics-reference.adoc
@@ -38,6 +38,7 @@ key-value attributes are added to the metric to provide additional information.
 | <<_kubewarden_policy_evaluations_total,Baggage>>
 |===
 
+[#_kubewarden_policy_evaluations_total]
 ==== `kubewarden_policy_evaluations_total`
 
 ===== Baggage

--- a/docs/admission-controller/version-1.29/modules/en/pages/reference/policy-evaluation-timeout.adoc
+++ b/docs/admission-controller/version-1.29/modules/en/pages/reference/policy-evaluation-timeout.adoc
@@ -73,7 +73,7 @@ timeout.
 Starting with Kubewarden v1.29.0, every Kubewarden Policy can set its own
 timeout value via its `spec.timeoutEvalSeconds` attribute. This is not to be
 confused with `spec.timeoutSeconds`, used for the Webhook timeout (see section
-[below](#comparison-with-kubernetes-dynamic-admission-controller-timeout)).
+<<_comparison_with_kubernetes_dynamic_admission_controller_timeout,below>>).
 
 The `spec.timeoutEvalSeconds` is fine-grained, allowing per-Policy tuning of
 their evaluation timeout.
@@ -161,6 +161,7 @@ spec:
       value: "3"
 ----
 
+[#_comparison_with_kubernetes_dynamic_admission_controller_timeout]
 == Comparison with Kubernetes Dynamic Admission Controller timeout
 
 Kubewarden is a https://en.wikipedia.org/wiki/Webhook[webhook] implementation of the https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[Kubernetes Dynamic Admission Controller].

--- a/docs/admission-controller/version-1.29/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
+++ b/docs/admission-controller/version-1.29/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
@@ -62,12 +62,11 @@ spec:
 ----
 
 Now, we need to write the CEL code that will fetch the existing Ingresses in
-the cluster. For that, we use the [Kubewarden CEL extension
-library](https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities).
+the cluster. For that, we use the https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities[Kubewarden CEL extension library].
 Particularly, the `kw.k8s` host capabilities, which allows us to query the
 cluster for GroupVersionKinds. You can see the available docs for the CEL
 functions
-[here](https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library).
+https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library[here].
 
 The library uses a builder pattern just as the upstream Kubernetes CEL
 extensions; calling a CEL function method returns a CEL object which on its own

--- a/docs/admission-controller/version-1.30/modules/en/pages/disclosure.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/disclosure.adoc
@@ -13,8 +13,7 @@ include::partial$variables.adoc[]
 
 The {project-name} team appreciates investigative work on security vulnerabilities
 carried out by well-intentioned, ethical security researchers. {short-project-name}
-follows the practice of [responsible
-disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) to best
+follows the practice of https://en.wikipedia.org/wiki/Responsible_disclosure[responsible disclosure] to best
 protect {short-project-name}'s user base from the impact of security issues. On
 {short-project-name}'s side, this means:
 
@@ -30,7 +29,7 @@ GitHub]. This mechanism allows maintainers to communicate privately with you,
 and you don't need to encrypt your messages.
 
 Alternatively, you can disclose it responsibly by emailing
-xref:mailto:cncf-kubewarden-maintainers@lists.cncf.io.adoc[cncf-kubewarden-maintainers@lists.cncf.io]
+mailto:cncf-kubewarden-maintainers@lists.cncf.io[cncf-kubewarden-maintainers@lists.cncf.io]
 in an *unencrypted* message. Please don't discuss potential vulnerabilities in
 public without validating with us first.
 

--- a/docs/admission-controller/version-1.30/modules/en/pages/explanations/comparisons/opa-comparison.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/explanations/comparisons/opa-comparison.adoc
@@ -78,6 +78,7 @@ Both OPA Gatekeeper and Kubernetes can write validation and mutation policies.
 These policies can target any kind of Kubernetes resource, including Custom
 Resources.
 
+[#_writing_policies]
 == Writing policies
 
 You write OPA Gatekeeper policies using
@@ -116,6 +117,7 @@ xref:/tutorials/writing-policies/rego/01-intro-rego.adoc[here].
 ====
 
 
+[#_context_aware]
 == Context aware
 
 Sometimes a policy needs data about the current state of the cluster to make a
@@ -140,6 +142,7 @@ Each policy has access only to the resources that the Kubernetes administrator
 specifies. Attempting to read unauthorized data is immediately blocked and
 reported to the cluster administrators.
 
+[#_kubernetes_integration]
 == Kubernetes integration
 
 OPA Gatekeeper has a cluster wide Custom Resource, permitting policy
@@ -156,6 +159,7 @@ manage `AdmissionPolicy` resources, in the namespaces they can access.
 
 This allows Kubernetes administrators to delegate policy-related work.
 
+[#_policy_distribution]
 == Policy distribution
 
 OPA Gatekeeper and {short-project-name} policies have policy source code (Rego for OPA
@@ -173,6 +177,7 @@ You can distribute {short-project-name} policies among geographically distribute
 container registries using the traditional tools and processes adopted for
 container images.
 
+[#_cicd_integration]
 == CI/CD integration
 
 Both OPA Gatekeeper and {short-project-name} are managed using GitOps methodologies.
@@ -219,6 +224,7 @@ operation modes:
 * `deny`: violation of a policy rejects the request
 * `warn`: violation of a policy doesn't cause rejection and is logged
 
+[#_deployment_mode]
 == Deployment mode
 
 The same server evaluates all the OPA Gatekeeper policies. Conversely,
@@ -243,6 +249,7 @@ This allows interesting scenarios like the following ones:
 * Deploy critical policies to a dedicated Policy Server pool.
 * Deploy the policies of a noisy tenant to a dedicated Policy Server pool.
 
+[#_background_checks]
 == Background checks
 
 As policies are added, removed, and reconfigured the resources already in the

--- a/docs/admission-controller/version-1.30/modules/en/pages/glossary.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/glossary.adoc
@@ -13,6 +13,7 @@ include::partial$variables.adoc[]
 
 == A
 
+[#_admissionpolicy]
 === AdmissionPolicy
 
 A namespace-wide resource. The policy processes only those requests targeting
@@ -20,10 +21,12 @@ the namespace in which the AdmissionPolicy is defined.
 
 == C
 
+[#_clusteradmissionpolicy]
 === ClusterAdmissionPolicy
 
 An <<_admissionpolicy,AdmissionPolicy>> which targets cluster-wide resources.
 
+[#_clusterreport]
 === ClusterReport
 
 A <<_report,Report>> and a ClusterReport store results of policy scans. Which
@@ -31,12 +34,14 @@ one is used, depends on the scope of the resource.
 
 == K
 
+[#_kwctl]
 === kwctl
 
 A CLI tool to generate and test Kubernetes YAML files for policy deployment.
 
 == M
 
+[#_mutatingwebhookconfiguration]
 === MutatingWebhookConfiguration
 
 A
@@ -47,18 +52,20 @@ this is how a {short-project-name} controller informs Kubernetes where to find a
 
 == P
 
+[#_report]
 === Report
 
 A Report and a <<_clusterreport,ClusterReport>> store results of
 policy scans. Which one is used depends on the scope of the resource.
 
-[#_policy_server]
+[#_policyserver]
 === PolicyServer
 
 A PolicyServer validates incoming requests by executing {short-project-name} policies against requests.
 
 == V
 
+[#_validatingwebhookconfiguration]
 === ValidatingWebhookConfiguration
 
 A
@@ -68,19 +75,23 @@ In other words, this is how {short-project-name} informs Kubernetes where to fin
 
 == W
 
+[#_wapc]
 === waPC
 
 WebAssembly Procedure Calls. https://wapc.io.
 
+[#_wasi]
 === WASI
 
 WebAssembly System Interface. https://wasi.dev.
 
+[#_wasm]
 === Wasm
 
 A binary instruction format for a stack-based virtual machine. Designed for web
 deployment. https://webassembly.org.
 
+[#_wasmtime]
 === Wasmtime
 
 A runtime for WebAssembly. https://wasmtime.dev.

--- a/docs/admission-controller/version-1.30/modules/en/pages/howtos/application-collection/01-verify-images.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/howtos/application-collection/01-verify-images.adoc
@@ -160,7 +160,7 @@ To test it, deploy a Pod with a signed image from Application Collection:
 
 [subs="+attributes",console]
 ----
-$ kubectl run nginx --image [dp.apps.rancher.io/containers/nginx:1.24.0](http://dp.apps.rancher.io/containers/nginx:1.24.0) --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
+$ kubectl run nginx --image dp.apps.rancher.io/containers/nginx:1.24.0 --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
  pod/nginx created
 ----
 

--- a/docs/admission-controller/version-1.30/modules/en/pages/howtos/emergency-disable.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/howtos/emergency-disable.adoc
@@ -1,6 +1,6 @@
 include::partial$variables.adoc[]
 = Emergency disable
-:revdate: 2025-07-09
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Emergency disable
 :sidebar_position: 31

--- a/docs/admission-controller/version-1.30/modules/en/pages/howtos/gatekeeper-migration.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/howtos/gatekeeper-migration.adoc
@@ -194,6 +194,7 @@ touch policy.wasm # opa creates the bundle with unix epoch timestamp, fix it
 There is more information on how to build Gatekeeper policies in our
 xref:/tutorials/writing-policies/rego/gatekeeper/03-build-and-run.adoc[tutorial].
 
+[#_rego_policy_code_and_opa_v1_0_0_compatibility]
 === Rego Policy code and OPA v1.0.0 compatibility
 
 With the release of OPA (Open Policy Agent)

--- a/docs/admission-controller/version-1.30/modules/en/pages/howtos/psp-migration.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/howtos/psp-migration.adoc
@@ -10,7 +10,7 @@ include::partial$variables.adoc[]
 :current-version: {page-origin-branch}
 
 = {title}
-:revdate: 2025-07-09
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 
 For Kubernetes ≥ v1.25.

--- a/docs/admission-controller/version-1.30/modules/en/pages/howtos/ui-extension/01-install.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/howtos/ui-extension/01-install.adoc
@@ -1,6 +1,6 @@
 include::partial$variables.adoc[]
 = Rancher UI extension quickstart
-:revdate: 2025-07-09
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: UI extension quickstart for {project-name}.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.30/modules/en/pages/introduction.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/introduction.adoc
@@ -91,6 +91,7 @@ https://github.com/opencontainers/artifacts[OCI artifacts].
 
 ifeval::["{build-type}" == "community"]
 
+[#_vendor_neutrality]
 == Vendor neutrality
 
 {short-project-name} is a

--- a/docs/admission-controller/version-1.30/modules/en/pages/reference/kwctl-cli.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/reference/kwctl-cli.adoc
@@ -2,7 +2,7 @@
 
 include::partial$variables.adoc[]
 = kwctl CLI
-:revdate: 2025-11-17
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :title: kwctl CLI
 :description: kwctl CLI reference documentation

--- a/docs/admission-controller/version-1.30/modules/en/pages/reference/metrics-reference.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/reference/metrics-reference.adoc
@@ -38,6 +38,7 @@ key-value attributes are added to the metric to provide additional information.
 | <<_kubewarden_policy_evaluations_total,Baggage>>
 |===
 
+[#_kubewarden_policy_evaluations_total]
 ==== `kubewarden_policy_evaluations_total`
 
 ===== Baggage

--- a/docs/admission-controller/version-1.30/modules/en/pages/reference/policy-evaluation-timeout.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/reference/policy-evaluation-timeout.adoc
@@ -71,7 +71,7 @@ timeout.
 Starting with {short-project-name} v1.29.0, every {short-project-name} Policy can set its own
 timeout value via its `spec.timeoutEvalSeconds` attribute. This is not to be
 confused with `spec.timeoutSeconds`, used for the Webhook timeout (see section
-[below](#comparison-with-kubernetes-dynamic-admission-controller-timeout)).
+<<_comparison_with_kubernetes_dynamic_admission_controller_timeout,below>>).
 
 The `spec.timeoutEvalSeconds` is fine-grained, allowing per-Policy tuning of
 their evaluation timeout.
@@ -159,6 +159,7 @@ spec:
       value: "3"
 ----
 
+[#_comparison_with_kubernetes_dynamic_admission_controller_timeout]
 == Comparison with Kubernetes Dynamic Admission Controller timeout
 
 {short-project-name} is a https://en.wikipedia.org/wiki/Webhook[webhook] implementation of the https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[Kubernetes Dynamic Admission Controller].

--- a/docs/admission-controller/version-1.30/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
@@ -1,6 +1,6 @@
 include::partial$variables.adoc[]
 = Reusing ValidatingAdmissionPolicies
-:revdate: 2025-11-17
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Example: Reusing ValidatingAdmissionPolicies
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.30/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
@@ -62,12 +62,11 @@ spec:
 ----
 
 Now, we need to write the CEL code that will fetch the existing Ingresses in
-the cluster. For that, we use the [{short-project-name} CEL extension
-library](https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities).
+the cluster. For that, we use the https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities[{short-project-name} CEL extension library].
 Particularly, the `kw.k8s` host capabilities, which allows us to query the
 cluster for GroupVersionKinds. You can see the available docs for the CEL
 functions
-[here](https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library).
+https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library[here].
 
 The library uses a builder pattern just as the upstream Kubernetes CEL
 extensions; calling a CEL function method returns a CEL object which on its own

--- a/docs/admission-controller/version-1.30/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
+++ b/docs/admission-controller/version-1.30/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
@@ -1,6 +1,6 @@
 include::partial$variables.adoc[]
 = Builtin support
-:revdate: 2025-07-09
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: The {project-name} provided support for executing wasm binaries.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.31/modules/en/pages/disclosure.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/disclosure.adoc
@@ -14,8 +14,7 @@ include::partial$variables.adoc[]
 
 The {project-name} team appreciates investigative work on security vulnerabilities
 carried out by well-intentioned, ethical security researchers. {short-project-name}
-follows the practice of [responsible
-disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) to best
+follows the practice of https://en.wikipedia.org/wiki/Responsible_disclosure[responsible disclosure] to best
 protect {short-project-name}'s user base from the impact of security issues. On
 {short-project-name}'s side, this means:
 
@@ -31,7 +30,7 @@ GitHub]. This mechanism allows maintainers to communicate privately with you,
 and you don't need to encrypt your messages.
 
 Alternatively, you can disclose it responsibly by emailing
-xref:mailto:cncf-kubewarden-maintainers@lists.cncf.io.adoc[cncf-kubewarden-maintainers@lists.cncf.io]
+mailto:cncf-kubewarden-maintainers@lists.cncf.io[cncf-kubewarden-maintainers@lists.cncf.io]
 in an *unencrypted* message. Please don't discuss potential vulnerabilities in
 public without validating with us first.
 

--- a/docs/admission-controller/version-1.31/modules/en/pages/explanations/comparisons/opa-comparison.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/explanations/comparisons/opa-comparison.adoc
@@ -79,6 +79,7 @@ Both OPA Gatekeeper and Kubernetes can write validation and mutation policies.
 These policies can target any kind of Kubernetes resource, including Custom
 Resources.
 
+[#_writing_policies]
 == Writing policies
 
 You write OPA Gatekeeper policies using
@@ -117,6 +118,7 @@ xref:/tutorials/writing-policies/rego/01-intro-rego.adoc[here].
 ====
 
 
+[#_context_aware]
 == Context aware
 
 Sometimes a policy needs data about the current state of the cluster to make a
@@ -141,6 +143,7 @@ Each policy has access only to the resources that the Kubernetes administrator
 specifies. Attempting to read unauthorized data is immediately blocked and
 reported to the cluster administrators.
 
+[#_kubernetes_integration]
 == Kubernetes integration
 
 OPA Gatekeeper has a cluster wide Custom Resource, permitting policy
@@ -157,6 +160,7 @@ manage `AdmissionPolicy` resources, in the namespaces they can access.
 
 This allows Kubernetes administrators to delegate policy-related work.
 
+[#_policy_distribution]
 == Policy distribution
 
 OPA Gatekeeper and {short-project-name} policies have policy source code (Rego for OPA
@@ -174,6 +178,7 @@ You can distribute {short-project-name} policies among geographically distribute
 container registries using the traditional tools and processes adopted for
 container images.
 
+[#_cicd_integration]
 == CI/CD integration
 
 Both OPA Gatekeeper and {short-project-name} are managed using GitOps methodologies.
@@ -220,6 +225,7 @@ operation modes:
 * `deny`: violation of a policy rejects the request
 * `warn`: violation of a policy doesn't cause rejection and is logged
 
+[#_deployment_mode]
 == Deployment mode
 
 The same server evaluates all the OPA Gatekeeper policies. Conversely,
@@ -244,6 +250,7 @@ This allows interesting scenarios like the following ones:
 * Deploy critical policies to a dedicated Policy Server pool.
 * Deploy the policies of a noisy tenant to a dedicated Policy Server pool.
 
+[#_background_checks]
 == Background checks
 
 As policies are added, removed, and reconfigured the resources already in the

--- a/docs/admission-controller/version-1.31/modules/en/pages/glossary.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/glossary.adoc
@@ -13,6 +13,7 @@ include::partial$variables.adoc[]
 
 == A
 
+[#_admissionpolicy]
 === AdmissionPolicy
 
 A namespace-wide resource. The policy processes only those requests targeting
@@ -20,10 +21,12 @@ the namespace in which the AdmissionPolicy is defined.
 
 == C
 
+[#_clusteradmissionpolicy]
 === ClusterAdmissionPolicy
 
 An <<_admissionpolicy,AdmissionPolicy>> which targets cluster-wide resources.
 
+[#_clusterreport]
 === ClusterReport
 
 A <<_report,Report>> and a ClusterReport store results of policy scans. Which
@@ -31,12 +34,14 @@ one is used, depends on the scope of the resource.
 
 == K
 
+[#_kwctl]
 === kwctl
 
 A CLI tool to generate and test Kubernetes YAML files for policy deployment.
 
 == M
 
+[#_mutatingwebhookconfiguration]
 === MutatingWebhookConfiguration
 
 A
@@ -47,18 +52,20 @@ this is how a {short-project-name} controller informs Kubernetes where to find a
 
 == P
 
+[#_report]
 === Report
 
 A Report and a <<_clusterreport,ClusterReport>> store results of
 policy scans. Which one is used depends on the scope of the resource.
 
-[#_policy_server]
+[#_policyserver]
 === PolicyServer
 
 A PolicyServer validates incoming requests by executing {short-project-name} policies against requests.
 
 == V
 
+[#_validatingwebhookconfiguration]
 === ValidatingWebhookConfiguration
 
 A
@@ -68,19 +75,23 @@ In other words, this is how {short-project-name} informs Kubernetes where to fin
 
 == W
 
+[#_wapc]
 === waPC
 
 WebAssembly Procedure Calls. https://wapc.io.
 
+[#_wasi]
 === WASI
 
 WebAssembly System Interface. https://wasi.dev.
 
+[#_wasm]
 === Wasm
 
 A binary instruction format for a stack-based virtual machine. Designed for web
 deployment. https://webassembly.org.
 
+[#_wasmtime]
 === Wasmtime
 
 A runtime for WebAssembly. https://wasmtime.dev.

--- a/docs/admission-controller/version-1.31/modules/en/pages/howtos/application-collection/01-verify-images.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/howtos/application-collection/01-verify-images.adoc
@@ -160,7 +160,7 @@ To test it, deploy a Pod with a signed image from Application Collection:
 
 [subs="+attributes",console]
 ----
-$ kubectl run nginx --image [dp.apps.rancher.io/containers/nginx:1.24.0](http://dp.apps.rancher.io/containers/nginx:1.24.0) --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
+$ kubectl run nginx --image dp.apps.rancher.io/containers/nginx:1.24.0 --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
  pod/nginx created
 ----
 

--- a/docs/admission-controller/version-1.31/modules/en/pages/howtos/emergency-disable.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/howtos/emergency-disable.adoc
@@ -1,6 +1,6 @@
 include::partial$variables.adoc[]
 = Emergency disable
-:revdate: 2025-11-17
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Emergency disable
 :sidebar_position: 31

--- a/docs/admission-controller/version-1.31/modules/en/pages/howtos/gatekeeper-migration.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/howtos/gatekeeper-migration.adoc
@@ -194,6 +194,7 @@ touch policy.wasm # opa creates the bundle with unix epoch timestamp, fix it
 There is more information on how to build Gatekeeper policies in our
 xref:/tutorials/writing-policies/rego/gatekeeper/03-build-and-run.adoc[tutorial].
 
+[#_rego_policy_code_and_opa_v1_0_0_compatibility]
 === Rego Policy code and OPA v1.0.0 compatibility
 
 With the release of OPA (Open Policy Agent)

--- a/docs/admission-controller/version-1.31/modules/en/pages/howtos/psp-migration.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/howtos/psp-migration.adoc
@@ -10,7 +10,7 @@ include::partial$variables.adoc[]
 :current-version: {page-origin-branch}
 
 = {title}
-:revdate: 2025-11-17
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 
 For Kubernetes ≥ v1.25.

--- a/docs/admission-controller/version-1.31/modules/en/pages/howtos/ui-extension/01-install.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/howtos/ui-extension/01-install.adoc
@@ -1,6 +1,6 @@
 include::partial$variables.adoc[]
 = Rancher UI extension quickstart
-:revdate: 2025-11-17
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: UI extension quickstart for {project-name}.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.31/modules/en/pages/introduction.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/introduction.adoc
@@ -91,6 +91,7 @@ https://github.com/opencontainers/artifacts[OCI artifacts].
 
 ifeval::["{build-type}" == "community"]
 
+[#_vendor_neutrality]
 == Vendor neutrality
 
 {short-project-name} is a

--- a/docs/admission-controller/version-1.31/modules/en/pages/reference/kwctl-cli.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/reference/kwctl-cli.adoc
@@ -2,7 +2,7 @@
 
 include::partial$variables.adoc[]
 = kwctl CLI
-:revdate: 2025-11-17
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :title: kwctl CLI
 :description: kwctl CLI reference documentation

--- a/docs/admission-controller/version-1.31/modules/en/pages/reference/metrics-reference.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/reference/metrics-reference.adoc
@@ -38,6 +38,7 @@ key-value attributes are added to the metric to provide additional information.
 | <<_kubewarden_policy_evaluations_total,Baggage>>
 |===
 
+[#_kubewarden_policy_evaluations_total]
 ==== `kubewarden_policy_evaluations_total`
 
 ===== Baggage

--- a/docs/admission-controller/version-1.31/modules/en/pages/reference/policy-evaluation-timeout.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/reference/policy-evaluation-timeout.adoc
@@ -71,7 +71,7 @@ timeout.
 Starting with {short-project-name} v1.29.0, every {short-project-name} Policy can set its own
 timeout value via its `spec.timeoutEvalSeconds` attribute. This is not to be
 confused with `spec.timeoutSeconds`, used for the Webhook timeout (see section
-[below](#comparison-with-kubernetes-dynamic-admission-controller-timeout)).
+<<_comparison_with_kubernetes_dynamic_admission_controller_timeout,below>>).
 
 The `spec.timeoutEvalSeconds` is fine-grained, allowing per-Policy tuning of
 their evaluation timeout.
@@ -159,6 +159,7 @@ spec:
       value: "3"
 ----
 
+[#_comparison_with_kubernetes_dynamic_admission_controller_timeout]
 == Comparison with Kubernetes Dynamic Admission Controller timeout
 
 {short-project-name} is a https://en.wikipedia.org/wiki/Webhook[webhook] implementation of the https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[Kubernetes Dynamic Admission Controller].

--- a/docs/admission-controller/version-1.31/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
@@ -1,6 +1,6 @@
 include::partial$variables.adoc[]
 = Reusing ValidatingAdmissionPolicies
-:revdate: 2025-11-17
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Example: Reusing ValidatingAdmissionPolicies
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.31/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
@@ -62,12 +62,11 @@ spec:
 ----
 
 Now, we need to write the CEL code that will fetch the existing Ingresses in
-the cluster. For that, we use the [{short-project-name} CEL extension
-library](https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities).
+the cluster. For that, we use the https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities[{short-project-name} CEL extension library].
 Particularly, the `kw.k8s` host capabilities, which allows us to query the
 cluster for GroupVersionKinds. You can see the available docs for the CEL
 functions
-[here](https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library).
+https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library[here].
 
 The library uses a builder pattern just as the upstream Kubernetes CEL
 extensions; calling a CEL function method returns a CEL object which on its own

--- a/docs/admission-controller/version-1.31/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
+++ b/docs/admission-controller/version-1.31/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
@@ -1,6 +1,6 @@
 include::partial$variables.adoc[]
 = Builtin support
-:revdate: 2025-11-17
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: The {project-name} provided support for executing wasm binaries.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.32/modules/en/pages/disclosure.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/disclosure.adoc
@@ -14,8 +14,7 @@ include::partial$variables.adoc[]
 
 The {project-name} team appreciates investigative work on security vulnerabilities
 carried out by well-intentioned, ethical security researchers. {short-project-name}
-follows the practice of [responsible
-disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) to best
+follows the practice of https://en.wikipedia.org/wiki/Responsible_disclosure[responsible disclosure] to best
 protect {short-project-name}'s user base from the impact of security issues. On
 {short-project-name}'s side, this means:
 
@@ -31,7 +30,7 @@ GitHub]. This mechanism allows maintainers to communicate privately with you,
 and you don't need to encrypt your messages.
 
 Alternatively, you can disclose it responsibly by emailing
-xref:mailto:cncf-kubewarden-maintainers@lists.cncf.io.adoc[cncf-kubewarden-maintainers@lists.cncf.io]
+mailto:cncf-kubewarden-maintainers@lists.cncf.io[cncf-kubewarden-maintainers@lists.cncf.io]
 in an *unencrypted* message. Please don't discuss potential vulnerabilities in
 public without validating with us first.
 

--- a/docs/admission-controller/version-1.32/modules/en/pages/explanations/comparisons/opa-comparison.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/explanations/comparisons/opa-comparison.adoc
@@ -79,6 +79,7 @@ Both OPA Gatekeeper and Kubernetes can write validation and mutation policies.
 These policies can target any kind of Kubernetes resource, including Custom
 Resources.
 
+[#_writing_policies]
 == Writing policies
 
 You write OPA Gatekeeper policies using
@@ -117,6 +118,7 @@ xref:/tutorials/writing-policies/rego/01-intro-rego.adoc[here].
 ====
 
 
+[#_context_aware]
 == Context aware
 
 Sometimes a policy needs data about the current state of the cluster to make a
@@ -141,6 +143,7 @@ Each policy has access only to the resources that the Kubernetes administrator
 specifies. Attempting to read unauthorized data is immediately blocked and
 reported to the cluster administrators.
 
+[#_kubernetes_integration]
 == Kubernetes integration
 
 OPA Gatekeeper has a cluster wide Custom Resource, permitting policy
@@ -157,6 +160,7 @@ manage `AdmissionPolicy` resources, in the namespaces they can access.
 
 This allows Kubernetes administrators to delegate policy-related work.
 
+[#_policy_distribution]
 == Policy distribution
 
 OPA Gatekeeper and {short-project-name} policies have policy source code (Rego for OPA
@@ -174,6 +178,7 @@ You can distribute {short-project-name} policies among geographically distribute
 container registries using the traditional tools and processes adopted for
 container images.
 
+[#_cicd_integration]
 == CI/CD integration
 
 Both OPA Gatekeeper and {short-project-name} are managed using GitOps methodologies.
@@ -220,6 +225,7 @@ operation modes:
 * `deny`: violation of a policy rejects the request
 * `warn`: violation of a policy doesn't cause rejection and is logged
 
+[#_deployment_mode]
 == Deployment mode
 
 The same server evaluates all the OPA Gatekeeper policies. Conversely,
@@ -244,6 +250,7 @@ This allows interesting scenarios like the following ones:
 * Deploy critical policies to a dedicated Policy Server pool.
 * Deploy the policies of a noisy tenant to a dedicated Policy Server pool.
 
+[#_background_checks]
 == Background checks
 
 As policies are added, removed, and reconfigured the resources already in the

--- a/docs/admission-controller/version-1.32/modules/en/pages/glossary.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/glossary.adoc
@@ -13,6 +13,7 @@ include::partial$variables.adoc[]
 
 == A
 
+[#_admissionpolicy]
 === AdmissionPolicy
 
 A namespace-wide resource. The policy processes only those requests targeting
@@ -20,10 +21,12 @@ the namespace in which the AdmissionPolicy is defined.
 
 == C
 
+[#_clusteradmissionpolicy]
 === ClusterAdmissionPolicy
 
 An <<_admissionpolicy,AdmissionPolicy>> which targets cluster-wide resources.
 
+[#_clusterreport]
 === ClusterReport
 
 A <<_report,Report>> and a ClusterReport store results of policy scans. Which
@@ -31,12 +34,14 @@ one is used, depends on the scope of the resource.
 
 == K
 
+[#_kwctl]
 === kwctl
 
 A CLI tool to generate and test Kubernetes YAML files for policy deployment.
 
 == M
 
+[#_mutatingwebhookconfiguration]
 === MutatingWebhookConfiguration
 
 A
@@ -47,18 +52,20 @@ this is how a {short-project-name} controller informs Kubernetes where to find a
 
 == P
 
+[#_report]
 === Report
 
 A Report and a <<_clusterreport,ClusterReport>> store results of
 policy scans. Which one is used depends on the scope of the resource.
 
-[#_policy_server]
+[#_policyserver]
 === PolicyServer
 
 A PolicyServer validates incoming requests by executing {short-project-name} policies against requests.
 
 == V
 
+[#_validatingwebhookconfiguration]
 === ValidatingWebhookConfiguration
 
 A
@@ -68,19 +75,23 @@ In other words, this is how {short-project-name} informs Kubernetes where to fin
 
 == W
 
+[#_wapc]
 === waPC
 
 WebAssembly Procedure Calls. https://wapc.io.
 
+[#_wasi]
 === WASI
 
 WebAssembly System Interface. https://wasi.dev.
 
+[#_wasm]
 === Wasm
 
 A binary instruction format for a stack-based virtual machine. Designed for web
 deployment. https://webassembly.org.
 
+[#_wasmtime]
 === Wasmtime
 
 A runtime for WebAssembly. https://wasmtime.dev.

--- a/docs/admission-controller/version-1.32/modules/en/pages/howtos/application-collection/01-verify-images.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/howtos/application-collection/01-verify-images.adoc
@@ -160,7 +160,7 @@ To test it, deploy a Pod with a signed image from Application Collection:
 
 [subs="+attributes",console]
 ----
-$ kubectl run nginx --image [dp.apps.rancher.io/containers/nginx:1.24.0](http://dp.apps.rancher.io/containers/nginx:1.24.0) --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
+$ kubectl run nginx --image dp.apps.rancher.io/containers/nginx:1.24.0 --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
  pod/nginx created
 ----
 

--- a/docs/admission-controller/version-1.32/modules/en/pages/howtos/emergency-disable.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/howtos/emergency-disable.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Emergency disable
 :description: Learn how to disable the {project-name} in emergency situations, stopping and deleting related configurations, and then restore.
-:revdate: 2025-11-25
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Emergency disable
 :sidebar_position: 31

--- a/docs/admission-controller/version-1.32/modules/en/pages/howtos/gatekeeper-migration.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/howtos/gatekeeper-migration.adoc
@@ -195,6 +195,7 @@ touch policy.wasm # opa creates the bundle with unix epoch timestamp, fix it
 There is more information on how to build Gatekeeper policies in our
 xref:/tutorials/writing-policies/rego/gatekeeper/03-build-and-run.adoc[tutorial].
 
+[#_rego_policy_code_and_opa_v1_0_0_compatibility]
 === Rego Policy code and OPA v1.0.0 compatibility
 
 With the release of OPA (Open Policy Agent)

--- a/docs/admission-controller/version-1.32/modules/en/pages/howtos/psp-migration.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/howtos/psp-migration.adoc
@@ -10,7 +10,7 @@ include::partial$variables.adoc[]
 
 = {title}
 :description: Configure {project-name} policies in your Kubernetes clusters to achieve granular control over policy configuration, replacing PodSecurityPolicy (PSP).
-:revdate: 2025-11-25
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 
 For Kubernetes ≥ v1.25.

--- a/docs/admission-controller/version-1.32/modules/en/pages/howtos/ui-extension/01-install.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/howtos/ui-extension/01-install.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Rancher UI extension quickstart
 :description: Learn how to install the {project-name} UI as an extension of Rancher Manager with a step-by-step guide through the installation process.
-:revdate: 2025-11-25
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]
 :doc-topic: ["operator-manual", "ui-extension", "installation"]

--- a/docs/admission-controller/version-1.32/modules/en/pages/introduction.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/introduction.adoc
@@ -91,6 +91,7 @@ https://github.com/opencontainers/artifacts[OCI artifacts].
 
 ifeval::["{build-type}" == "community"]
 
+[#_vendor_neutrality]
 == Vendor neutrality
 
 {short-project-name} is a

--- a/docs/admission-controller/version-1.32/modules/en/pages/reference/kwctl-cli.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/reference/kwctl-cli.adoc
@@ -3,7 +3,7 @@
 include::partial$variables.adoc[]
 = kwctl CLI
 :description: Explore the `kwctl` command-line tool to manage {project-name} policies and perform tasks like loading policies.
-:revdate: 2025-12-10
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :title: kwctl CLI
 :keywords: cli, reference, kwctl

--- a/docs/admission-controller/version-1.32/modules/en/pages/reference/metrics-reference.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/reference/metrics-reference.adoc
@@ -38,6 +38,7 @@ key-value attributes are added to the metric to provide additional information.
 | <<_kubewarden_policy_evaluations_total,Baggage>>
 |===
 
+[#_kubewarden_policy_evaluations_total]
 ==== `kubewarden_policy_evaluations_total`
 
 ===== Baggage

--- a/docs/admission-controller/version-1.32/modules/en/pages/reference/policy-evaluation-timeout.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/reference/policy-evaluation-timeout.adoc
@@ -71,7 +71,7 @@ timeout.
 Starting with {short-project-name} v1.29.0, every {short-project-name} Policy can set its own
 timeout value via its `spec.timeoutEvalSeconds` attribute. This is not to be
 confused with `spec.timeoutSeconds`, used for the Webhook timeout (see section
-[below](#comparison-with-kubernetes-dynamic-admission-controller-timeout)).
+<<_comparison_with_kubernetes_dynamic_admission_controller_timeout,below>>).
 
 The `spec.timeoutEvalSeconds` is fine-grained, allowing per-Policy tuning of
 their evaluation timeout.
@@ -159,6 +159,7 @@ spec:
       value: "3"
 ----
 
+[#_comparison_with_kubernetes_dynamic_admission_controller_timeout]
 == Comparison with Kubernetes Dynamic Admission Controller timeout
 
 {short-project-name} is a https://en.wikipedia.org/wiki/Webhook[webhook] implementation of the https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[Kubernetes Dynamic Admission Controller].

--- a/docs/admission-controller/version-1.32/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Reusing ValidatingAdmissionPolicies
 :description: Learn about reusing and validating admission policies in Kubernetes using {project-name}'s (cel-policy).
-:revdate: 2025-11-25
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]
 :doc-topic: ["kubewarden", "writing-policies", "cel", "ValidatingAdmissionPolicies"]

--- a/docs/admission-controller/version-1.32/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
@@ -62,12 +62,11 @@ spec:
 ----
 
 Now, we need to write the CEL code that will fetch the existing Ingresses in
-the cluster. For that, we use the [{short-project-name} CEL extension
-library](https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities).
+the cluster. For that, we use the https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities[{short-project-name} CEL extension library].
 Particularly, the `kw.k8s` host capabilities, which allows us to query the
 cluster for GroupVersionKinds. You can see the available docs for the CEL
 functions
-[here](https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library).
+https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library[here].
 
 The library uses a builder pattern just as the upstream Kubernetes CEL
 extensions; calling a CEL function method returns a CEL object which on its own

--- a/docs/admission-controller/version-1.32/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
+++ b/docs/admission-controller/version-1.32/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Builtin support
 :description: Determine which built-in functions are available for WebAssembly modules and understand their implementation and use in Rego policy development.
-:revdate: 2025-11-25
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :doc-persona: ["kubewarden-policy-developer"]
 :doc-topic: ["writing-policies", "rego", "built-in-support"]

--- a/docs/admission-controller/version-1.33/modules/en/pages/disclosure.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/disclosure.adoc
@@ -14,8 +14,7 @@ include::partial$variables.adoc[]
 
 The {project-name} team appreciates investigative work on security vulnerabilities
 carried out by well-intentioned, ethical security researchers. {short-project-name}
-follows the practice of [responsible
-disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) to best
+follows the practice of https://en.wikipedia.org/wiki/Responsible_disclosure[responsible disclosure] to best
 protect {short-project-name}'s user base from the impact of security issues. On
 {short-project-name}'s side, this means:
 
@@ -31,7 +30,7 @@ GitHub]. This mechanism allows maintainers to communicate privately with you,
 and you don't need to encrypt your messages.
 
 Alternatively, you can disclose it responsibly by emailing
-xref:mailto:cncf-kubewarden-maintainers@lists.cncf.io.adoc[cncf-kubewarden-maintainers@lists.cncf.io]
+mailto:cncf-kubewarden-maintainers@lists.cncf.io[cncf-kubewarden-maintainers@lists.cncf.io]
 in an *unencrypted* message. Please don't discuss potential vulnerabilities in
 public without validating with us first.
 

--- a/docs/admission-controller/version-1.33/modules/en/pages/explanations/audit-scanner/policy-reports.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/explanations/audit-scanner/policy-reports.adoc
@@ -18,7 +18,7 @@ scans using the https://openreports.io/[OpenReports] Custom Resources.
 ====
 
 With {project-name} 1.33, the Audit Scanner feature saves the reports
-into OpenReports CRDs from [openreports.io](https://openreports.io) by default.
+into OpenReports CRDs from https://openreports.io[openreports.io] by default.
 
 The
 link:https://htmlpreview.github.io/?https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/045372e558b896695b2daae92e8c7a04d4d40282/policy-report/docs/index.html[PolicyReport]

--- a/docs/admission-controller/version-1.33/modules/en/pages/explanations/comparisons/opa-comparison.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/explanations/comparisons/opa-comparison.adoc
@@ -79,6 +79,7 @@ Both OPA Gatekeeper and Kubernetes can write validation and mutation policies.
 These policies can target any kind of Kubernetes resource, including Custom
 Resources.
 
+[#_writing_policies]
 == Writing policies
 
 You write OPA Gatekeeper policies using
@@ -117,6 +118,7 @@ xref:/tutorials/writing-policies/rego/01-intro-rego.adoc[here].
 ====
 
 
+[#_context_aware]
 == Context aware
 
 Sometimes a policy needs data about the current state of the cluster to make a
@@ -141,6 +143,7 @@ Each policy has access only to the resources that the Kubernetes administrator
 specifies. Attempting to read unauthorized data is immediately blocked and
 reported to the cluster administrators.
 
+[#_kubernetes_integration]
 == Kubernetes integration
 
 OPA Gatekeeper has a cluster wide Custom Resource, permitting policy
@@ -157,6 +160,7 @@ manage `AdmissionPolicy` resources, in the namespaces they can access.
 
 This allows Kubernetes administrators to delegate policy-related work.
 
+[#_policy_distribution]
 == Policy distribution
 
 OPA Gatekeeper and {short-project-name} policies have policy source code (Rego for OPA
@@ -174,6 +178,7 @@ You can distribute {short-project-name} policies among geographically distribute
 container registries using the traditional tools and processes adopted for
 container images.
 
+[#_cicd_integration]
 == CI/CD integration
 
 Both OPA Gatekeeper and {short-project-name} are managed using GitOps methodologies.
@@ -220,6 +225,7 @@ operation modes:
 * `deny`: violation of a policy rejects the request
 * `warn`: violation of a policy doesn't cause rejection and is logged
 
+[#_deployment_mode]
 == Deployment mode
 
 The same server evaluates all the OPA Gatekeeper policies. Conversely,
@@ -244,6 +250,7 @@ This allows interesting scenarios like the following ones:
 * Deploy critical policies to a dedicated Policy Server pool.
 * Deploy the policies of a noisy tenant to a dedicated Policy Server pool.
 
+[#_background_checks]
 == Background checks
 
 As policies are added, removed, and reconfigured the resources already in the

--- a/docs/admission-controller/version-1.33/modules/en/pages/glossary.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/glossary.adoc
@@ -13,6 +13,7 @@ include::partial$variables.adoc[]
 
 == A
 
+[#_admissionpolicy]
 === AdmissionPolicy
 
 A namespace-wide resource. The policy processes only those requests targeting
@@ -20,10 +21,12 @@ the namespace in which the AdmissionPolicy is defined.
 
 == C
 
+[#_clusteradmissionpolicy]
 === ClusterAdmissionPolicy
 
 An <<_admissionpolicy,AdmissionPolicy>> which targets cluster-wide resources.
 
+[#_clusterreport]
 === ClusterReport
 
 A <<_report,Report>> and a ClusterReport store results of policy scans. Which
@@ -31,12 +34,14 @@ one is used, depends on the scope of the resource.
 
 == K
 
+[#_kwctl]
 === kwctl
 
 A CLI tool to generate and test Kubernetes YAML files for policy deployment.
 
 == M
 
+[#_mutatingwebhookconfiguration]
 === MutatingWebhookConfiguration
 
 A
@@ -47,18 +52,20 @@ this is how a {short-project-name} controller informs Kubernetes where to find a
 
 == P
 
+[#_report]
 === Report
 
 A Report and a <<_clusterreport,ClusterReport>> store results of
 policy scans. Which one is used depends on the scope of the resource.
 
-[#_policy_server]
+[#_policyserver]
 === PolicyServer
 
 A PolicyServer validates incoming requests by executing {short-project-name} policies against requests.
 
 == V
 
+[#_validatingwebhookconfiguration]
 === ValidatingWebhookConfiguration
 
 A
@@ -68,19 +75,23 @@ In other words, this is how {short-project-name} informs Kubernetes where to fin
 
 == W
 
+[#_wapc]
 === waPC
 
 WebAssembly Procedure Calls. https://wapc.io.
 
+[#_wasi]
 === WASI
 
 WebAssembly System Interface. https://wasi.dev.
 
+[#_wasm]
 === Wasm
 
 A binary instruction format for a stack-based virtual machine. Designed for web
 deployment. https://webassembly.org.
 
+[#_wasmtime]
 === Wasmtime
 
 A runtime for WebAssembly. https://wasmtime.dev.

--- a/docs/admission-controller/version-1.33/modules/en/pages/howtos/application-collection/01-verify-images.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/howtos/application-collection/01-verify-images.adoc
@@ -160,7 +160,7 @@ To test it, deploy a Pod with a signed image from Application Collection:
 
 [subs="+attributes",console]
 ----
-$ kubectl run nginx --image [dp.apps.rancher.io/containers/nginx:1.24.0](http://dp.apps.rancher.io/containers/nginx:1.24.0) --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
+$ kubectl run nginx --image dp.apps.rancher.io/containers/nginx:1.24.0 --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
  pod/nginx created
 ----
 

--- a/docs/admission-controller/version-1.33/modules/en/pages/howtos/audit-scanner.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/howtos/audit-scanner.adoc
@@ -51,7 +51,7 @@ helm install kubewarden-crds kubewarden/kubewarden-crds
 [NOTE]
 ====
 With Kubewarden 1.33, the Audit Scanner feature saves the reports
-into OpenReports CRDs from [openreports.io](https://openreports.io) by default.
+into OpenReports CRDs from https://openreports.io[openreports.io] by default.
 
 The
 link:https://htmlpreview.github.io/?https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/045372e558b896695b2daae92e8c7a04d4d40282/policy-report/docs/index.html[PolicyReport]

--- a/docs/admission-controller/version-1.33/modules/en/pages/howtos/emergency-disable.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/howtos/emergency-disable.adoc
@@ -1,6 +1,6 @@
 include::partial$variables.adoc[]
 = Emergency disable
-:revdate: 2026-03-18
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Emergency disable
 :sidebar_position: 31

--- a/docs/admission-controller/version-1.33/modules/en/pages/howtos/gatekeeper-migration.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/howtos/gatekeeper-migration.adoc
@@ -194,6 +194,7 @@ touch policy.wasm # opa creates the bundle with unix epoch timestamp, fix it
 There is more information on how to build Gatekeeper policies in our
 xref:/tutorials/writing-policies/rego/gatekeeper/03-build-and-run.adoc[tutorial].
 
+[#_rego_policy_code_and_opa_v1_0_0_compatibility]
 === Rego Policy code and OPA v1.0.0 compatibility
 
 With the release of OPA (Open Policy Agent)

--- a/docs/admission-controller/version-1.33/modules/en/pages/howtos/psp-migration.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/howtos/psp-migration.adoc
@@ -10,7 +10,7 @@ include::partial$variables.adoc[]
 :current-version: {page-origin-branch}
 
 = {title}
-:revdate: 2026-03-18
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 
 For Kubernetes ≥ v1.25.

--- a/docs/admission-controller/version-1.33/modules/en/pages/howtos/ui-extension/01-install.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/howtos/ui-extension/01-install.adoc
@@ -1,6 +1,6 @@
 include::partial$variables.adoc[]
 = Rancher UI extension quickstart
-:revdate: 2026-03-18
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to install the {project-name} UI as an extension of Rancher Manager with a step-by-step guide through the installation process.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.33/modules/en/pages/introduction.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/introduction.adoc
@@ -91,6 +91,7 @@ https://github.com/opencontainers/artifacts[OCI artifacts].
 
 ifeval::["{build-type}" == "community"]
 
+[#_vendor_neutrality]
 == Vendor neutrality
 
 {short-project-name} is a

--- a/docs/admission-controller/version-1.33/modules/en/pages/reference/kwctl-cli.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/reference/kwctl-cli.adoc
@@ -2,7 +2,7 @@
 
 include::partial$variables.adoc[]
 = kwctl CLI
-:revdate: 2026-03-18
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :title: kwctl CLI
 :description: Explore the `kwctl` command-line tool to manage {project-name} policies and perform tasks like loading policies.

--- a/docs/admission-controller/version-1.33/modules/en/pages/reference/metrics-reference.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/reference/metrics-reference.adoc
@@ -38,6 +38,7 @@ key-value attributes are added to the metric to provide additional information.
 | <<_kubewarden_policy_evaluations_total,Baggage>>
 |===
 
+[#_kubewarden_policy_evaluations_total]
 ==== `kubewarden_policy_evaluations_total`
 
 ===== Baggage

--- a/docs/admission-controller/version-1.33/modules/en/pages/reference/policy-evaluation-timeout.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/reference/policy-evaluation-timeout.adoc
@@ -71,7 +71,7 @@ timeout.
 Starting with {short-project-name} v1.29.0, every {short-project-name} Policy can set its own
 timeout value via its `spec.timeoutEvalSeconds` attribute. This is not to be
 confused with `spec.timeoutSeconds`, used for the Webhook timeout (see section
-[below](#comparison-with-kubernetes-dynamic-admission-controller-timeout)).
+<<_comparison_with_kubernetes_dynamic_admission_controller_timeout,below>>).
 
 The `spec.timeoutEvalSeconds` is fine-grained, allowing per-Policy tuning of
 their evaluation timeout.
@@ -159,6 +159,7 @@ spec:
       value: "3"
 ----
 
+[#_comparison_with_kubernetes_dynamic_admission_controller_timeout]
 == Comparison with Kubernetes Dynamic Admission Controller timeout
 
 {short-project-name} is a https://en.wikipedia.org/wiki/Webhook[webhook] implementation of the https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[Kubernetes Dynamic Admission Controller].

--- a/docs/admission-controller/version-1.33/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
@@ -1,6 +1,6 @@
 include::partial$variables.adoc[]
 = Reusing ValidatingAdmissionPolicies
-:revdate: 2026-03-18
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about reusing and validating admission policies in Kubernetes using {project-name}'s (cel-policy).
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.33/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
@@ -62,12 +62,11 @@ spec:
 ----
 
 Now, we need to write the CEL code that will fetch the existing Ingresses in
-the cluster. For that, we use the [{short-project-name} CEL extension
-library](https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities).
+the cluster. For that, we use the https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities[{short-project-name} CEL extension library].
 Particularly, the `kw.k8s` host capabilities, which allows us to query the
 cluster for GroupVersionKinds. You can see the available docs for the CEL
 functions
-[here](https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library).
+https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library[here].
 
 The library uses a builder pattern just as the upstream Kubernetes CEL
 extensions; calling a CEL function method returns a CEL object which on its own

--- a/docs/admission-controller/version-1.33/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
+++ b/docs/admission-controller/version-1.33/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
@@ -1,6 +1,6 @@
 include::partial$variables.adoc[]
 = Builtin support
-:revdate: 2026-03-18
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Determine which built-in functions are available for WebAssembly modules and understand their implementation and use in Rego policy development.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.34/modules/en/pages/disclosure.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/disclosure.adoc
@@ -15,8 +15,7 @@ include::partial$variables.adoc[]
 
 The {project-name} team appreciates investigative work on security vulnerabilities
 carried out by well-intentioned, ethical security researchers. {short-project-name}
-follows the practice of [responsible
-disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) to best
+follows the practice of https://en.wikipedia.org/wiki/Responsible_disclosure[responsible disclosure] to best
 protect {short-project-name}'s user base from the impact of security issues. On
 {short-project-name}'s side, this means:
 
@@ -32,7 +31,7 @@ GitHub]. This mechanism allows maintainers to communicate privately with you,
 and you don't need to encrypt your messages.
 
 Alternatively, you can disclose it responsibly by emailing
-xref:mailto:cncf-kubewarden-maintainers@lists.cncf.io.adoc[cncf-kubewarden-maintainers@lists.cncf.io]
+mailto:cncf-kubewarden-maintainers@lists.cncf.io[cncf-kubewarden-maintainers@lists.cncf.io]
 in an *unencrypted* message. Please don't discuss potential vulnerabilities in
 public without validating with us first.
 

--- a/docs/admission-controller/version-1.34/modules/en/pages/explanations/audit-scanner/policy-reports.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/explanations/audit-scanner/policy-reports.adoc
@@ -19,7 +19,7 @@ scans using the https://openreports.io/[OpenReports] Custom Resources.
 ====
 
 With {project-name} 1.33, the Audit Scanner feature saves the reports
-into OpenReports CRDs from [openreports.io](https://openreports.io) by default.
+into OpenReports CRDs from https://openreports.io[openreports.io] by default.
 
 The
 link:https://htmlpreview.github.io/?https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/045372e558b896695b2daae92e8c7a04d4d40282/policy-report/docs/index.html[PolicyReport]

--- a/docs/admission-controller/version-1.34/modules/en/pages/explanations/comparisons/opa-comparison.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/explanations/comparisons/opa-comparison.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = {project-name} vs OPA Gatekeeper
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-30
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :page-aliases: explanations/opa-comparison.adoc
 :description: Compare OPA Gatekeeper and {project-name} policy management for Kubernetes environments to determine the best approach for your use case.

--- a/docs/admission-controller/version-1.34/modules/en/pages/howtos/application-collection/01-verify-images.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/howtos/application-collection/01-verify-images.adoc
@@ -161,7 +161,7 @@ To test it, deploy a Pod with a signed image from Application Collection:
 
 [subs="+attributes",console]
 ----
-$ kubectl run nginx --image [dp.apps.rancher.io/containers/nginx:1.24.0](http://dp.apps.rancher.io/containers/nginx:1.24.0) --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
+$ kubectl run nginx --image dp.apps.rancher.io/containers/nginx:1.24.0 --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
  pod/nginx created
 ----
 

--- a/docs/admission-controller/version-1.34/modules/en/pages/howtos/audit-scanner.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/howtos/audit-scanner.adoc
@@ -52,7 +52,7 @@ helm install kubewarden-crds kubewarden/kubewarden-crds
 [NOTE]
 ====
 With Kubewarden 1.33, the Audit Scanner feature saves the reports
-into OpenReports CRDs from [openreports.io](https://openreports.io) by default.
+into OpenReports CRDs from https://openreports.io[openreports.io] by default.
 
 The
 link:https://htmlpreview.github.io/?https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/045372e558b896695b2daae92e8c7a04d4d40282/policy-report/docs/index.html[PolicyReport]

--- a/docs/admission-controller/version-1.34/modules/en/pages/howtos/emergency-disable.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/howtos/emergency-disable.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Emergency disable
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-03-18
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Emergency disable
 :sidebar_position: 31

--- a/docs/admission-controller/version-1.34/modules/en/pages/howtos/ui-extension/01-install.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/howtos/ui-extension/01-install.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Rancher UI extension quickstart
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-03-18
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to install the {project-name} UI as an extension of Rancher Manager with a step-by-step guide through the installation process.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.34/modules/en/pages/introduction.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/introduction.adoc
@@ -92,6 +92,7 @@ https://github.com/opencontainers/artifacts[OCI artifacts].
 
 ifeval::["{build-type}" == "community"]
 
+[#_vendor_neutrality]
 == Vendor neutrality
 
 {short-project-name} is a

--- a/docs/admission-controller/version-1.34/modules/en/pages/reference/kwctl-cli.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/reference/kwctl-cli.adoc
@@ -3,7 +3,7 @@
 include::partial$variables.adoc[]
 = kwctl CLI
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-03-18
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :title: kwctl CLI
 :description: Explore the `kwctl` command-line tool to manage {project-name} policies and perform tasks like loading policies.

--- a/docs/admission-controller/version-1.34/modules/en/pages/reference/metrics-reference.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/reference/metrics-reference.adoc
@@ -39,6 +39,7 @@ key-value attributes are added to the metric to provide additional information.
 | <<_kubewarden_policy_evaluations_total,Baggage>>
 |===
 
+[#_kubewarden_policy_evaluations_total]
 ==== `kubewarden_policy_evaluations_total`
 
 ===== Baggage

--- a/docs/admission-controller/version-1.34/modules/en/pages/reference/policy-evaluation-timeout.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/reference/policy-evaluation-timeout.adoc
@@ -72,7 +72,7 @@ timeout.
 Starting with {short-project-name} v1.29.0, every {short-project-name} Policy can set its own
 timeout value via its `spec.timeoutEvalSeconds` attribute. This is not to be
 confused with `spec.timeoutSeconds`, used for the Webhook timeout (see section
-[below](#comparison-with-kubernetes-dynamic-admission-controller-timeout)).
+<<_comparison_with_kubernetes_dynamic_admission_controller_timeout,below>>).
 
 The `spec.timeoutEvalSeconds` is fine-grained, allowing per-Policy tuning of
 their evaluation timeout.
@@ -160,6 +160,7 @@ spec:
       value: "3"
 ----
 
+[#_comparison_with_kubernetes_dynamic_admission_controller_timeout]
 == Comparison with Kubernetes Dynamic Admission Controller timeout
 
 {short-project-name} is a https://en.wikipedia.org/wiki/Webhook[webhook] implementation of the https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[Kubernetes Dynamic Admission Controller].

--- a/docs/admission-controller/version-1.34/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Reusing ValidatingAdmissionPolicies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-03-18
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about reusing and validating admission policies in Kubernetes using {project-name}'s (cel-policy).
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.34/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
@@ -63,12 +63,11 @@ spec:
 ----
 
 Now, we need to write the CEL code that will fetch the existing Ingresses in
-the cluster. For that, we use the [{short-project-name} CEL extension
-library](https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities).
+the cluster. For that, we use the https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities[{short-project-name} CEL extension library].
 Particularly, the `kw.k8s` host capabilities, which allows us to query the
 cluster for GroupVersionKinds. You can see the available docs for the CEL
 functions
-[here](https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library).
+https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library[here].
 
 The library uses a builder pattern just as the upstream Kubernetes CEL
 extensions; calling a CEL function method returns a CEL object which on its own

--- a/docs/admission-controller/version-1.34/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
+++ b/docs/admission-controller/version-1.34/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Builtin support
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-03-18
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Determine which built-in functions are available for WebAssembly modules and understand their implementation and use in Rego policy development.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.35/modules/en/pages/disclosure.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/disclosure.adoc
@@ -15,8 +15,7 @@ include::partial$variables.adoc[]
 
 The {project-name} team appreciates investigative work on security vulnerabilities
 carried out by well-intentioned, ethical security researchers. {short-project-name}
-follows the practice of [responsible
-disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) to best
+follows the practice of https://en.wikipedia.org/wiki/Responsible_disclosure[responsible disclosure] to best
 protect {short-project-name}'s user base from the impact of security issues. On
 {short-project-name}'s side, this means:
 
@@ -32,7 +31,7 @@ GitHub]. This mechanism allows maintainers to communicate privately with you,
 and you don't need to encrypt your messages.
 
 Alternatively, you can disclose it responsibly by emailing
-xref:mailto:cncf-kubewarden-maintainers@lists.cncf.io.adoc[cncf-kubewarden-maintainers@lists.cncf.io]
+mailto:cncf-kubewarden-maintainers@lists.cncf.io[cncf-kubewarden-maintainers@lists.cncf.io]
 in an *unencrypted* message. Please don't discuss potential vulnerabilities in
 public without validating with us first.
 

--- a/docs/admission-controller/version-1.35/modules/en/pages/enterprise.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/enterprise.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Enterprise support
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-30
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Access centralized information on enterprise support for {project-name} solutions through various interfaces.
 :keywords: [ {project-name}, kubewarden, support, ]

--- a/docs/admission-controller/version-1.35/modules/en/pages/explanations/audit-scanner/policy-reports.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/explanations/audit-scanner/policy-reports.adoc
@@ -19,7 +19,7 @@ scans using the https://openreports.io/[OpenReports] Custom Resources.
 ====
 
 With {project-name} 1.33, the Audit Scanner feature saves the reports
-into OpenReports CRDs from [openreports.io](https://openreports.io) by default.
+into OpenReports CRDs from https://openreports.io[openreports.io] by default.
 
 The
 link:https://htmlpreview.github.io/?https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/045372e558b896695b2daae92e8c7a04d4d40282/policy-report/docs/index.html[PolicyReport]

--- a/docs/admission-controller/version-1.35/modules/en/pages/explanations/comparisons/opa-comparison.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/explanations/comparisons/opa-comparison.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = {project-name} vs OPA Gatekeeper
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-30
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :page-aliases: explanations/opa-comparison.adoc
 :description: Compare OPA Gatekeeper and {project-name} policy management for Kubernetes environments to determine the best approach for your use case.

--- a/docs/admission-controller/version-1.35/modules/en/pages/howtos/application-collection/01-verify-images.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/howtos/application-collection/01-verify-images.adoc
@@ -161,7 +161,7 @@ To test it, deploy a Pod with a signed image from Application Collection:
 
 [subs="+attributes",console]
 ----
-$ kubectl run nginx --image [dp.apps.rancher.io/containers/nginx:1.24.0](http://dp.apps.rancher.io/containers/nginx:1.24.0) --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
+$ kubectl run nginx --image dp.apps.rancher.io/containers/nginx:1.24.0 --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
  pod/nginx created
 ----
 

--- a/docs/admission-controller/version-1.35/modules/en/pages/howtos/audit-scanner.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/howtos/audit-scanner.adoc
@@ -52,7 +52,7 @@ helm install kubewarden-crds kubewarden/kubewarden-crds
 [NOTE]
 ====
 With Kubewarden 1.33, the Audit Scanner feature saves the reports
-into OpenReports CRDs from [openreports.io](https://openreports.io) by default.
+into OpenReports CRDs from https://openreports.io[openreports.io] by default.
 
 The
 link:https://htmlpreview.github.io/?https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/045372e558b896695b2daae92e8c7a04d4d40282/policy-report/docs/index.html[PolicyReport]

--- a/docs/admission-controller/version-1.35/modules/en/pages/howtos/emergency-disable.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/howtos/emergency-disable.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Emergency disable
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-30
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Emergency disable
 :sidebar_position: 31

--- a/docs/admission-controller/version-1.35/modules/en/pages/howtos/kubestellar-console.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/howtos/kubestellar-console.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Installing {project-name} with KubeStellar Console
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-30
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: KubeStellar Console
 :sidebar_position: 150

--- a/docs/admission-controller/version-1.35/modules/en/pages/howtos/policy-servers/06-namespaced-policies-capabilities.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/howtos/policy-servers/06-namespaced-policies-capabilities.adoc
@@ -18,8 +18,8 @@ include::partial$variables.adoc[]
 
 This how-to explains how cluster operators can enforce that promise by:
 
-1. Restricting which host capabilities PolicyServers expose to namespaced policies.
-2. Controlling which PolicyServer a namespaced policy runs on, using the
+. Restricting which host capabilities PolicyServers expose to namespaced policies.
+. Controlling which PolicyServer a namespaced policy runs on, using the
    `ns-policyserver-mapper` policy.
 
 [WARNING]
@@ -189,11 +189,11 @@ The `ns-policyserver-mapper` policy is a mutating `ClusterAdmissionPolicy` that
 intercepts `CREATE` and `UPDATE` requests for `AdmissionPolicy` and
 `AdmissionPolicyGroup` resources. It:
 
-1. Reads the `admission.kubewarden.io/policy-server` label from the `Namespace`
+. Reads the `admission.kubewarden.io/policy-server` label from the `Namespace`
    in which the policy is being deployed.
-2. Mutates the policy's `spec.policyServer` field to the value of that label,
+. Mutates the policy's `spec.policyServer` field to the value of that label,
    overriding whatever the user specified.
-3. *Rejects* the request if the Namespace does not have the label, preventing
+. *Rejects* the request if the Namespace does not have the label, preventing
    policies from being silently scheduled on an unintended PolicyServer.
 
 === Labeling Namespaces

--- a/docs/admission-controller/version-1.35/modules/en/pages/howtos/ui-extension/01-install.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/howtos/ui-extension/01-install.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Rancher UI extension quickstart
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-30
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to install the {project-name} UI as an extension of Rancher Manager with a step-by-step guide through the installation process.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.35/modules/en/pages/introduction.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/introduction.adoc
@@ -92,6 +92,7 @@ https://github.com/opencontainers/artifacts[OCI artifacts].
 
 ifeval::["{build-type}" == "community"]
 
+[#_vendor_neutrality]
 == Vendor neutrality
 
 {short-project-name} is a

--- a/docs/admission-controller/version-1.35/modules/en/pages/organization.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/organization.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Documentation organization
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-30
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Organization
 :sidebar_position: 75

--- a/docs/admission-controller/version-1.35/modules/en/pages/reference/kwctl-cli.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/reference/kwctl-cli.adoc
@@ -3,7 +3,7 @@
 include::partial$variables.adoc[]
 = kwctl CLI
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :title: kwctl CLI
 :description: Explore the `kwctl` command-line tool to manage {admc-name} policies and perform tasks like loading policies.

--- a/docs/admission-controller/version-1.35/modules/en/pages/reference/metrics-reference.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/reference/metrics-reference.adoc
@@ -39,6 +39,7 @@ key-value attributes are added to the metric to provide additional information.
 | <<_kubewarden_policy_evaluations_total,Baggage>>
 |===
 
+[#_kubewarden_policy_evaluations_total]
 ==== `kubewarden_policy_evaluations_total`
 
 ===== Baggage

--- a/docs/admission-controller/version-1.35/modules/en/pages/reference/policy-evaluation-timeout.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/reference/policy-evaluation-timeout.adoc
@@ -72,7 +72,7 @@ timeout.
 Starting with {short-project-name} v1.29.0, every {short-project-name} Policy can set its own
 timeout value via its `spec.timeoutEvalSeconds` attribute. This is not to be
 confused with `spec.timeoutSeconds`, used for the Webhook timeout (see section
-[below](#comparison-with-kubernetes-dynamic-admission-controller-timeout)).
+<<_comparison_with_kubernetes_dynamic_admission_controller_timeout,below>>).
 
 The `spec.timeoutEvalSeconds` is fine-grained, allowing per-Policy tuning of
 their evaluation timeout.
@@ -160,6 +160,7 @@ spec:
       value: "3"
 ----
 
+[#_comparison_with_kubernetes_dynamic_admission_controller_timeout]
 == Comparison with Kubernetes Dynamic Admission Controller timeout
 
 {short-project-name} is a https://en.wikipedia.org/wiki/Webhook[webhook] implementation of the https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[Kubernetes Dynamic Admission Controller].

--- a/docs/admission-controller/version-1.35/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Reusing ValidatingAdmissionPolicies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-30
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about reusing and validating admission policies in Kubernetes using {project-name}'s (cel-policy).
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.35/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
@@ -63,12 +63,11 @@ spec:
 ----
 
 Now, we need to write the CEL code that will fetch the existing Ingresses in
-the cluster. For that, we use the [{short-project-name} CEL extension
-library](https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities).
+the cluster. For that, we use the https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities[{short-project-name} CEL extension library].
 Particularly, the `kw.k8s` host capabilities, which allows us to query the
 cluster for GroupVersionKinds. You can see the available docs for the CEL
 functions
-[here](https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library).
+https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library[here].
 
 The library uses a builder pattern just as the upstream Kubernetes CEL
 extensions; calling a CEL function method returns a CEL object which on its own

--- a/docs/admission-controller/version-1.35/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
+++ b/docs/admission-controller/version-1.35/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Builtin support
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-30
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Determine which built-in functions are available for WebAssembly modules and understand their implementation and use in Rego policy development.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.36/modules/en/pages/disclosure.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/disclosure.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Security disclosure
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Investigative security researchers work with the {project-security-team} to identify vulnerabilities using responsible disclosure protocols.
 :doc-persona: ["kubewarden-all"]
@@ -32,7 +32,7 @@ GitHub]. This mechanism allows maintainers to communicate privately with you,
 and you don't need to encrypt your messages.
 
 Alternatively, you can disclose it responsibly by emailing
-xref:mailto:cncf-kubewarden-maintainers@lists.cncf.io.adoc[cncf-kubewarden-maintainers@lists.cncf.io]
+mailto:cncf-kubewarden-maintainers@lists.cncf.io[cncf-kubewarden-maintainers@lists.cncf.io]
 in an *unencrypted* message. Please don't discuss potential vulnerabilities in
 public without validating with us first.
 

--- a/docs/admission-controller/version-1.36/modules/en/pages/enterprise.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/enterprise.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Enterprise support
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Access centralized information on enterprise support for {admc-name} solutions through various interfaces.
 :keywords: [ {admc-name}, kubewarden, support, ]

--- a/docs/admission-controller/version-1.36/modules/en/pages/explanations/audit-scanner/policy-reports.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/explanations/audit-scanner/policy-reports.adoc
@@ -19,7 +19,7 @@ scans using the https://openreports.io/[OpenReports] Custom Resources.
 ====
 
 With {admc-name} 1.33, the Audit Scanner feature saves the reports
-into OpenReports CRDs from [openreports.io](https://openreports.io) by default.
+into OpenReports CRDs from https://openreports.io[openreports.io] by default.
 
 The
 link:https://htmlpreview.github.io/?https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/045372e558b896695b2daae92e8c7a04d4d40282/policy-report/docs/index.html[PolicyReport]

--- a/docs/admission-controller/version-1.36/modules/en/pages/explanations/comparisons/kyverno-comparison.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/explanations/comparisons/kyverno-comparison.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = {admc-name} vs Kyverno
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-22
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Compare Kyverno and {admc-name} policy management for Kubernetes environments to determine the best approach for your use case.
 :doc-persona: ["kubewarden-all"]

--- a/docs/admission-controller/version-1.36/modules/en/pages/explanations/comparisons/opa-comparison.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/explanations/comparisons/opa-comparison.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = {admc-name} vs OPA Gatekeeper
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :page-aliases: explanations/opa-comparison.adoc
 :description: Compare OPA Gatekeeper and {admc-name} policy management for Kubernetes environments to determine the best approach for your use case.

--- a/docs/admission-controller/version-1.36/modules/en/pages/explanations/mutating-policies.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/explanations/mutating-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Mutating policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Rebuild requests by configuring and managing mutating policies within ClusterAdmissionPolicy according to predefined settings.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.36/modules/en/pages/explanations/policy-lifecycle.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/explanations/policy-lifecycle.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Policy lifecycle
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-19
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about creating the lifecycle of policies 
 :doc-persona: ["kubewarden-operator"]

--- a/docs/admission-controller/version-1.36/modules/en/pages/howtos/Rancher-Fleet.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/howtos/Rancher-Fleet.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Managing {admc-name} with Rancher Fleet
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Manage {admc-name} Helm charts using Rancher Fleet and Kubernetes Custom Resource Definitions (CRDs) to implement a GitOps approach.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.36/modules/en/pages/howtos/application-collection/01-verify-images.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/howtos/application-collection/01-verify-images.adoc
@@ -161,7 +161,7 @@ To test it, deploy a Pod with a signed image from Application Collection:
 
 [subs="+attributes",console]
 ----
-$ kubectl run nginx --image [dp.apps.rancher.io/containers/nginx:1.24.0](http://dp.apps.rancher.io/containers/nginx:1.24.0) --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
+$ kubectl run nginx --image dp.apps.rancher.io/containers/nginx:1.24.0 --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
  pod/nginx created
 ----
 

--- a/docs/admission-controller/version-1.36/modules/en/pages/howtos/audit-scanner.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/howtos/audit-scanner.adoc
@@ -52,7 +52,7 @@ helm install kubewarden-crds kubewarden/kubewarden-crds
 [NOTE]
 ====
 With Kubewarden 1.33, the Audit Scanner feature saves the reports
-into OpenReports CRDs from [openreports.io](https://openreports.io) by default.
+into OpenReports CRDs from https://openreports.io[openreports.io] by default.
 
 The
 link:https://htmlpreview.github.io/?https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/045372e558b896695b2daae92e8c7a04d4d40282/policy-report/docs/index.html[PolicyReport]

--- a/docs/admission-controller/version-1.36/modules/en/pages/howtos/emergency-disable.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/howtos/emergency-disable.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Emergency disable
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Emergency disable
 :sidebar_position: 31

--- a/docs/admission-controller/version-1.36/modules/en/pages/howtos/host-network.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/howtos/host-network.adoc
@@ -68,10 +68,10 @@ instance:
 `spec.webhookPort` and `spec.readinessProbePort` are the fields that directly
 help with host-port conflicts for two main reasons:
 
-1. *Running multiple PolicyServers on the same node.* By assigning different
+. *Running multiple PolicyServers on the same node.* By assigning different
    ports to each PolicyServer, you can schedule them on the same node without
    port conflicts.
-2. *Avoiding conflicts with other host services.* If another service on the
+. *Avoiding conflicts with other host services.* If another service on the
    node already uses a default port, you can change the PolicyServer port to
    avoid the collision.
 

--- a/docs/admission-controller/version-1.36/modules/en/pages/howtos/kubestellar-console.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/howtos/kubestellar-console.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Installing {admc-name} with KubeStellar Console
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: KubeStellar Console
 :sidebar_position: 150

--- a/docs/admission-controller/version-1.36/modules/en/pages/howtos/policy-servers/06-namespaced-policies-capabilities.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/howtos/policy-servers/06-namespaced-policies-capabilities.adoc
@@ -18,8 +18,8 @@ include::partial$variables.adoc[]
 
 This how-to explains how cluster operators can enforce that promise by:
 
-1. Restricting which host capabilities PolicyServers expose to namespaced policies.
-2. Controlling which PolicyServer a namespaced policy runs on, using the
+. Restricting which host capabilities PolicyServers expose to namespaced policies.
+. Controlling which PolicyServer a namespaced policy runs on, using the
    `ns-policyserver-mapper` policy.
 
 [WARNING]
@@ -189,11 +189,11 @@ The `ns-policyserver-mapper` policy is a mutating `ClusterAdmissionPolicy` that
 intercepts `CREATE` and `UPDATE` requests for `AdmissionPolicy` and
 `AdmissionPolicyGroup` resources. It:
 
-1. Reads the `admission.kubewarden.io/policy-server` label from the `Namespace`
+. Reads the `admission.kubewarden.io/policy-server` label from the `Namespace`
    in which the policy is being deployed.
-2. Mutates the policy's `spec.policyServer` field to the value of that label,
+. Mutates the policy's `spec.policyServer` field to the value of that label,
    overriding whatever the user specified.
-3. *Rejects* the request if the Namespace does not have the label, preventing
+. *Rejects* the request if the Namespace does not have the label, preventing
    policies from being silently scheduled on an unintended PolicyServer.
 
 === Labeling Namespaces

--- a/docs/admission-controller/version-1.36/modules/en/pages/howtos/ui-extension/01-install.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/howtos/ui-extension/01-install.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Rancher UI extension quickstart
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to install the {admc-name} UI as an extension of Rancher Manager with a step-by-step guide through the installation process.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.36/modules/en/pages/introduction.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/introduction.adoc
@@ -93,6 +93,7 @@ https://github.com/opencontainers/artifacts[OCI artifacts].
 
 ifeval::["{build-type}" == "community"]
 
+[#_vendor_neutrality]
 == Vendor neutrality
 
 {admc-short-name} is a

--- a/docs/admission-controller/version-1.36/modules/en/pages/organization.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/organization.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Documentation organization
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Organization
 :sidebar_position: 75

--- a/docs/admission-controller/version-1.36/modules/en/pages/reference/kwctl-cli.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/reference/kwctl-cli.adoc
@@ -3,7 +3,7 @@
 include::partial$variables.adoc[]
 = kwctl CLI
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :title: kwctl CLI
 :description: Explore the `kwctl` command-line tool to manage {admc-name} policies and perform tasks like loading policies.

--- a/docs/admission-controller/version-1.36/modules/en/pages/reference/metrics-reference.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/reference/metrics-reference.adoc
@@ -39,6 +39,7 @@ key-value attributes are added to the metric to provide additional information.
 | <<_kubewarden_policy_evaluations_total,Baggage>>
 |===
 
+[#_kubewarden_policy_evaluations_total]
 ==== `kubewarden_policy_evaluations_total`
 
 ===== Baggage

--- a/docs/admission-controller/version-1.36/modules/en/pages/reference/policy-evaluation-timeout.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/reference/policy-evaluation-timeout.adoc
@@ -73,7 +73,7 @@ timeout.
 Starting with {admc-short-name} v1.29.0, every {admc-short-name} Policy can set its own
 timeout value via its `spec.timeoutEvalSeconds` attribute. This is not to be
 confused with `spec.timeoutSeconds`, used for the Webhook timeout (see section
-[below](#comparison-with-kubernetes-dynamic-admission-controller-timeout)).
+<<_comparison_with_kubernetes_dynamic_admission_controller_timeout,below>>).
 
 The `spec.timeoutEvalSeconds` is fine-grained, allowing per-Policy tuning of
 their evaluation timeout.
@@ -161,6 +161,7 @@ spec:
       value: "3"
 ----
 
+[#_comparison_with_kubernetes_dynamic_admission_controller_timeout]
 == Comparison with Kubernetes Dynamic Admission Controller timeout
 
 {admc-short-name} is a https://en.wikipedia.org/wiki/Webhook[webhook] implementation of the https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[Kubernetes Dynamic Admission Controller].

--- a/docs/admission-controller/version-1.36/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Reusing ValidatingAdmissionPolicies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about reusing and validating admission policies in Kubernetes using {admc-name}'s (cel-policy).
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.36/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
@@ -63,12 +63,11 @@ spec:
 ----
 
 Now, we need to write the CEL code that will fetch the existing Ingresses in
-the cluster. For that, we use the [{admc-short-name} CEL extension
-library](https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities).
+the cluster. For that, we use the https://github.com/kubewarden/cel-policy?tab=readme-ov-file#host-capabilities[{admc-short-name} CEL extension library].
 Particularly, the `kw.k8s` host capabilities, which allows us to query the
 cluster for GroupVersionKinds. You can see the available docs for the CEL
 functions
-[here](https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library).
+https://pkg.go.dev/github.com/kubewarden/cel-policy/internal/cel/library[here].
 
 The library uses a builder pattern just as the upstream Kubernetes CEL
 extensions; calling a CEL function method returns a CEL object which on its own

--- a/docs/admission-controller/version-1.36/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
+++ b/docs/admission-controller/version-1.36/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Builtin support
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Determine which built-in functions are available for WebAssembly modules and understand their implementation and use in Rego policy development.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/disclosure.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/disclosure.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Security disclosure
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Investigative security researchers work with the {project-security-team} to identify vulnerabilities using responsible disclosure protocols.
 :doc-persona: ["kubewarden-all"]
@@ -32,7 +32,7 @@ GitHub]. This mechanism allows maintainers to communicate privately with you,
 and you don't need to encrypt your messages.
 
 Alternatively, you can disclose it responsibly by emailing
-xref:mailto:cncf-kubewarden-maintainers@lists.cncf.io.adoc[cncf-kubewarden-maintainers@lists.cncf.io]
+mailto:cncf-kubewarden-maintainers@lists.cncf.io[cncf-kubewarden-maintainers@lists.cncf.io]
 in an *unencrypted* message. Please don't discuss potential vulnerabilities in
 public without validating with us first.
 

--- a/docs/admission-controller/version-1.37/modules/en/pages/enterprise.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/enterprise.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Enterprise support
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Access centralized information on enterprise support for {admc-name} solutions through various interfaces.
 :keywords: [ {admc-name}, kubewarden, support, ]

--- a/docs/admission-controller/version-1.37/modules/en/pages/explanations/architecture.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/explanations/architecture.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = {admc-name} architecture
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Discover how {admc-name} uses core Kubernetes features to integrate seamlessly into your cluster.
 :doc-persona: ["kubewarden-all"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/explanations/audit-scanner/audit-scanner.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/explanations/audit-scanner/audit-scanner.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = What is the Audit Scanner?
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about the Audit Scanner's role in continuously verifying cluster compliance with admission controller policies across your clusters.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/explanations/audit-scanner/limitations.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/explanations/audit-scanner/limitations.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Audit Scanner - Limitations
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about limitations when using the Audit Scanner to evaluate policies and event types in a Kubernetes environment, including its use for policy and event type evaluation.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/explanations/audit-scanner/policy-reports.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/explanations/audit-scanner/policy-reports.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Audit Scanner - Policy Reports
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Store and query audit scanner policy scan results using either Report or ClusterReport objects within your Kubernetes cluster.
 :doc-persona: [“kubewarden-user”, “kubewarden-operator”, “kubewarden-policy-developer”, “kubewarden-integrator”]
@@ -19,7 +19,7 @@ scans using the https://openreports.io/[OpenReports] Custom Resources.
 ====
 
 With {admc-name} 1.33, the Audit Scanner feature saves the reports
-into OpenReports CRDs from [openreports.io](https://openreports.io) by default.
+into OpenReports CRDs from https://openreports.io[openreports.io] by default.
 
 The
 link:https://htmlpreview.github.io/?https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/045372e558b896695b2daae92e8c7a04d4d40282/policy-report/docs/index.html[PolicyReport]

--- a/docs/admission-controller/version-1.37/modules/en/pages/explanations/certificates.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/explanations/certificates.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Certificate rotation
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to rotate certificates in your {admc-name} without causing downtime.
 :doc-persona: ["kubewarden-operator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/explanations/comparisons/opa-comparison.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/explanations/comparisons/opa-comparison.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = {admc-name} vs OPA Gatekeeper
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :page-aliases: explanations/opa-comparison.adoc
 :description: Compare OPA Gatekeeper and {admc-name} policy management for Kubernetes environments to determine the best approach for your use case.

--- a/docs/admission-controller/version-1.37/modules/en/pages/explanations/context-aware-policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/explanations/context-aware-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Context aware policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Developers can create context-aware policies that fetch Kubernetes cluster information at runtime to determine AdmissionRequest acceptance criteria.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/explanations/distributing-policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/explanations/distributing-policies.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Distributing policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Distribute policies securely via an OCI-compliant registry using tools like kwctl, and ensure cluster security through {admc-name} policy management.
 :doc-persona: ["kubewarden-operator", "kubewarden-policy-developer", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/explanations/mutating-policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/explanations/mutating-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Mutating policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Rebuild requests by configuring and managing mutating policies within ClusterAdmissionPolicy according to predefined settings.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/explanations/policy-groups.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/explanations/policy-groups.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Policy Groups
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about creating complex policies by combining simpler ones through Policy Groups, specifically using AdmissionPolicyGroup and ClusterAdmissionPolicyGroup definitions.
 :doc-persona: ["kubewarden-operator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/glossary.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/glossary.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Glossary
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore key resources and configurations related to {admc-name} policies in Kubernetes environments for more information.
 :doc-persona: ["kubewarden-all"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/Rancher-Fleet.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/Rancher-Fleet.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Managing {admc-name} with Rancher Fleet
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Manage {admc-name} Helm chart using Rancher Fleet and Kubernetes Custom Resource Definitions (CRDs) to implement a GitOps approach.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/airgap/01-requirements.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/airgap/01-requirements.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Requirements for installing {admc-name} in an air-gapped installation
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about installation requirements for {admc-name} in air-gapped environments, including supported private registries and compatibility details.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/application-collection/01-verify-images.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/application-collection/01-verify-images.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Verify Rancher Application Collection images
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure PolicyServers to authenticate with and pull images from Rancher Application Collection using a Docker Config Secret.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]
@@ -161,7 +161,7 @@ To test it, deploy a Pod with a signed image from Application Collection:
 
 [subs="+attributes",console]
 ----
-$ kubectl run nginx --image [dp.apps.rancher.io/containers/nginx:1.24.0](http://dp.apps.rancher.io/containers/nginx:1.24.0) --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
+$ kubectl run nginx --image dp.apps.rancher.io/containers/nginx:1.24.0 --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
  pod/nginx created
 ----
 

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/argocd-installation.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/argocd-installation.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = ArgoCD Installation
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: ArgoCD Installation
 :sidebar_position: 35

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/audit-scanner.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/audit-scanner.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Audit Scanner
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Verify the compliance state of your clusters using the Audit Scanner feature within {admc-name}, to ensure their proper configuration.
 :doc-persona: ["kubewarden-operator", "kubewarden-distributor", "kubewarden-integrator"]
@@ -51,7 +51,7 @@ The audit scanner is enabled by default. To disable it, set the
 [NOTE]
 ====
 With Kubewarden 1.33, the Audit Scanner feature saves the reports
-into OpenReports CRDs from [openreports.io](https://openreports.io) by default.
+into OpenReports CRDs from https://openreports.io[openreports.io] by default.
 
 The
 link:https://htmlpreview.github.io/?https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/045372e558b896695b2daae92e8c7a04d4d40282/policy-report/docs/index.html[PolicyReport]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/contribution-guide/contributing.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/contribution-guide/contributing.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Contributing to {admc-short-name} documentation
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Contribute to {admc-name} documentation through improvements to existing content, creation of new topics, and assistance with translation.
 :doc-persona: ["kubewarden-developer", "kubewarden-operator", "kubewarden-manager"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/contribution-guide/contribution-guide.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/contribution-guide/contribution-guide.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Contribution guide
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about contributing to SUSE projects with our comprehensive contribution guide, which outlines the steps and best practices.
 :doc-persona: ["kubewarden-developer", "kubewarden-operator", "kubewarden-manager"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/contribution-guide/suggesting-an-improvement.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/contribution-guide/suggesting-an-improvement.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Suggesting a documentation improvement
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Initiate a documentation improvement by opening a GitHub issue with clear details about what's missing, outdated, erroneous, or requires a quality review.
 :doc-persona: ["kubewarden-developer", "kubewarden-operator", "kubewarden-manager"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/custom-certificate-authorities.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/custom-certificate-authorities.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Custom certificate authorities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure custom certificate authorities for use with {admc-name} installations to ensure secure communication and authentication.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/deploy-at-scale.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/deploy-at-scale.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = {admc-name} in a Large-Scale Environment
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure {admc-name}s with {admc-name} to ensure high availability and performance in demanding large-scale environments.
 :keywords: [kubewarden, "{admc-name}", kubernetes, policyservers, production]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/emergency-disable.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/emergency-disable.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Emergency disable
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Emergency disable
 :sidebar_position: 31

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/gatekeeper-migration.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/gatekeeper-migration.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Migrating Gatekeeper Policies to {admc-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure a {admc-name} policy by migrating an existing Gatekeeper policy through two main steps: compiling Rego code into WebAssembly.
 :keywords: ["{admc-name}", kubewarden, gatekeeper]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/host-network.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/host-network.adoc
@@ -68,10 +68,10 @@ instance:
 `spec.webhookPort` and `spec.readinessProbePort` are the fields that directly
 help with host-port conflicts for two main reasons:
 
-1. *Running multiple PolicyServers on the same node.* By assigning different
+. *Running multiple PolicyServers on the same node.* By assigning different
    ports to each PolicyServer, you can schedule them on the same node without
    port conflicts.
-2. *Avoiding conflicts with other host services.* If another service on the
+. *Avoiding conflicts with other host services.* If another service on the
    node already uses a default port, you can change the PolicyServer port to
    avoid the collision.
 

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/install-kwctl.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/install-kwctl.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Installing kwctl ({admc-name} CLI)
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :title: Installing kwctl
 :description: Install kwctl (the {admc-name} CLI) by following its installation instructions for various operating systems, then enable shell completion.

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/kubestellar-console.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/kubestellar-console.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Installing {admc-name} with KubeStellar Console
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: KubeStellar Console
 :sidebar_position: 150

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/pod-security-admission-with-kubewarden.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/pod-security-admission-with-kubewarden.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Using Pod Security Admission with {admc-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure Pod Security Admission in a Kubernetes cluster with {admc-name}'s to secure pods.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Configuring policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure policies by selecting specific Namespaces or setting custom rejection messages, and negate results using AdmissionPolicyGroup.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-groups.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-groups.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = How to use policy groups
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Implement policy groups with specific rules that reject non-compliant Pods based on image signatures and other criteria.
 :doc-persona: ["kubewarden-operator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-servers/01-custom-cas.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-servers/01-custom-cas.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Using custom certificate authorities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure PolicyServer to use either custom certificate authorities or insecure sources in conjunction with specified registries.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-servers/02-private-registry.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-servers/02-private-registry.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Configuring PolicyServers to use private registries
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure PolicyServers to use private registries by creating a Docker configuration secret and configuring the spec.imagePullSecret field in the configuration.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-servers/03-production-deployments.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-servers/03-production-deployments.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Configuring PolicyServers for production
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configuring PolicyServers for production.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-servers/04-using-proxies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-servers/04-using-proxies.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Configuring PolicyServers with proxies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configuring PolicyServers with proxies
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-servers/06-namespaced-policies-capabilities.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-servers/06-namespaced-policies-capabilities.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Controlling host capabilities for namespaced policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Namespaced policy host capabilities
 :sidebar_position: 60
@@ -18,8 +18,8 @@ include::partial$variables.adoc[]
 
 This how-to explains how cluster operators can enforce that promise by:
 
-1. Restricting which host capabilities PolicyServers expose to namespaced policies.
-2. Controlling which PolicyServer a namespaced policy runs on, using the
+. Restricting which host capabilities PolicyServers expose to namespaced policies.
+. Controlling which PolicyServer a namespaced policy runs on, using the
    `ns-policyserver-mapper` policy.
 
 [WARNING]
@@ -189,11 +189,11 @@ The `ns-policyserver-mapper` policy is a mutating `ClusterAdmissionPolicy` that
 intercepts `CREATE` and `UPDATE` requests for `AdmissionPolicy` and
 `AdmissionPolicyGroup` resources. It:
 
-1. Reads the `admission.kubewarden.io/policy-server` label from the `Namespace`
+. Reads the `admission.kubewarden.io/policy-server` label from the `Namespace`
    in which the policy is being deployed.
-2. Mutates the policy's `spec.policyServer` field to the value of that label,
+. Mutates the policy's `spec.policyServer` field to the value of that label,
    overriding whatever the user specified.
-3. *Rejects* the request if the Namespace does not have the label, preventing
+. *Rejects* the request if the Namespace does not have the label, preventing
    policies from being silently scheduled on an unintended PolicyServer.
 
 === Labeling Namespaces

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-servers/07-host-capability-call-reference.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/policy-servers/07-host-capability-call-reference.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Host capabilities call reference
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Capabilities call reference
 :description: List of all host capabilities calls.

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/production-deployments.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/production-deployments.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Configuring the {admc-name} stack for production
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure tolerations and affinity rules for optimal scheduling and reliability within the {admc-name} stack in a Kubernetes cluster.
 :keywords: ["{admc-name}", kubewarden, kubernetes, policyservers, production, poddisruptionbudget, affinity, limits, tolerations, priorityclass]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/psp-migration.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/psp-migration.adoc
@@ -11,7 +11,7 @@ include::partial$variables.adoc[]
 
 = {title}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 
 For Kubernetes ≥ v1.25.

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/rancher-backup-operator.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/rancher-backup-operator.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Backup and restore with Rancher Backup Operator
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure and manage backups and restores using the rancher-backup operator on any Kubernetes cluster.
 :keywords: "{admc-name}", kubernetes, kubewarden, rancher backup operator, backup, restore

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/raw-policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/raw-policies.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Raw policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure raw policies as a generic policy evaluation engine using {admc-name}.
 :doc-persona: ["kubewarden-distributor", "kubewarden-integrator", "kubewarden-operator", "kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/security-hardening/secure-supply-chain.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/security-hardening/secure-supply-chain.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Secure supply chain
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure {admc-name} to validate the integrity of artifact signatures and admission policies.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/security-hardening/security-hardening.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/security-hardening/security-hardening.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Security hardening
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Security hardening
 :sidebar_position: 50

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/security-hardening/webhook-mtls.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/security-hardening/webhook-mtls.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Secure webhooks with mutual TLS with K3s
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Enable mTLS with K3s
 :description: Implement mutual Transport Layer Security (mTLS) protocols for secure webhooks with K3s in your SUSE Kubernetes distribution.

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/tasks.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/tasks.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Common tasks
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Manage policies in your Kubernetes cluster with {admc-name} using the kwctl CLI tool.
 :doc-persona: ["kubewarden-all"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/telemetry/10-opentelemetry-qs.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/telemetry/10-opentelemetry-qs.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Open Telemetry quick start
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure and deploy the OpenTelemetry collector in sidecar mode using the official Kubernetes Helm chart for simple and enhanced deployment.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/telemetry/20-tracing-qs.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/telemetry/20-tracing-qs.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Tracing quickstart
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Enable tracing support for the Policy Server using this quickstart guide to collect fine-grained details about policy evaluations, which can be used to debug SUSE Security Admission issues.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/telemetry/30-metrics-qs.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/telemetry/30-metrics-qs.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Metrics quickstart
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure metrics reporting on the Policy Server using Prometheus and {admc-name} enabled through Helm charts for data collection.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/telemetry/40-custom-otel-collector.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/telemetry/40-custom-otel-collector.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Custom OpenTelemetry Collector
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure the {admc-name} to securely send telemetry data to a custom OpenTelemetry Collector deployed within the cluster.
 :keywords: kubewarden, kubernetes, metrics, tracing, opentelemetry

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/ui-extension/02-metrics.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/ui-extension/02-metrics.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Monitoring
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure monitoring for Rancher environments by integrating with the {admc-name} and Prometheus.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/ui-extension/03-tracing.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/ui-extension/03-tracing.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Tracing
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Enable tracing for fine-grained details about policy evaluations and debug issues related to the {admc-name} deployment.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/vap-migration.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/vap-migration.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = ValidatingAdmissionPolicy migration
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Migrate a ValidatingAdmissionPolicy to {admc-name} via the kwctl command's migration steps for a smooth policy transition.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/howtos/workarounds/policy-server-certificate-expiry.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/howtos/workarounds/policy-server-certificate-expiry.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Policy Server certificate rotation issue for release ≤ v1.16.0
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Resolve policy server certificate rotation issues in {admc-name}, starting with version 1.16.
 :doc-persona: ["kubewarden-operator", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/introduction.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/introduction.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = What is {admc-name}?
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about {admc-name}'s role in Kubernetes policy management, which includes enforcing compliance and optimizing resources.
 :doc-persona: ["kubewarden-all"]
@@ -93,6 +93,7 @@ https://github.com/opencontainers/artifacts[OCI artifacts].
 
 ifeval::["{build-type}" == "community"]
 
+[#_vendor_neutrality]
 == Vendor neutrality
 
 {admc-short-name} is a

--- a/docs/admission-controller/version-1.37/modules/en/pages/organization.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/organization.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Documentation organization
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Organization
 :sidebar_position: 75

--- a/docs/admission-controller/version-1.37/modules/en/pages/personas.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/personas.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Who is this project for? The personas.
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Who is this project for? The personas.
 :keywords: ["{admc-name}", kubewarden, documentation, personas]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/CRDs.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/CRDs.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Custom Resource Definitions (CRD)
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about Custom Resource Definitions (CRDs) for {admc-name}, and access related API references.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/artifacts.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/artifacts.adoc
@@ -7,7 +7,7 @@ include::partial$variables.adoc[]
 :doc-type: [reference]
 :doc-topic: [operator-manual, artifacts, registry, images]
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/dependency-matrix.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/dependency-matrix.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Dependency matrix
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about the dependencies of the {admc-name}, including their version constraints.
 :doc-persona: [“kubewarden-all”]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/metrics-reference.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/metrics-reference.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Metrics reference
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore cluster metrics and patterns with {admc-name}'s exposed platform metrics to inform decision-making processes.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-integrator"]
@@ -39,6 +39,7 @@ key-value attributes are added to the metric to provide additional information.
 | <<_kubewarden_policy_evaluations_total,Baggage>>
 |===
 
+[#_kubewarden_policy_evaluations_total]
 ==== `kubewarden_policy_evaluations_total`
 
 ===== Baggage

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/monitor-mode.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/monitor-mode.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Monitor mode
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure ClusterAdmissionPolicies or AdmissionPolicies for monitor mode to track and analyze policy actions without modifying incoming requests.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/oci-registries-support.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/oci-registries-support.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = OCI registry support for {admc-short-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Distribute {admc-name} policies as OCI artifacts via regular Open Container Initiative (OCI) registries.
 :doc-persona: ["kubewarden-all"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/policy-evaluation-timeout.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/policy-evaluation-timeout.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Policy evaluation timeout protection
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure policy evaluation timeouts to ensure timely completion and prevent resource exhaustion with the Policy Server's built-in protection feature.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]
@@ -73,7 +73,7 @@ timeout.
 Starting with {admc-short-name} v1.29.0, every {admc-short-name} Policy can set its own
 timeout value via its `spec.timeoutEvalSeconds` attribute. This is not to be
 confused with `spec.timeoutSeconds`, used for the Webhook timeout (see section
-#comparison-with-kubernetes-dynamic-admission-controller-timeout[below]).
+<<_comparison_with_kubernetes_dynamic_admission_controller_timeout,below>>).
 
 The `spec.timeoutEvalSeconds` is fine-grained, allowing per-Policy tuning of
 their evaluation timeout.
@@ -161,6 +161,7 @@ spec:
       value: "3"
 ----
 
+[#_comparison_with_kubernetes_dynamic_admission_controller_timeout]
 == Comparison with Kubernetes Dynamic Admission Controller timeout
 
 {admc-short-name} is a https://en.wikipedia.org/wiki/Webhook[webhook] implementation of the https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[Kubernetes Dynamic Admission Controller].

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/security-hardening/webhooks-hardening.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/security-hardening/webhooks-hardening.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Hardening the {admc-short-name} webhooks
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Webhooks
 :description: Configure network policies and authentication to limit access to webhooks in your Kubernetes cluster, specifically restricting connections from invalid callers.

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/sources_yaml.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/sources_yaml.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Reference for sources.yaml
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure your sources.yaml file to work with PolicyServer CRs by specifying the path and format for source authorities, as well as insecure sources.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/01-intro-spec.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/01-intro-spec.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Policy communication specification
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Discover how to effectively use the {admc-name} policies through a well-defined API enabling seamless interaction and communication.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/02-settings.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/02-settings.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Policy settings
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure policy settings using {admc-name}'s for validation and serialization of policy data.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/03-validating-policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/03-validating-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Validating policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Evaluate your validation requests using policy-specific settings to determine acceptance or rejection of Kubernetes AdmissionReview objects.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/04-mutating-policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/04-mutating-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Mutating policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure mutating policies by implementing validation functions (validate and validate_settings) in a waPC (whatever-after Policy Configurator) for proposing object mutations in Kubernetes clusters.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/05-context-aware-policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/05-context-aware-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Context aware policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore context-aware policy capabilities in admission control, including resource access and caching, to optimize policy evaluation.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/01-intro-host-capabilities.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/01-intro-host-capabilities.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Host capabilities specification
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: During evaluation, understand the host capabilities offered by the environment for {admc-name} policies.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/02-signature-verifier-policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/02-signature-verifier-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Signature verifier policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Implement secure policies for your cluster using the provided verifier policy, or build upon it with your chosen language SDK.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/03-container-registry.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/03-container-registry.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Container registry capabilities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore container registry capabilities including calculating OCI manifest digests and fetching OCI object manifests.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/04-net.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/04-net.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Network capabilities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about network capabilities and how to use host functions for DNS lookups, as well as communication protocols.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/05-crypto.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/05-crypto.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Cryptographic capabilities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about the cryptographic capabilities and functions of the Wasm host for evaluating PKI certificates in use.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/06-kubernetes.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/06-kubernetes.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Kubernetes capabilities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore Kubernetes capabilities using {admc-name}'s context-aware policies and the waPC protocol to access cluster resources.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/07-host-capability-call-reference.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/spec/host-capabilities/07-host-capability-call-reference.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Host capabilities call reference
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: List of all host capabilities calls
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/threat-model.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/threat-model.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Threat Model
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Read and understand the Admission Control Threat Model to devise your own circumstance-specific threat model, ensuring secure defaults within Kubernetes.
 :doc-persona: ["kubewarden-all"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/reference/verification-config.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/reference/verification-config.adoc
@@ -9,7 +9,7 @@ include::partial$variables.adoc[]
 
 = Verification configuration format
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 
 == Introduction

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/publish-policy-to-artifact-hub.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/publish-policy-to-artifact-hub.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Publish policies to Artifact Hub
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Publish {admc-name} policies to Artifact Hub by creating a well-formatted Git repository layout and configuring GitHub Actions for automated packaging, facilitating continuous integration.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-policy-developer", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/testing-policies/02-policy-authors.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/testing-policies/02-policy-authors.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Testing for policy authors
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to test policy authors with kwctl, either using bats or standard testing, specifically for {admc-name} policies in Wasm.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/testing-policies/03-cluster-operators.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/testing-policies/03-cluster-operators.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Testing for cluster operators
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Test cluster operator policies with kwctl using different configurations and validation request objects to validate policy settings.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/testing-policies/index.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/testing-policies/index.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Policy testing
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to create and test {admc-name} Policies with {admc-name} for secure cluster management.
 :doc-persona: ["kubewarden-operator", "kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/verifying-kubewarden.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/verifying-kubewarden.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Verifying {admc-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Verify different artifacts produced by the {admc-name} team to ensure a secure supply chain through use of SBOMs and provenance files.
 :doc-persona: ["kubewarden-operator", "kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/CEL/01-intro-cel.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/CEL/01-intro-cel.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Introduction to CEL
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about CEL (Computation Expression Language) as a fast, portable, and safe expression language designed for Kubernetes validation rules and extensions to the Kubernetes API.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Reusing ValidatingAdmissionPolicies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about reusing and validating admission policies in Kubernetes using {admc-name}'s (cel-policy).
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Context-aware CEL policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure context-aware policies to ensure unique Ingress rules across hosts, preventing conflicts with {admc-name}'s CEL extension libraries.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/CEL/04-example-sigstore.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/CEL/04-example-sigstore.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Sigstore host capabilities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to implement Sigstore host capabilities using CEL policies in Kubewarden to verify container images and enforce secure admission control.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/dotnet.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/dotnet.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = C#
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore and write validation and mutation of admission control policies using .NET Core SDK with WASI support on WebAssembly platforms like Kubernetes.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/01-intro-go.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/01-intro-go.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Writing policies in Go
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Write effective admission controller validation policies using TinyGo, using its useful libraries and tools designed specifically for Go developers.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/02-scaffold.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/02-scaffold.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Creating a new validation policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore creating a new validation policy that rejects Pods with deny-list labels, while validating labels with user-provided regular expressions to ensure security.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/03-policy-settings.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/03-policy-settings.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Defining policy settings
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Modify the code in the settings.go file to define policy settings, including implementation of custom functions for marshaling and unmarshaling regular expressions.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/04-validation.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/04-validation.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Writing the validation logic
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to write and test validation logic in Go by extracting relevant information from incoming payloads and creating setting objects.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/05-e2e-tests.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/05-e2e-tests.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = End-to-end testing
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Discover how to write and automate end-to-end tests running against the WebAssembly binary produced by TinyGo with bats and kwctl.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/06-logging.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/06-logging.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Logging
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure logger initialization for structured logging in your policy using the oneLog project's Go SDK integration.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/07-automate.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/07-automate.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Integrating with GitHub Actions
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about integrating GitHub Actions for automated tasks, unit testing, end-to-end testing, and CI/CD workflows.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/08-distribute.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/08-distribute.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Distributing policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to distribute policies and access related information for {admc-name}, including configuration details.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/09-validation-with-queries.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/09-validation-with-queries.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Validation using JSON queries
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Implement validation logic using JSON queries by extracting relevant data from a Kubernetes object's JSON representation.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/10-raw-policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/go/10-raw-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Writing raw policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn to write raw policies that can evaluate arbitrary JSON documents for validation and mutation, allowing for flexible data processing.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/index.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/index.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Writing {admc-name} policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Develop admission controller policies by exposing well-defined functionalities via a specific API using any supported programming language.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/metadata.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/metadata.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Policy metadata
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure policy metadata in the metadata.yaml file to define policy settings, author information, and resource permissions.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/other-languages.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/other-languages.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Other languages
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about writing {admc-name} policies using various programming languages that target WebAssembly modules and the WASI interface.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/01-intro-rego.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/01-intro-rego.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Rego
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about Rego language basics, including its use in conjunction with Open Policy Agent and Gatekeeper frameworks to implement policies as code.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Builtin support
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Determine which built-in functions are available for WebAssembly modules and understand their implementation and use in Rego policy development.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/01-intro.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/01-intro.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Gatekeeper support
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Access central gatekeeper policies and learn how to integrate them with Kubernetes admission controllers.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/02-create-policy.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/02-create-policy.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Creating a new Gatekeeper Rego policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Implement Gatekeeper Rego policies to reject resources targeting the default namespace by creating and testing a new policy.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/03-build-and-run.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/03-build-and-run.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Build and run a Gatekeeper policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Develop and deploy a Gatekeeper policy using familiar Rego syntax and tools to enforce admission control within Kubernetes environments.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/04-distribute.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/04-distribute.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Distributing a Gatekeeper policy with {admc-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Distribute Gatekeeper policies across Kubernetes clusters by annotating policy files with metadata and deploying them via ClusterAdmissionPolicy.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/01-intro.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/01-intro.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Introduction to Open Policy Agent
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how the Open Policy Agent uses the Rego language to write policies that evaluate and produce outputs for secure decision-making.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/02-create-policy.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/02-create-policy.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Creating a new policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Create a policy that evaluates all namespaced resources and forbids their creation in the default namespace for hands-on learning.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/03-build-and-run.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/03-build-and-run.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Build and run a OPA policy for {admc-short-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Build a custom OPA policy for your project by constructing a Rego policy package, compiling it into a WASM target, and integrating with kwctl.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/04-distribute.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/04-distribute.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Distributing an OPA policy with {admc-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Annotate your Rego policy with relevant metadata, then push it to an OCI registry to prepare for deployment.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/05-raw-policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/05-raw-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Writing raw policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to write raw policies that evaluate arbitrary JSON documents and enforce access control rules in your system.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/01-intro-rust.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/01-intro-rust.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Rust
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to write admission controller policies in Rust with SUSE's security admission controllers simplified SDK and template projects.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/02-create-policy.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/02-create-policy.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Creating a policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn to create and configure validation policies that control Pod creation requests based on customizable rejection criteria.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/03-define-policy-settings.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/03-define-policy-settings.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Defining policy settings
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Define policy settings and structure in your code to establish a foundation for validating policy integrity through efficient setting management. Ensure that all changes are tracked, such as who made the change, when, and what was changed.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/04-write-validation-logic.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/04-write-validation-logic.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Writing validation logic
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Write validation logic to check the validity of incoming requests by parsing payloads and verifying Pod objects.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/05-mutation-policy.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/05-mutation-policy.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Creating a new mutation policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure a new {admc-name} mutation policy to mutate incoming objects with custom annotations, then test it.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/06-logging.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/06-logging.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Logging
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure logging capabilities for your policy by using the {admc-name}'s integration with the SLOG library and initializing.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/07-build-and-distribute.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/07-build-and-distribute.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Building and distributing policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Follow these essential steps to build and distribute policies effectively for your {admc-name} setup.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/08-raw-policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/rust/08-raw-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Raw policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about raw policies that evaluate arbitrary JSON documents, as well as view examples of policy implementation in Rust.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/swift.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/swift.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Swift
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to use the Swift compiler with WebAssembly support through SwiftWasm to access tools for building {admc-name} policies.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/typescript/01-intro-typescript.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/typescript/01-intro-typescript.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Writing policies in TypeScript/JavaScript
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to write effective {admc-name} validation policies using TypeScript/JavaScript.
 :keywords: kubewarden, kubernetes, writing policies in TypeScript, writing policies in JavaScript

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/typescript/02-scaffold.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/typescript/02-scaffold.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Creating a new validation policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Create a new validation policy to reject invalid hostnames in Pod objects through configuration of policy settings, tested with provided tools.
 :keywords: {admc-name}, kubewarden, kubernetes, writing policies in TypeScript, new validation policy

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/typescript/03-policy-settings.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/typescript/03-policy-settings.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Defining policy settings
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Define and implement effective policy settings structures through {admc-name} policies in src/types.ts and src/index.ts files.
 :keywords: "{admc-name}", kubewarden, kubernetes, defining policy settings, TypeScript

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/typescript/04-validation.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/typescript/04-validation.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Writing the validation logic
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Write the validation logic for Kubernetes resources in the src/index.ts file, accessing the incoming request data to return a response.
 :keywords: "{admc-name}", kubewarden, kubernetes, writing policies, typescript

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/typescript/05-e2etests.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/typescript/05-e2etests.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = End-to-end testing
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to write and run comprehensive end-to-end tests for policy behavior using BATS and kwctl.
 :keywords: "{admc-name}", kubewarden, kubernetes, testing policies, typescript, e2e testing

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/wasi/01-intro-wasi.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/wasi/01-intro-wasi.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = WASI
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Write WASI policies that interact with system primitives when a limitation in the Go compiler prevents using the waPC communication mechanism.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/wasi/02-raw-policies.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/tutorials/writing-policies/wasi/02-raw-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Writing raw policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Write raw policies that evaluate arbitrary JSON documents by defining custom validation and mutation logic for.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.37/modules/en/pages/use-cases.adoc
+++ b/docs/admission-controller/version-1.37/modules/en/pages/use-cases.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = {admc-name} use cases
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Use cases
 :sidebar_position: 74

--- a/docs/admission-controller/version-1.38/modules/en/pages/disclosure.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/disclosure.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Security disclosure
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Investigative security researchers work with the {project-security-team} to identify vulnerabilities using responsible disclosure protocols.
 :doc-persona: ["kubewarden-all"]
@@ -25,13 +25,13 @@ On {admc-short-name}'s side, this means:
 * {admc-short-name} always transparently lets the community know about any incident that
   affects them.
 
-If you have found a security vulnerability in Kubewarden, the easiest way to
+If you have found a security vulnerability in {admc-name}, the easiest way to
 report a vulnerability is through the Security tab on GitHub for the specific
 repo. This mechanism allows maintainers to communicate privately with you,
 and you don't need to encrypt your messages.
 
 Alternatively, you can disclose it responsibly by emailing
-xref:mailto:cncf-kubewarden-maintainers@lists.cncf.io.adoc[cncf-kubewarden-maintainers@lists.cncf.io]
+mailto:cncf-kubewarden-maintainers@lists.cncf.io[cncf-kubewarden-maintainers@lists.cncf.io]
 in an *unencrypted* message. Please don't discuss potential vulnerabilities in
 public without validating with us first.
 

--- a/docs/admission-controller/version-1.38/modules/en/pages/enterprise.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/enterprise.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Enterprise support
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Access centralized information on enterprise support for {admc-name} solutions through various interfaces.
 :keywords: [ {admc-name}, kubewarden, support, ]

--- a/docs/admission-controller/version-1.38/modules/en/pages/explanations/architecture.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/explanations/architecture.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = {admc-name} architecture
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Discover how {admc-name} uses core Kubernetes features to integrate seamlessly into your cluster.
 :doc-persona: ["kubewarden-all"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/explanations/audit-scanner/audit-scanner.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/explanations/audit-scanner/audit-scanner.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = What is the Audit Scanner?
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about the Audit Scanner's role in continuously verifying cluster compliance with admission controller policies across your clusters.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/explanations/audit-scanner/limitations.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/explanations/audit-scanner/limitations.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Audit Scanner - Limitations
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about limitations when using the Audit Scanner to evaluate policies and event types in a Kubernetes environment, including its use for policy and event type evaluation.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/explanations/audit-scanner/policy-reports.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/explanations/audit-scanner/policy-reports.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Audit Scanner - Policy Reports
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Store and query audit scanner policy scan results using either Report or ClusterReport objects within your Kubernetes cluster.
 :doc-persona: [“kubewarden-user”, “kubewarden-operator”, “kubewarden-policy-developer”, “kubewarden-integrator”]
@@ -19,7 +19,7 @@ scans using the https://openreports.io/[OpenReports] Custom Resources.
 ====
 
 With {admc-name} 1.33, the Audit Scanner feature saves the reports
-into OpenReports CRDs from [openreports.io](https://openreports.io) by default.
+into OpenReports CRDs from https://openreports.io[openreports.io] by default.
 
 The
 link:https://htmlpreview.github.io/?https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/045372e558b896695b2daae92e8c7a04d4d40282/policy-report/docs/index.html[PolicyReport]

--- a/docs/admission-controller/version-1.38/modules/en/pages/explanations/certificates.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/explanations/certificates.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Certificate rotation
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to rotate certificates in your {admc-name} without causing downtime.
 :doc-persona: ["kubewarden-operator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/explanations/comparisons/opa-comparison.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/explanations/comparisons/opa-comparison.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = {admc-name} vs OPA Gatekeeper
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :page-aliases: explanations/opa-comparison.adoc
 :description: Compare OPA Gatekeeper and {admc-name} policy management for Kubernetes environments to determine the best approach for your use case.

--- a/docs/admission-controller/version-1.38/modules/en/pages/explanations/context-aware-policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/explanations/context-aware-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Context aware policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Developers can create context-aware policies that fetch Kubernetes cluster information at runtime to determine AdmissionRequest acceptance criteria.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/explanations/distributing-policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/explanations/distributing-policies.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Distributing policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Distribute policies securely via an OCI-compliant registry using tools like kwctl, and ensure cluster security through {admc-name} policy management.
 :doc-persona: ["kubewarden-operator", "kubewarden-policy-developer", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/explanations/mutating-policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/explanations/mutating-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Mutating policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Rebuild requests by configuring and managing mutating policies within ClusterAdmissionPolicy according to predefined settings.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/explanations/policy-groups.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/explanations/policy-groups.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Policy Groups
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about creating complex policies by combining simpler ones through Policy Groups, specifically using AdmissionPolicyGroup and ClusterAdmissionPolicyGroup definitions.
 :doc-persona: ["kubewarden-operator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/glossary.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/glossary.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Glossary
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore key resources and configurations related to {admc-name} policies in Kubernetes environments for more information.
 :doc-persona: ["kubewarden-all"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/Rancher-Fleet.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/Rancher-Fleet.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Managing {admc-name} with Rancher Fleet
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Manage {admc-name} Helm chart using Rancher Fleet and Kubernetes Custom Resource Definitions (CRDs) to implement a GitOps approach.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/airgap/01-requirements.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/airgap/01-requirements.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Requirements for installing {admc-name} in an air-gapped installation
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about installation requirements for {admc-name} in air-gapped environments, including supported private registries and compatibility details.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/application-collection/01-verify-images.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/application-collection/01-verify-images.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Verify Rancher Application Collection images
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure PolicyServers to authenticate with and pull images from Rancher Application Collection using a Docker Config Secret.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]
@@ -161,7 +161,7 @@ To test it, deploy a Pod with a signed image from Application Collection:
 
 [subs="+attributes",console]
 ----
-$ kubectl run nginx --image [dp.apps.rancher.io/containers/nginx:1.24.0](http://dp.apps.rancher.io/containers/nginx:1.24.0) --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
+$ kubectl run nginx --image dp.apps.rancher.io/containers/nginx:1.24.0 --overrides='{"spec": {"imagePullSecrets":[{"name": "application-collection"}]}}'
  pod/nginx created
 ----
 

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/argocd-installation.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/argocd-installation.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = ArgoCD Installation
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: ArgoCD Installation
 :sidebar_position: 35

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/audit-scanner.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/audit-scanner.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Audit Scanner
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Verify the compliance state of your clusters using the Audit Scanner feature within {admc-name}, to ensure their proper configuration.
 :doc-persona: ["kubewarden-operator", "kubewarden-distributor", "kubewarden-integrator"]
@@ -51,7 +51,7 @@ The audit scanner is enabled by default. To disable it, set the
 [NOTE]
 ====
 With Kubewarden 1.33, the Audit Scanner feature saves the reports
-into OpenReports CRDs from [openreports.io](https://openreports.io) by default.
+into OpenReports CRDs from https://openreports.io[openreports.io] by default.
 
 The
 link:https://htmlpreview.github.io/?https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/045372e558b896695b2daae92e8c7a04d4d40282/policy-report/docs/index.html[PolicyReport]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/contribution-guide/contributing.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/contribution-guide/contributing.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Contributing to {admc-short-name} documentation
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Contribute to {admc-name} documentation through improvements to existing content, creation of new topics, and assistance with translation.
 :doc-persona: ["kubewarden-developer", "kubewarden-operator", "kubewarden-manager"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/contribution-guide/contribution-guide.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/contribution-guide/contribution-guide.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Contribution guide
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about contributing to SUSE projects with our comprehensive contribution guide, which outlines the steps and best practices.
 :doc-persona: ["kubewarden-developer", "kubewarden-operator", "kubewarden-manager"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/contribution-guide/suggesting-an-improvement.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/contribution-guide/suggesting-an-improvement.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Suggesting a documentation improvement
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Initiate a documentation improvement by opening a GitHub issue with clear details about what's missing, outdated, erroneous, or requires a quality review.
 :doc-persona: ["kubewarden-developer", "kubewarden-operator", "kubewarden-manager"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/custom-certificate-authorities.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/custom-certificate-authorities.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Custom certificate authorities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure custom certificate authorities for use with {admc-name} installations to ensure secure communication and authentication.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/deploy-at-scale.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/deploy-at-scale.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = {admc-name} in a Large-Scale Environment
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure {admc-name}s with {admc-name} to ensure high availability and performance in demanding large-scale environments.
 :keywords: [kubewarden, "{admc-name}", kubernetes, policyservers, production]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/emergency-disable.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/emergency-disable.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Emergency disable
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Emergency disable
 :sidebar_position: 31

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/gatekeeper-migration.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/gatekeeper-migration.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Migrating Gatekeeper Policies to {admc-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure a {admc-name} policy by migrating an existing Gatekeeper policy through two main steps: compiling Rego code into WebAssembly.
 :keywords: ["{admc-name}", kubewarden, gatekeeper]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/host-network.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/host-network.adoc
@@ -68,10 +68,10 @@ instance:
 `spec.webhookPort` and `spec.readinessProbePort` are the fields that directly
 help with host-port conflicts for two main reasons:
 
-1. *Running multiple PolicyServers on the same node.* By assigning different
+. *Running multiple PolicyServers on the same node.* By assigning different
    ports to each PolicyServer, you can schedule them on the same node without
    port conflicts.
-2. *Avoiding conflicts with other host services.* If another service on the
+. *Avoiding conflicts with other host services.* If another service on the
    node already uses a default port, you can change the PolicyServer port to
    avoid the collision.
 

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/install-kwctl.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/install-kwctl.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Installing kwctl ({admc-name} CLI)
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :title: Installing kwctl
 :description: Install kwctl (the {admc-name} CLI) by following its installation instructions for various operating systems, then enable shell completion.

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/kubestellar-console.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/kubestellar-console.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Installing {admc-name} with KubeStellar Console
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: KubeStellar Console
 :sidebar_position: 150

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/pod-security-admission-with-kubewarden.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/pod-security-admission-with-kubewarden.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Using Pod Security Admission with {admc-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure Pod Security Admission in a Kubernetes cluster with {admc-name}'s to secure pods.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Configuring policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure policies by selecting specific Namespaces or setting custom rejection messages, and negate results using AdmissionPolicyGroup.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-groups.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-groups.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = How to use policy groups
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Implement policy groups with specific rules that reject non-compliant Pods based on image signatures and other criteria.
 :doc-persona: ["kubewarden-operator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-servers/01-custom-cas.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-servers/01-custom-cas.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Using custom certificate authorities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure PolicyServer to use either custom certificate authorities or insecure sources in conjunction with specified registries.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-servers/02-private-registry.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-servers/02-private-registry.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Configuring PolicyServers to use private registries
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure PolicyServers to use private registries by creating a Docker configuration secret and configuring the spec.imagePullSecret field in the configuration.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-servers/03-production-deployments.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-servers/03-production-deployments.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Configuring PolicyServers for production
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configuring PolicyServers for production.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-servers/04-using-proxies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-servers/04-using-proxies.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Configuring PolicyServers with proxies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configuring PolicyServers with proxies
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-servers/06-namespaced-policies-capabilities.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-servers/06-namespaced-policies-capabilities.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Controlling host capabilities for namespaced policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Namespaced policy host capabilities
 :sidebar_position: 60
@@ -18,8 +18,8 @@ include::partial$variables.adoc[]
 
 This how-to explains how cluster operators can enforce that promise by:
 
-1. Restricting which host capabilities PolicyServers expose to namespaced policies.
-2. Controlling which PolicyServer a namespaced policy runs on, using the
+. Restricting which host capabilities PolicyServers expose to namespaced policies.
+. Controlling which PolicyServer a namespaced policy runs on, using the
    `ns-policyserver-mapper` policy.
 
 [WARNING]
@@ -189,11 +189,11 @@ The `ns-policyserver-mapper` policy is a mutating `ClusterAdmissionPolicy` that
 intercepts `CREATE` and `UPDATE` requests for `AdmissionPolicy` and
 `AdmissionPolicyGroup` resources. It:
 
-1. Reads the `admission.kubewarden.io/policy-server` label from the `Namespace`
+. Reads the `admission.kubewarden.io/policy-server` label from the `Namespace`
    in which the policy is being deployed.
-2. Mutates the policy's `spec.policyServer` field to the value of that label,
+. Mutates the policy's `spec.policyServer` field to the value of that label,
    overriding whatever the user specified.
-3. *Rejects* the request if the Namespace does not have the label, preventing
+. *Rejects* the request if the Namespace does not have the label, preventing
    policies from being silently scheduled on an unintended PolicyServer.
 
 === Labeling Namespaces

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-servers/07-host-capability-call-reference.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/policy-servers/07-host-capability-call-reference.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Host capabilities call reference
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Capabilities call reference
 :description: List of all host capabilities calls.

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/production-deployments.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/production-deployments.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Configuring the {admc-name} stack for production
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure tolerations and affinity rules for optimal scheduling and reliability within the {admc-name} stack in a Kubernetes cluster.
 :keywords: ["{admc-name}", kubewarden, kubernetes, policyservers, production, poddisruptionbudget, affinity, limits, tolerations, priorityclass]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/psp-migration.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/psp-migration.adoc
@@ -11,7 +11,7 @@ include::partial$variables.adoc[]
 
 = {title}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 
 For Kubernetes ≥ v1.25.

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/rancher-backup-operator.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/rancher-backup-operator.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Backup and restore with Rancher Backup Operator
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure and manage backups and restores using the rancher-backup operator on any Kubernetes cluster.
 :keywords: "{admc-name}", kubernetes, kubewarden, rancher backup operator, backup, restore

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/raw-policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/raw-policies.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Raw policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure raw policies as a generic policy evaluation engine using {admc-name}.
 :doc-persona: ["kubewarden-distributor", "kubewarden-integrator", "kubewarden-operator", "kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/security-hardening/secure-supply-chain.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/security-hardening/secure-supply-chain.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Secure supply chain
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure {admc-name} to validate the integrity of artifact signatures and admission policies.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/security-hardening/security-hardening.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/security-hardening/security-hardening.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Security hardening
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Security hardening
 :sidebar_position: 50

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/security-hardening/webhook-mtls.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/security-hardening/webhook-mtls.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Secure webhooks with mutual TLS with K3s
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Enable mTLS with K3s
 :description: Implement mutual Transport Layer Security (mTLS) protocols for secure webhooks with K3s in your SUSE Kubernetes distribution.

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/tasks.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/tasks.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Common tasks
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Manage policies in your Kubernetes cluster with {admc-name} using the kwctl CLI tool.
 :doc-persona: ["kubewarden-all"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/telemetry/10-opentelemetry-qs.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/telemetry/10-opentelemetry-qs.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Open Telemetry quick start
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure and deploy the OpenTelemetry collector in sidecar mode using the official Kubernetes Helm chart for simple and enhanced deployment.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/telemetry/20-tracing-qs.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/telemetry/20-tracing-qs.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Tracing quickstart
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Enable tracing support for the Policy Server using this quickstart guide to collect fine-grained details about policy evaluations, which can be used to debug SUSE Security Admission issues.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/telemetry/30-metrics-qs.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/telemetry/30-metrics-qs.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Metrics quickstart
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure metrics reporting on the Policy Server using Prometheus and {admc-name} enabled through Helm charts for data collection.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/telemetry/40-custom-otel-collector.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/telemetry/40-custom-otel-collector.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Custom OpenTelemetry Collector
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure the {admc-name} to securely send telemetry data to a custom OpenTelemetry Collector deployed within the cluster.
 :keywords: kubewarden, kubernetes, metrics, tracing, opentelemetry

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/ui-extension/02-metrics.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/ui-extension/02-metrics.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Monitoring
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure monitoring for Rancher environments by integrating with the {admc-name} and Prometheus.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/ui-extension/03-tracing.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/ui-extension/03-tracing.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Tracing
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Enable tracing for fine-grained details about policy evaluations and debug issues related to the {admc-name} deployment.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/vap-migration.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/vap-migration.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = ValidatingAdmissionPolicy migration
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Migrate a ValidatingAdmissionPolicy to {admc-name} via the kwctl command's migration steps for a smooth policy transition.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/workarounds/policy-server-certificate-expiry.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/workarounds/policy-server-certificate-expiry.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Policy Server certificate rotation issue for release ≤ v1.16.0
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Resolve policy server certificate rotation issues in {admc-name}, starting with version 1.16.
 :doc-persona: ["kubewarden-operator", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/introduction.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/introduction.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = What is {admc-name}?
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about {admc-name}'s role in Kubernetes policy management, which includes enforcing compliance and optimizing resources.
 :doc-persona: ["kubewarden-all"]
@@ -93,6 +93,7 @@ https://github.com/opencontainers/artifacts[OCI artifacts].
 
 ifeval::["{build-type}" == "community"]
 
+[#_vendor_neutrality]
 == Vendor neutrality
 
 {admc-short-name} is a

--- a/docs/admission-controller/version-1.38/modules/en/pages/organization.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/organization.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Documentation organization
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Organization
 :sidebar_position: 75

--- a/docs/admission-controller/version-1.38/modules/en/pages/personas.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/personas.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Who is this project for? The personas.
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Who is this project for? The personas.
 :keywords: ["{admc-name}", kubewarden, documentation, personas]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/CRDs.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/CRDs.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Custom Resource Definitions (CRD)
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about Custom Resource Definitions (CRDs) for {admc-name}, and access related API references.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/artifacts.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/artifacts.adoc
@@ -7,7 +7,7 @@ include::partial$variables.adoc[]
 :doc-type: [reference]
 :doc-topic: [operator-manual, artifacts, registry, images]
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 
 = {title}

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/dependency-matrix.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/dependency-matrix.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Dependency matrix
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about the dependencies of the {admc-name}, including their version constraints.
 :doc-persona: [“kubewarden-all”]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/metrics-reference.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/metrics-reference.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Metrics reference
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore cluster metrics and patterns with {admc-name}'s exposed platform metrics to inform decision-making processes.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-integrator"]
@@ -39,6 +39,7 @@ key-value attributes are added to the metric to provide additional information.
 | <<_kubewarden_policy_evaluations_total,Baggage>>
 |===
 
+[#_kubewarden_policy_evaluations_total]
 ==== `kubewarden_policy_evaluations_total`
 
 ===== Baggage

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/monitor-mode.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/monitor-mode.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Monitor mode
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure ClusterAdmissionPolicies or AdmissionPolicies for monitor mode to track and analyze policy actions without modifying incoming requests.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/oci-registries-support.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/oci-registries-support.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = OCI registry support for {admc-short-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Distribute {admc-name} policies as OCI artifacts via regular Open Container Initiative (OCI) registries.
 :doc-persona: ["kubewarden-all"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/policy-evaluation-timeout.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/policy-evaluation-timeout.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Policy evaluation timeout protection
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure policy evaluation timeouts to ensure timely completion and prevent resource exhaustion with the Policy Server's built-in protection feature.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]
@@ -73,7 +73,7 @@ timeout.
 Starting with {admc-short-name} v1.29.0, every {admc-short-name} Policy can set its own
 timeout value via its `spec.timeoutEvalSeconds` attribute. This is not to be
 confused with `spec.timeoutSeconds`, used for the Webhook timeout (see section
-#comparison-with-kubernetes-dynamic-admission-controller-timeout[below]).
+<<_comparison_with_kubernetes_dynamic_admission_controller_timeout,below>>).
 
 The `spec.timeoutEvalSeconds` is fine-grained, allowing per-Policy tuning of
 their evaluation timeout.
@@ -161,6 +161,7 @@ spec:
       value: "3"
 ----
 
+[#_comparison_with_kubernetes_dynamic_admission_controller_timeout]
 == Comparison with Kubernetes Dynamic Admission Controller timeout
 
 {admc-short-name} is a https://en.wikipedia.org/wiki/Webhook[webhook] implementation of the https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/[Kubernetes Dynamic Admission Controller].

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/security-hardening/webhooks-hardening.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/security-hardening/webhooks-hardening.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Hardening the {admc-short-name} webhooks
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Webhooks
 :description: Configure network policies and authentication to limit access to webhooks in your Kubernetes cluster, specifically restricting connections from invalid callers.

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/sources_yaml.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/sources_yaml.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Reference for sources.yaml
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure your sources.yaml file to work with PolicyServer CRs by specifying the path and format for source authorities, as well as insecure sources.
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/01-intro-spec.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/01-intro-spec.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Policy communication specification
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Discover how to effectively use the {admc-name} policies through a well-defined API enabling seamless interaction and communication.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/02-settings.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/02-settings.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Policy settings
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure policy settings using {admc-name}'s for validation and serialization of policy data.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/03-validating-policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/03-validating-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Validating policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Evaluate your validation requests using policy-specific settings to determine acceptance or rejection of Kubernetes AdmissionReview objects.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/04-mutating-policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/04-mutating-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Mutating policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure mutating policies by implementing validation functions (validate and validate_settings) in a waPC (whatever-after Policy Configurator) for proposing object mutations in Kubernetes clusters.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/05-context-aware-policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/05-context-aware-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Context aware policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore context-aware policy capabilities in admission control, including resource access and caching, to optimize policy evaluation.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/01-intro-host-capabilities.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/01-intro-host-capabilities.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Host capabilities specification
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: During evaluation, understand the host capabilities offered by the environment for {admc-name} policies.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/02-signature-verifier-policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/02-signature-verifier-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Signature verifier policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Implement secure policies for your cluster using the provided verifier policy, or build upon it with your chosen language SDK.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/03-container-registry.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/03-container-registry.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Container registry capabilities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore container registry capabilities including calculating OCI manifest digests and fetching OCI object manifests.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/04-net.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/04-net.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Network capabilities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about network capabilities and how to use host functions for DNS lookups, as well as communication protocols.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/05-crypto.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/05-crypto.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Cryptographic capabilities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about the cryptographic capabilities and functions of the Wasm host for evaluating PKI certificates in use.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/06-kubernetes.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/06-kubernetes.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Kubernetes capabilities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore Kubernetes capabilities using {admc-name}'s context-aware policies and the waPC protocol to access cluster resources.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/07-host-capability-call-reference.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/spec/host-capabilities/07-host-capability-call-reference.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Host capabilities call reference
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: List of all host capabilities calls
 :doc-persona: ["kubewarden-operator", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/threat-model.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/threat-model.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Threat Model
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Read and understand the Admission Control Threat Model to devise your own circumstance-specific threat model, ensuring secure defaults within Kubernetes.
 :doc-persona: ["kubewarden-all"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/reference/verification-config.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/reference/verification-config.adoc
@@ -9,7 +9,7 @@ include::partial$variables.adoc[]
 
 = Verification configuration format
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 
 == Introduction

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/publish-policy-to-artifact-hub.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/publish-policy-to-artifact-hub.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Publish policies to Artifact Hub
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Publish {admc-name} policies to Artifact Hub by creating a well-formatted Git repository layout and configuring GitHub Actions for automated packaging, facilitating continuous integration.
 :doc-persona: ["kubewarden-user", "kubewarden-operator", "kubewarden-policy-developer", "kubewarden-distributor", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/testing-policies/02-policy-authors.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/testing-policies/02-policy-authors.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Testing for policy authors
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to test policy authors with kwctl, either using bats or standard testing, specifically for {admc-name} policies in Wasm.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/testing-policies/03-cluster-operators.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/testing-policies/03-cluster-operators.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Testing for cluster operators
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Test cluster operator policies with kwctl using different configurations and validation request objects to validate policy settings.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/testing-policies/index.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/testing-policies/index.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Policy testing
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to create and test {admc-name} Policies with {admc-name} for secure cluster management.
 :doc-persona: ["kubewarden-operator", "kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/verifying-kubewarden.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/verifying-kubewarden.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Verifying {admc-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Verify different artifacts produced by the {admc-name} team to ensure a secure supply chain through use of SBOMs and provenance files.
 :doc-persona: ["kubewarden-operator", "kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/CEL/01-intro-cel.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/CEL/01-intro-cel.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Introduction to CEL
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about CEL (Computation Expression Language) as a fast, portable, and safe expression language designed for Kubernetes validation rules and extensions to the Kubernetes API.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/CEL/02-reusing-vap.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Reusing ValidatingAdmissionPolicies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about reusing and validating admission policies in Kubernetes using {admc-name}'s (cel-policy).
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/CEL/03-context-aware.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Context-aware CEL policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure context-aware policies to ensure unique Ingress rules across hosts, preventing conflicts with {admc-name}'s CEL extension libraries.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/CEL/04-example-sigstore.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/CEL/04-example-sigstore.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Sigstore host capabilities
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to implement Sigstore host capabilities using CEL policies in Kubewarden to verify container images and enforce secure admission control.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/dotnet.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/dotnet.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = C#
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore and write validation and mutation of admission control policies using .NET Core SDK with WASI support on WebAssembly platforms like Kubernetes.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/01-intro-go.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/01-intro-go.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Writing policies in Go
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Write effective admission controller validation policies using TinyGo, using its useful libraries and tools designed specifically for Go developers.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/02-scaffold.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/02-scaffold.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Creating a new validation policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Explore creating a new validation policy that rejects Pods with deny-list labels, while validating labels with user-provided regular expressions to ensure security.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/03-policy-settings.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/03-policy-settings.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Defining policy settings
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Modify the code in the settings.go file to define policy settings, including implementation of custom functions for marshaling and unmarshaling regular expressions.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/04-validation.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/04-validation.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Writing the validation logic
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to write and test validation logic in Go by extracting relevant information from incoming payloads and creating setting objects.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/05-e2e-tests.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/05-e2e-tests.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = End-to-end testing
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Discover how to write and automate end-to-end tests running against the WebAssembly binary produced by TinyGo with bats and kwctl.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/06-logging.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/06-logging.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Logging
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure logger initialization for structured logging in your policy using the oneLog project's Go SDK integration.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/07-automate.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/07-automate.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Integrating with GitHub Actions
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about integrating GitHub Actions for automated tasks, unit testing, end-to-end testing, and CI/CD workflows.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/08-distribute.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/08-distribute.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Distributing policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to distribute policies and access related information for {admc-name}, including configuration details.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/09-validation-with-queries.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/09-validation-with-queries.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Validation using JSON queries
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Implement validation logic using JSON queries by extracting relevant data from a Kubernetes object's JSON representation.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/10-raw-policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/go/10-raw-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Writing raw policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn to write raw policies that can evaluate arbitrary JSON documents for validation and mutation, allowing for flexible data processing.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/index.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/index.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Writing {admc-name} policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Develop admission controller policies by exposing well-defined functionalities via a specific API using any supported programming language.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/metadata.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/metadata.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Policy metadata
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure policy metadata in the metadata.yaml file to define policy settings, author information, and resource permissions.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/other-languages.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/other-languages.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Other languages
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about writing {admc-name} policies using various programming languages that target WebAssembly modules and the WASI interface.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/01-intro-rego.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/01-intro-rego.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Rego
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about Rego language basics, including its use in conjunction with Open Policy Agent and Gatekeeper frameworks to implement policies as code.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/02-builtin-support.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Builtin support
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Determine which built-in functions are available for WebAssembly modules and understand their implementation and use in Rego policy development.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/01-intro.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/01-intro.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Gatekeeper support
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Access central gatekeeper policies and learn how to integrate them with Kubernetes admission controllers.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/02-create-policy.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/02-create-policy.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Creating a new Gatekeeper Rego policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Implement Gatekeeper Rego policies to reject resources targeting the default namespace by creating and testing a new policy.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/03-build-and-run.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/03-build-and-run.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Build and run a Gatekeeper policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Develop and deploy a Gatekeeper policy using familiar Rego syntax and tools to enforce admission control within Kubernetes environments.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/04-distribute.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/gatekeeper/04-distribute.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Distributing a Gatekeeper policy with {admc-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Distribute Gatekeeper policies across Kubernetes clusters by annotating policy files with metadata and deploying them via ClusterAdmissionPolicy.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/01-intro.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/01-intro.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Introduction to Open Policy Agent
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how the Open Policy Agent uses the Rego language to write policies that evaluate and produce outputs for secure decision-making.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/02-create-policy.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/02-create-policy.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Creating a new policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Create a policy that evaluates all namespaced resources and forbids their creation in the default namespace for hands-on learning.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/03-build-and-run.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/03-build-and-run.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Build and run a OPA policy for {admc-short-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Build a custom OPA policy for your project by constructing a Rego policy package, compiling it into a WASM target, and integrating with kwctl.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/04-distribute.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/04-distribute.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Distributing an OPA policy with {admc-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Annotate your Rego policy with relevant metadata, then push it to an OCI registry to prepare for deployment.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/05-raw-policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rego/open-policy-agent/05-raw-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Writing raw policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to write raw policies that evaluate arbitrary JSON documents and enforce access control rules in your system.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/01-intro-rust.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/01-intro-rust.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Rust
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to write admission controller policies in Rust with SUSE's security admission controllers simplified SDK and template projects.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/02-create-policy.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/02-create-policy.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Creating a policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn to create and configure validation policies that control Pod creation requests based on customizable rejection criteria.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/03-define-policy-settings.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/03-define-policy-settings.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Defining policy settings
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Define policy settings and structure in your code to establish a foundation for validating policy integrity through efficient setting management. Ensure that all changes are tracked, such as who made the change, when, and what was changed.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/04-write-validation-logic.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/04-write-validation-logic.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Writing validation logic
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Write validation logic to check the validity of incoming requests by parsing payloads and verifying Pod objects.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/05-mutation-policy.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/05-mutation-policy.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Creating a new mutation policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure a new {admc-name} mutation policy to mutate incoming objects with custom annotations, then test it.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/06-logging.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/06-logging.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Logging
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Configure logging capabilities for your policy by using the {admc-name}'s integration with the SLOG library and initializing.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/07-build-and-distribute.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/07-build-and-distribute.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Building and distributing policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Follow these essential steps to build and distribute policies effectively for your {admc-name} setup.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-operator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/08-raw-policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/rust/08-raw-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Raw policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn about raw policies that evaluate arbitrary JSON documents, as well as view examples of policy implementation in Rust.
 :doc-persona: ["kubewarden-policy-developer", "kubewarden-integrator"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/swift.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/swift.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Swift
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to use the Swift compiler with WebAssembly support through SwiftWasm to access tools for building {admc-name} policies.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/typescript/01-intro-typescript.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/typescript/01-intro-typescript.adoc
@@ -2,7 +2,7 @@ include::partial$variables.adoc[]
 
 = Writing policies in TypeScript/JavaScript
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-14
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to write effective {admc-name} validation policies using TypeScript/JavaScript.
 :keywords: kubewarden, kubernetes, writing policies in TypeScript, writing policies in JavaScript

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/typescript/02-scaffold.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/typescript/02-scaffold.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Creating a new validation policy
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Create a new validation policy to reject invalid hostnames in Pod objects through configuration of policy settings, tested with provided tools.
 :keywords: {admc-name}, kubewarden, kubernetes, writing policies in TypeScript, new validation policy

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/typescript/03-policy-settings.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/typescript/03-policy-settings.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Defining policy settings
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Define and implement effective policy settings structures through {admc-name} policies in src/types.ts and src/index.ts files.
 :keywords: "{admc-name}", kubewarden, kubernetes, defining policy settings, TypeScript

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/typescript/04-validation.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/typescript/04-validation.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Writing the validation logic
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Write the validation logic for Kubernetes resources in the src/index.ts file, accessing the incoming request data to return a response.
 :keywords: "{admc-name}", kubewarden, kubernetes, writing policies, typescript

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/typescript/05-e2etests.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/typescript/05-e2etests.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = End-to-end testing
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Learn how to write and run comprehensive end-to-end tests for policy behavior using BATS and kwctl.
 :keywords: "{admc-name}", kubewarden, kubernetes, testing policies, typescript, e2e testing

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/wasi/01-intro-wasi.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/wasi/01-intro-wasi.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = WASI
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Write WASI policies that interact with system primitives when a limitation in the Go compiler prevents using the waPC communication mechanism.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/wasi/02-raw-policies.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/tutorials/writing-policies/wasi/02-raw-policies.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = Writing raw policies
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :description: Write raw policies that evaluate arbitrary JSON documents by defining custom validation and mutation logic for.
 :doc-persona: ["kubewarden-policy-developer"]

--- a/docs/admission-controller/version-1.38/modules/en/pages/use-cases.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/use-cases.adoc
@@ -1,7 +1,7 @@
 include::partial$variables.adoc[]
 = {admc-name} use cases
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-05-04
+:revdate: 2026-06-18
 :page-revdate: {revdate}
 :sidebar_label: Use cases
 :sidebar_position: 74

--- a/shared/modules/en/partials/kubewarden-variables-1.24-next.adoc
+++ b/shared/modules/en/partials/kubewarden-variables-1.24-next.adoc
@@ -54,17 +54,17 @@ endif::[]
 
 :cluster-admission-policy: xref:glossary.adoc#_clusteradmissionpolicy[ClusterAdmissionPolicy]
 
-:cluster-policy-report: xref:glossary.adoc#_clusterpolicyreport[ClusterPolicyReport]
+:cluster-policy-report: xref:glossary.adoc#_clusterreport[ClusterPolicyReport]
 
 :kwctl: xref:glossary.adoc#_kwctl[kwctl]
 
 :mutating-webhook-configuration: xref:glossary.adoc#_mutatingwebhookconfiguration[MutatingWebhookConfiguration]
 
-:policy-report: xref:glossary.adoc#_policyreport[PolicyReport]
+:policy-report: xref:glossary.adoc#_report[PolicyReport]
 
 :policy-server: xref:glossary.adoc#_policyserver[PolicyServer]
 
-:validating-webhook-configuration: xref:glossary.adoc#_walidatingwebhookconfiguration[ValidatingWebhookConfiguration]
+:validating-webhook-configuration: xref:glossary.adoc#_validatingwebhookconfiguration[ValidatingWebhookConfiguration]
 
 :waPC: xref:glossary.adoc#_wapc[waPC]
 

--- a/shared/modules/en/partials/kubewarden-variables-1.36-forward.adoc
+++ b/shared/modules/en/partials/kubewarden-variables-1.36-forward.adoc
@@ -77,17 +77,17 @@ endif::[]
 
 :cluster-admission-policy: xref:glossary.adoc#_clusteradmissionpolicy[ClusterAdmissionPolicy]
 
-:cluster-policy-report: xref:glossary.adoc#_clusterpolicyreport[ClusterPolicyReport]
+:cluster-policy-report: xref:glossary.adoc#_clusterreport[ClusterPolicyReport]
 
 :kwctl: xref:glossary.adoc#_kwctl[kwctl]
 
 :mutating-webhook-configuration: xref:glossary.adoc#_mutatingwebhookconfiguration[MutatingWebhookConfiguration]
 
-:policy-report: xref:glossary.adoc#_policyreport[PolicyReport]
+:policy-report: xref:glossary.adoc#_report[PolicyReport]
 
 :policy-server: xref:glossary.adoc#_policyserver[PolicyServer]
 
-:validating-webhook-configuration: xref:glossary.adoc#_walidatingwebhookconfiguration[ValidatingWebhookConfiguration]
+:validating-webhook-configuration: xref:glossary.adoc#_validatingwebhookconfiguration[ValidatingWebhookConfiguration]
 
 :waPC: xref:glossary.adoc#_wapc[waPC]
 

--- a/shared/modules/en/partials/kubewarden-variables.adoc
+++ b/shared/modules/en/partials/kubewarden-variables.adoc
@@ -34,17 +34,17 @@ endif::[]
 
 :cluster-admission-policy: xref:glossary.adoc#_clusteradmissionpolicy[ClusterAdmissionPolicy]
 
-:cluster-policy-report: xref:glossary.adoc#_clusterpolicyreport[ClusterPolicyReport]
+:cluster-policy-report: xref:glossary.adoc#_clusterreport[ClusterPolicyReport]
 
 :kwctl: xref:glossary.adoc#_kwctl[kwctl]
 
 :mutating-webhook-configuration: xref:glossary.adoc#_mutatingwebhookconfiguration[MutatingWebhookConfiguration]
 
-:policy-report: xref:glossary.adoc#_policyreport[PolicyReport]
+:policy-report: xref:glossary.adoc#_report[PolicyReport]
 
 :policy-server: xref:glossary.adoc#_policyserver[PolicyServer]
 
-:validating-webhook-configuration: xref:glossary.adoc#_walidatingwebhookconfiguration[ValidatingWebhookConfiguration]
+:validating-webhook-configuration: xref:glossary.adoc#_validatingwebhookconfiguration[ValidatingWebhookConfiguration]
 
 :waPC: xref:glossary.adoc#_wapc[waPC]
 


### PR DESCRIPTION
Replace Antora's auto-generated section anchors with explicit ones so that xrefs no longer break when a section title is reworded, and correct several link constructs that rendered as raw markup without emitting any build warning.

- Add explicit [id=...] anchors and retarget xrefs to them
- Convert Markdown-style links to AsciiDoc in disclosure.adoc
- Wrap URLs that follow a non-boundary character (CJK, punctuation) in link:...[] so Asciidoctor recognises them
- Fix xref:mailto:...adoc[] to mailto:addr[addr]; the old form produced an undeliverable address on the security disclosure page
- Use {admc-name} rather than a hardcoded product name in disclosure.adoc
- Drop the numbers from ordered list markers (1. -> .); output is unchanged
- Align revdate/page-revdate with kubewarden-product-docs, taking the most recent date for each page

Build is clean: 0 errors and 14 warnings, all of them in the auto-generated CRD and CLI reference docs.


- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
