### PR TITLE
fix(ssc): invalid policy server spec and missing cli flags

### DIFF
--- a/docs/admission-controller/version-1.38/modules/en/pages/howtos/security-hardening/secure-supply-chain.adoc
+++ b/docs/admission-controller/version-1.38/modules/en/pages/howtos/security-hardening/secure-supply-chain.adoc
@@ -406,19 +406,19 @@ You can use this `verification_config.yml` to create the `ConfigMap`.
 
 [subs="+attributes",console]
 ----
-$ kubectl create configmap my-signatures-configuration --from-file==verification_config.yaml
+$ kubectl create configmap -n {admc-namespace}  my-signatures-configuration --from-file=verification_config.yaml
 configmap/my-signatures-configuration created
 ----
 
 Then we can inspect with `get configmap`.
 
-.kubectl get configmap
+.kubectl get configmap -n {admc-namespace}
 [%collapsible]
 ======
 
 [subs="+attributes",console]
 ----
-$ kubectl get configmap -o yaml my-signatures-configuration
+$ kubectl get configmap -n {admc-namespace} -o yaml my-signatures-configuration
 apiVersion: v1
 data:
   verification-config: |+
@@ -465,7 +465,7 @@ metadata:
   finalizers:
     - kubewarden
 spec:
-  image: image: ghcr.io/kubewarden/adm-controller/policy-server:v1.36.0
+  image: {default-policy-server-image-tag}
   serviceAccountName: policy-server
   replicas: 1
 //highlight-next-l


### PR DESCRIPTION
## Description

Fixes some commands used in the Secure Supply Chain docs adding missing CLI flag to kubectl command. As well as, fixing a invalid PolicyServer spec.
